### PR TITLE
Place provenance pill after lists, matching table behavior

### DIFF
--- a/inst/www/commons-chat/commons-chat.js
+++ b/inst/www/commons-chat/commons-chat.js
@@ -41,7 +41,7 @@
         var blocks = content.querySelectorAll("p, li, table");
         var target = blocks[blocks.length - 1] || content;
 
-        if (target.tagName === "TABLE") {
+        if (target.tagName === "TABLE" || target.tagName === "LI") {
           content.appendChild(document.createElement("br"));
           content.appendChild(pill);
           return;


### PR DESCRIPTION
Closes #9. When the model provides a list of answers, the pill gets placed inline on the last answer, making it look like only the last number is verified.

There could probably be some additional styling, but right now it just matches what was already happening with tables. 
