### PR TITLE
Render measure tool results as HTML tables for data frames

### DIFF
--- a/R/tools.R
+++ b/R/tools.R
@@ -120,7 +120,7 @@ call_measure_tool <- function(registry, name, arguments) {
     body,
     title = sprintf("Measure: %s", html_escape(tool_title(td))),
     icon = maybe_icon("shield-check"),
-    html = measure_display_html(args, body),
+    html = measure_display_html(args, value),
     tag = "A",
     open = TRUE,
     show_request = FALSE,
@@ -260,19 +260,32 @@ measure_args_html <- function(args) {
   sprintf("<div class=\"commons-measure-args\">%s</div>", rows)
 }
 
-measure_display_html <- function(args, result) {
+measure_display_html <- function(args, value) {
   sprintf(
     "<div class=\"commons-measure-display\">%s%s</div>",
     measure_args_html(args),
-    measure_result_html(result)
+    measure_result_html(value)
   )
 }
 
-measure_result_html <- function(result) {
+measure_result_html <- function(value) {
   sprintf(
     "<div class=\"commons-measure-result\"><strong>Tool result</strong><div class=\"commons-measure-result-value\">%s</div></div>",
-    html_escape(result)
+    format_measure_html(value)
   )
+}
+
+# Render a measure result for display: data frames become HTML tables; other
+# values reuse the text formatting, escaped for HTML.
+format_measure_html <- function(value) {
+  if (inherits(value, "tbl_sql")) {
+    rlang::check_installed("dplyr")
+    value <- dplyr::collect(value)
+  }
+  if (is.data.frame(value)) {
+    return(df_to_html(value))
+  }
+  html_escape(format_measure_value(value))
 }
 
 label_name <- function(x) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -34,6 +34,16 @@ df_to_markdown <- function(df, max_rows = 50) {
   paste(out, collapse = "\n")
 }
 
+df_to_html <- function(df, max_rows = 50) {
+  n <- nrow(df)
+  shown <- utils::head(df, max_rows)
+  out <- paste(knitr::kable(shown, format = "html"), collapse = "")
+  if (n > max_rows) {
+    out <- paste0(out, sprintf("<p>%d more rows not shown</p>", n - max_rows))
+  }
+  out
+}
+
 # Icons are decorative, so bsicons is optional.
 maybe_icon <- function(name) {
   if (is_installed("bsicons")) {

--- a/inst/www/commons-chat/commons-chat.css
+++ b/inst/www/commons-chat/commons-chat.css
@@ -123,3 +123,23 @@
   color: var(--bs-body-color, #212529);
   white-space: pre-wrap;
 }
+
+.commons-measure-result-value table {
+  border-collapse: collapse;
+  font-size: 0.85rem;
+  width: 100%;
+}
+
+.commons-measure-result-value th,
+.commons-measure-result-value td {
+  border-bottom: 1px solid var(--bs-border-color, #dee2e6);
+  padding: 0.3rem 0.5rem;
+}
+
+.commons-measure-result-value th {
+  font-weight: 600;
+}
+
+.commons-measure-result-value tbody tr:nth-child(even) {
+  background: var(--bs-tertiary-bg, #f3f4f6);
+}


### PR DESCRIPTION
Measure tool-result cards showed data-frame results as raw markdown because the card's custom HTML display embedded HTML-escaped markdown instead of a table.

This changes data-frame results to render as HTML tables. 
