### PR TITLE
derive answers from measure outputs

### DIFF
--- a/R/tools.R
+++ b/R/tools.R
@@ -28,18 +28,22 @@ tool_search_measures <- function(private) {
 
 tool_call_measure <- function(private) {
   ellmer::tool(
-    function(name, arguments = "{}") {
-      call_measure_tool(private$registry, name, arguments)
+    function(name, arguments = "{}", sql = NULL) {
+      call_measure_tool(private$registry, name, arguments, sql)
     },
     # For small registries, we may eventually expose each measure schema upfront
     # instead of relying on search_measures for discovery.
-    "Run a registered measure returned by search_measures. `arguments` is a JSON object using exactly the argument names from search_measures.",
+    "Run a registered measure returned by search_measures. `arguments` is a JSON object using exactly the argument names from search_measures. If the measure output is close to the answer but needs a final filter, total, ratio, ranking, or other derivation, pass a read-only SELECT query in `sql`; the measure output is available as the table `measure`.",
     arguments = list(
       name = ellmer::type_string(
         "The measure name, exactly as returned by search_measures."
       ),
       arguments = ellmer::type_string(
         "A JSON object of the measure's arguments."
+      ),
+      sql = ellmer::type_string(
+        "Optional read-only SELECT query to run against the measure output, exposed as the table `measure`. Prefer this over calculating from the measure output yourself when a governed measure gets close to the answer.",
+        required = FALSE
       )
     ),
     name = "call_measure",
@@ -103,7 +107,7 @@ tool_run_sql <- function(private) {
   )
 }
 
-call_measure_tool <- function(registry, name, arguments) {
+call_measure_tool <- function(registry, name, arguments, sql = NULL) {
   td <- registry[[name]]
   if (is.null(td)) {
     detail <- if (length(registry)) {
@@ -115,17 +119,64 @@ call_measure_tool <- function(registry, name, arguments) {
   }
   args <- validate_measure_args(td, parse_json_args(arguments))
   value <- do.call(td, args)
-  body <- format_measure_value(value)
+  derived <- !is.null(sql) && !identical(sql, "")
+  if (derived) {
+    result <- query_measure_output(value, sql)
+    body <- df_to_markdown(result)
+    tag <- "B"
+    html <- measure_display_html(args, value, sql = sql, derived_value = result)
+  } else {
+    body <- format_measure_value(value)
+    tag <- "A"
+    html <- measure_display_html(args, value)
+  }
   tool_result(
     body,
     title = sprintf("Measure: %s", html_escape(tool_title(td))),
     icon = maybe_icon("shield-check"),
-    html = measure_display_html(args, value),
-    tag = "A",
+    html = html,
+    tag = tag,
     open = TRUE,
     show_request = FALSE,
     show_tag = FALSE
   )
+}
+
+query_measure_output <- function(value, sql, call = rlang::caller_env()) {
+  check_query(sql, call = call)
+  df <- collect_measure_frame(value, call = call)
+
+  con <- duckdb_connect()
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+  duckdb_lock_down(con)
+
+  registered <- FALSE
+  tryCatch(
+    {
+      invisible(duckdb::duckdb_register(con, "measure", df))
+      registered <- TRUE
+      DBI::dbGetQuery(con, sql)
+    },
+    finally = {
+      if (registered) {
+        try(duckdb::duckdb_unregister(con, "measure"), silent = TRUE)
+      }
+    }
+  )
+}
+
+collect_measure_frame <- function(value, call = rlang::caller_env()) {
+  if (inherits(value, "tbl_sql")) {
+    rlang::check_installed("dplyr")
+    value <- dplyr::collect(value)
+  }
+  if (!is.data.frame(value)) {
+    cli::cli_abort(
+      "{.arg sql} can only be supplied when the measure returns a data frame or lazy table.",
+      call = call
+    )
+  }
+  as.data.frame(value)
 }
 
 search_context_tool <- function(context, query) {
@@ -260,18 +311,32 @@ measure_args_html <- function(args) {
   sprintf("<div class=\"commons-measure-args\">%s</div>", rows)
 }
 
-measure_display_html <- function(args, value) {
+measure_display_html <- function(args, value, sql = NULL, derived_value = NULL) {
+  result_label <- if (is.null(sql)) "Tool result" else "Measure result"
   sprintf(
-    "<div class=\"commons-measure-display\">%s%s</div>",
+    "<div class=\"commons-measure-display\">%s%s%s</div>",
     measure_args_html(args),
-    measure_result_html(value)
+    measure_result_html(value, label = result_label),
+    measure_sql_html(sql, derived_value)
   )
 }
 
-measure_result_html <- function(value) {
+measure_result_html <- function(value, label = "Tool result") {
   sprintf(
-    "<div class=\"commons-measure-result\"><strong>Tool result</strong><div class=\"commons-measure-result-value\">%s</div></div>",
+    "<div class=\"commons-measure-result\"><strong>%s</strong><div class=\"commons-measure-result-value\">%s</div></div>",
+    html_escape(label),
     format_measure_html(value)
+  )
+}
+
+measure_sql_html <- function(sql, value) {
+  if (is.null(sql)) {
+    return("")
+  }
+  sprintf(
+    "<div class=\"commons-measure-sql\"><strong>Post-processing SQL</strong><pre><code>%s</code></pre></div>%s",
+    html_escape(sql),
+    measure_result_html(value, label = "Derived result")
   )
 }
 

--- a/inst/prompts/system-prompt.md
+++ b/inst/prompts/system-prompt.md
@@ -11,6 +11,12 @@ the user's question. Do this even if a table looks easy to query directly. If
 `search_measures` returns a relevant measure, call `call_measure` with the exact
 measure name and argument names returned by `search_measures`.
 
+If a measure output is close to the answer but needs a further derivation, pass a
+`sql` argument to `call_measure` instead of calculating from the output yourself
+or rewriting the governed logic with `run_sql`. The measure output is available
+to that SQL as the table `measure`. Prefer the measure's own arguments when they
+can answer the question directly.
+
 Do not call `run_sql` or `describe_table` until after you have called
 `search_measures` for the user's question. Use SQL only when `search_measures`
 does not return a relevant measure. Search context with `search_context`,

--- a/tests/testthat/test-tools.R
+++ b/tests/testthat/test-tools.R
@@ -38,6 +38,67 @@ test_that("call_measure_tool uses measure display titles", {
   expect_match(res@extra$display$html, "No arguments")
 })
 
+test_that("call_measure_tool can derive from tabular measure output with SQL", {
+  registry <- list(
+    revenue_by_region = measure(
+      "revenue_by_region",
+      "Revenue by region.",
+      function() aggregate(revenue ~ region, test_sales(), sum),
+      arguments = list()
+    )
+  )
+
+  res <- call_measure_tool(
+    registry,
+    "revenue_by_region",
+    "{}",
+    sql = "SELECT sum(revenue) AS total_revenue FROM measure WHERE region IN ('Americas', 'EMEA')"
+  )
+
+  expect_s7_class(res, ellmer::ContentToolResult)
+  expect_match(res@value, "5350")
+  expect_equal(res@extra$commons_tag, "B")
+  expect_match(res@extra$display$html, "Measure result")
+  expect_match(res@extra$display$html, "Post-processing SQL")
+  expect_match(res@extra$display$html, "Derived result")
+  expect_match(res@extra$display$html, "total_revenue")
+})
+
+test_that("call_measure_tool requires tabular output when SQL is supplied", {
+  registry <- list(order_count = count_measure_tool())
+
+  expect_error(
+    call_measure_tool(
+      registry,
+      "order_count",
+      "{}",
+      sql = "SELECT * FROM measure"
+    ),
+    "data frame or lazy table"
+  )
+})
+
+test_that("call_measure_tool checks SQL before deriving from measure output", {
+  registry <- list(
+    orders = measure(
+      "orders",
+      "Orders.",
+      function() test_sales(),
+      arguments = list()
+    )
+  )
+
+  expect_error(
+    call_measure_tool(
+      registry,
+      "orders",
+      "{}",
+      sql = "DROP TABLE measure"
+    ),
+    "disallowed operation"
+  )
+})
+
 test_that("call_measure_tool errors for an unknown measure name", {
   expect_snapshot(call_measure_tool(list(), "nope", "{}"), error = TRUE)
 })


### PR DESCRIPTION
Closes #4.

Adds an optional `sql` argument to `call_measure` for post-processing tabular measure results through an ephemeral DuckDB scratch connection. This lets the agent build on governed measure outputs for final filters, totals, ratios, and rankings while demoting derived answers to the B trust path.