### PR TITLE
build the context store lazily and prewarm it from the Shiny module

### DIFF
--- a/R/chat.R
+++ b/R/chat.R
@@ -56,6 +56,14 @@ commons_mod_server <- function(
   check_chat_packages()
   check_commons_client(client)
 
+  # Build the context index during post-startup idle time (while the user
+  # reads the welcome message) rather than inside the first search. Errors are
+  # swallowed: the first search retries the build and surfaces the failure to
+  # the model.
+  later::later(function() {
+    tryCatch(client$prewarm(), error = function(err) NULL)
+  })
+
   mod <- shinychat::chat_mod_server(
     id,
     client = client,

--- a/R/commons.R
+++ b/R/commons.R
@@ -177,6 +177,17 @@ Commons <- R6::R6Class(
         private$finalize_turn()
         coro::exhausted()
       })()
+    },
+
+    #' @description Build the context layer's search index ahead of the first
+    #'   `search_context` call, e.g. during idle time right after a Shiny
+    #'   session starts. [commons_mod_server()] does this automatically.
+    prewarm = function() {
+      layer <- private$context_layer
+      if (!is.null(layer) && length(layer$docs) > 0) {
+        context_store(layer)
+      }
+      invisible(self)
     }
   ),
   private = list(

--- a/R/context-layer.R
+++ b/R/context-layer.R
@@ -3,8 +3,9 @@
 #' A context layer contains text that helps a [commons()] agent interpret its
 #' data source.
 #'
-#' Files are chunked and indexed with \pkg{ragnar}. The `always` argument is for
-#' short facts that should be included in every system prompt.
+#' Files are chunked and indexed with \pkg{ragnar} when the agent first
+#' searches its context. The `always` argument is for short facts that should
+#' be included in every system prompt.
 #'
 #' @param files Character vector of paths to text/markdown files to index.
 #' @param always Character vector of facts to inject into the system prompt on
@@ -23,21 +24,17 @@ context_layer <- function(files = character(), always = character()) {
     cli::cli_abort("{.arg files} and {.arg always} must be character vectors.")
   }
 
-  store <- ragnar::ragnar_store_create(embed = NULL)
+  # Read eagerly so a bad path fails at construction; index lazily (see
+  # context_store()).
+  docs <- character(0)
   for (path in files) {
     md <- strip_frontmatter(paste(readLines(path, warn = FALSE), collapse = "\n"))
     if (nzchar(trimws(md))) {
-      ragnar::ragnar_store_insert(store, ragnar::markdown_chunk(md))
+      docs <- c(docs, md)
     }
   }
-  if (length(files)) {
-    ragnar::ragnar_store_build_index(store, type = "fts")
-  }
 
-  structure(
-    list(store = store, always = always, n_docs = length(files)),
-    class = "commons_context_layer"
-  )
+  new_context_layer(docs, always)
 }
 
 # Dictionary prose doubles as searchable context, inserted at natural YAML
@@ -55,12 +52,14 @@ augment_context_layer <- function(context_layer, sources) {
   }
 
   layer <- context_layer %||% context_layer()
-  for (chunk in chunks) {
-    ragnar::ragnar_store_insert(layer$store, ragnar::markdown_chunk(chunk))
-  }
-  ragnar::ragnar_store_build_index(layer$store, type = "fts")
-  layer$n_docs <- layer$n_docs + length(chunks)
-  layer
+  new_context_layer(c(layer$docs, chunks), layer$always)
+}
+
+new_context_layer <- function(docs, always) {
+  structure(
+    list(docs = docs, always = always, cache = new.env(parent = emptyenv())),
+    class = "commons_context_layer"
+  )
 }
 
 dictionary_context_chunks <- function(dictionary) {
@@ -96,11 +95,28 @@ strip_frontmatter <- function(md) {
   sub("(?s)^---\r?\n.*?\r?\n---(\r?\n|$)", "", md, perl = TRUE)
 }
 
-context_search <- function(store, query, n = 3) {
-  if (store$n_docs == 0) {
+# Store setup (duckdb creation, chunk insertion, FTS indexing) is the most
+# expensive part of building an agent and many conversations never search, so
+# it's deferred to the first search. The cache environment is created fresh
+# whenever a layer's docs change, so layers sharing docs share a store and
+# layers that differ never do.
+context_store <- function(layer) {
+  if (is.null(layer$cache$store)) {
+    store <- ragnar::ragnar_store_create(embed = NULL)
+    for (doc in layer$docs) {
+      ragnar::ragnar_store_insert(store, ragnar::markdown_chunk(doc))
+    }
+    ragnar::ragnar_store_build_index(store, type = "fts")
+    layer$cache$store <- store
+  }
+  layer$cache$store
+}
+
+context_search <- function(layer, query, n = 3) {
+  if (length(layer$docs) == 0) {
     return(character(0))
   }
-  res <- ragnar::ragnar_retrieve_bm25(store$store, query, top_k = n)
+  res <- ragnar::ragnar_retrieve_bm25(context_store(layer), query, top_k = n)
   if (nrow(res) == 0) {
     return(character(0))
   }

--- a/man/commons.Rd
+++ b/man/commons.Rd
@@ -105,6 +105,7 @@ agent <- commons(
     \item \href{#method-Commons-initialize}{\code{Commons$new()}}
     \item \href{#method-Commons-chat}{\code{Commons$chat()}}
     \item \href{#method-Commons-stream_async}{\code{Commons$stream_async()}}
+    \item \href{#method-Commons-prewarm}{\code{Commons$prewarm()}}
     \item \href{#method-Commons-clone}{\code{Commons$clone()}}
   }
 }
@@ -208,6 +209,20 @@ log. See \link[ellmer:Chat]{ellmer::Chat} for arguments.
       \item{\code{stream}}{Whether to stream plain text or \link[ellmer:Content]{ellmer::Content} objects.}
       \item{\code{controller}}{Optional \code{\link[ellmer:stream_controller]{ellmer::stream_controller()}}.}
     }
+    \if{html}{\out{</div>}}
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-Commons-prewarm"></a>}}
+\if{latex}{\out{\hypertarget{method-Commons-prewarm}{}}}
+\subsection{\code{Commons$prewarm()}}{
+  Build the context layer's search index ahead of the first
+\code{search_context} call, e.g. during idle time right after a Shiny
+session starts. \code{\link[=commons_mod_server]{commons_mod_server()}} does this automatically.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{Commons$prewarm()}
     \if{html}{\out{</div>}}
   }
 }

--- a/man/context_layer.Rd
+++ b/man/context_layer.Rd
@@ -20,8 +20,9 @@ A context layer contains text that helps a \code{\link[=commons]{commons()}} age
 data source.
 }
 \details{
-Files are chunked and indexed with \pkg{ragnar}. The \code{always} argument is for
-short facts that should be included in every system prompt.
+Files are chunked and indexed with \pkg{ragnar} when the agent first
+searches its context. The \code{always} argument is for short facts that should
+be included in every system prompt.
 }
 \examples{
 layer <- context_layer(

--- a/tests/testthat/test-commons.R
+++ b/tests/testthat/test-commons.R
@@ -467,3 +467,22 @@ test_that("commons() errors on injection parameters matching no name", {
   )
 })
 
+
+test_that("prewarm() builds the context store ahead of the first search", {
+  path <- withr::local_tempfile(fileext = ".md")
+  writeLines(c("# Revenue", "", "Revenue means booked revenue."), path)
+  layer <- context_layer(files = path)
+
+  # test_source() has no dictionary, so the agent augments nothing and shares
+  # `layer`'s cache environment.
+  agent <- test_agent(context_layer = layer)
+  expect_null(layer$cache$store)
+
+  agent$prewarm()
+  expect_false(is.null(layer$cache$store))
+  expect_match(context_search(layer, "revenue")[[1]], "booked")
+})
+
+test_that("prewarm() without a context layer is a no-op", {
+  expect_no_error(test_agent()$prewarm())
+})

--- a/tests/testthat/test-data-dictionary.R
+++ b/tests/testthat/test-data-dictionary.R
@@ -249,7 +249,7 @@ test_that("augmenting keeps existing context and always facts", {
   augmented <- augment_context_layer(layer, list(local_dict_source()))
 
   expect_equal(augmented$always, "Booked revenue excludes tax.")
-  expect_gt(augmented$n_docs, 0)
+  expect_gt(length(augmented$docs), 0)
 })
 
 test_that("augmenting without dictionaries is a no-op", {


### PR DESCRIPTION
cc @skaltman—this schedules the building of the context layer for the moment the UI appears, so the page will load much more quickly but the server will be busy for the same amount of time that it previously took the page to load. This should be an issue unless users send a message relatively quickly on app load.

This will deserve a more thorough treatment later.