### PR TITLE
Fix DuckDB connection failure with coexisting connections

### DIFF
--- a/R/data-source.R
+++ b/R/data-source.R
@@ -227,15 +227,26 @@ SET lock_configuration = true;
 
 # DuckDB defaults its extension and home directories to the package library,
 # which is read-only in deployed environments (e.g. Posit Connect). Point them
-# at the session temp directory. This must happen at connection time: any query
-# (even `SET extension_directory`) first initializes the extension subsystem
-# against the default directory, which fails when that directory is read-only.
+# at the session temp directory.
+#
+# `extension_directory` must be set in `config` (i.e. at startup): any query
+# first initializes the extension subsystem against this directory, which fails
+# when it defaults to the read-only package library. `home_directory`, however,
+# is a process-global option; passing it in `config` re-sets a global option on
+# every connection, which DuckDB rejects once any DuckDB instance already exists
+# in the process (e.g. the connection a data frame `data_source()` holds). Set it
+# instead with a session-scoped `SET`, which is safe across coexisting connections.
 duckdb_connect <- function() {
   dir <- file.path(tempdir(), "duckdb")
   dir.create(dir, showWarnings = FALSE, recursive = TRUE)
-  DBI::dbConnect(
-    duckdb::duckdb(config = list(extension_directory = dir, home_directory = dir))
+  con <- DBI::dbConnect(
+    duckdb::duckdb(config = list(extension_directory = dir))
   )
+  DBI::dbExecute(
+    con,
+    paste0("SET home_directory=", DBI::dbQuoteString(con, dir), ";")
+  )
+  con
 }
 
 normalize_table_registry <- function(tables, call = rlang::caller_env()) {

--- a/tests/testthat/test-data-source.R
+++ b/tests/testthat/test-data-source.R
@@ -108,6 +108,21 @@ test_that("the frame-path DuckDB is locked down", {
   )
 })
 
+test_that("duckdb_connect supports coexisting connections in one process", {
+  con1 <- duckdb_connect()
+  withr::defer(DBI::dbDisconnect(con1, shutdown = TRUE))
+  # home_directory is a process-global option; a second connection must not fail
+  # trying to re-set it once the first instance exists.
+  con2 <- expect_no_error(duckdb_connect())
+  withr::defer(DBI::dbDisconnect(con2, shutdown = TRUE))
+
+  dir <- file.path(tempdir(), "duckdb")
+  expect_equal(
+    DBI::dbGetQuery(con2, "SELECT current_setting('home_directory') AS h")$h,
+    dir
+  )
+})
+
 test_that("data_source rejects unnamed or non-data-frame input", {
   expect_snapshot(data_source(data.frame(x = 1)), error = TRUE)
   expect_snapshot(data_source(a = 1), error = TRUE)


### PR DESCRIPTION
From Claude (have tested, but not verified in real app). Putting this here in case you have a chance to take a look, otherwise I will test it out later. 

## Problem

`duckdb_connect()` passed `home_directory` in the DuckDB `config`. But `home_directory` is a process-global, set-at-startup option, so re-setting it on a second connection in the same process fails with:

> Could not set option "home_directory" as a global option

This happens whenever two DuckDB connections coexist — e.g. the connection `query_measure_output()` opens for SQL post-processing while a data-frame `data_source()` still holds one. The result is that `call_measure(..., sql = ...)` can fail in a long-lived Shiny/Connect app. (On duckdb 1.3.2 the config-with-`home_directory` connect fails on the *first* connection too.)

## Fix

- Keep `extension_directory` in `config` — it must be set at startup, before the extension subsystem initializes against the read-only package library on Connect.
- Set `home_directory` with a session-scoped `SET home_directory = ...` after connecting, which avoids the global-option conflict and is safe across coexisting connections.

<img width="682" height="361" alt="image" src="https://github.com/user-attachments/assets/c40df871-c38c-4f4e-b40b-6c42e8dd387a" />
