### PR TITLE
remove `always` in favor of `system_prompt`

### DIFF
--- a/R/commons.R
+++ b/R/commons.R
@@ -16,6 +16,29 @@
 #'   `describe_table` tools take a source's name as a `source` argument.
 #' @param context_layer An optional [context_layer()].
 #' @param semantic_layer An optional [semantic_layer()].
+#' @param system_prompt The agent's system prompt, as a single string. The
+#'   default interpolates the markdown prompt shipped with commons, filling
+#'   its `{{date}}` keyword. To customize the prompt, copy that file into
+#'   your project, edit freely, and interpolate it yourself:
+#'
+#'   ```r
+#'   file.copy(
+#'     system.file("prompts/system-prompt.md", package = "commons"),
+#'     "system-prompt.md"
+#'   )
+#'   commons(
+#'     # ...
+#'     system_prompt = ellmer::interpolate_file(
+#'       "system-prompt.md",
+#'       date = Sys.Date()
+#'     )
+#'   )
+#'   ```
+#'
+#'   Pass values for any `{{keyword}}` tokens you add as arguments to
+#'   [ellmer::interpolate_file()]. commons appends documentation of the
+#'   available tables and data dictionaries to the prompt itself; the file
+#'   needn't (and shouldn't) describe them.
 #' @param log Whether to capture conversation trajectories with OpenTelemetry
 #'   (default `FALSE`). When `TRUE`, commons enables GenAI message-content
 #'   capture in \pkg{ellmer} and tags each turn's spans with a conversation
@@ -91,6 +114,10 @@ commons <- function(
   data_sources,
   context_layer = NULL,
   semantic_layer = NULL,
+  system_prompt = ellmer::interpolate_file(
+    system.file("prompts/system-prompt.md", package = "commons"),
+    date = Sys.Date()
+  ),
   log = FALSE,
   share_with = NULL
 ) {
@@ -103,6 +130,7 @@ commons <- function(
   check_context_layer(context_layer)
   semantic_layer <- semantic_layer %||% new_semantic_layer()
   check_semantic_layer(semantic_layer)
+  check_system_prompt(system_prompt)
   check_log(log)
   check_share_with(share_with)
 
@@ -111,6 +139,7 @@ commons <- function(
     data_sources = data_sources,
     context_layer = context_layer,
     semantic_layer = semantic_layer,
+    system_prompt = system_prompt,
     log = log,
     share_with = share_with
   )
@@ -124,13 +153,17 @@ Commons <- R6::R6Class(
   public = list(
     #' @description Create a Commons agent. Most users should call [commons()]
     #'   rather than this method directly.
-    #' @param client,data_sources,context_layer,semantic_layer,log,share_with
+    #' @param client,data_sources,context_layer,semantic_layer,system_prompt,log,share_with
     #'   See [commons()].
     initialize = function(
       client,
       data_sources,
       context_layer = NULL,
       semantic_layer = NULL,
+      system_prompt = ellmer::interpolate_file(
+        system.file("prompts/system-prompt.md", package = "commons"),
+        date = Sys.Date()
+      ),
       log = FALSE,
       share_with = NULL
     ) {
@@ -154,7 +187,7 @@ Commons <- R6::R6Class(
 
       self$register_tools(build_commons_tools(self, private))
       self$set_system_prompt(
-        commons_system_prompt(private$sources, private$context_layer)
+        commons_system_prompt(private$sources, system_prompt)
       )
     },
 

--- a/R/commons.R
+++ b/R/commons.R
@@ -9,7 +9,8 @@
 #' to use the agent as a vitals solver.
 #'
 #' @param client An [ellmer::Chat] giving the provider and model to use, e.g.
-#'   [ellmer::chat_anthropic()].
+#'   [ellmer::chat_anthropic()]. A system prompt already set on the client is
+#'   ignored, with a warning; use `system_prompt` instead.
 #' @param data_sources A [data_source()], or a named list of them. Measures
 #'   can take a source's connection as an argument named after the source; see
 #'   [semantic_layer()]. When there are several sources, the `run_sql` and
@@ -124,6 +125,15 @@ commons <- function(
   if (!inherits(client, "Chat")) {
     cli::cli_abort(
       "{.arg client} must be an {.cls ellmer::Chat}, e.g. from {.fn ellmer::chat_anthropic}."
+    )
+  }
+  if (!is.null(client$get_system_prompt())) {
+    cli::cli_warn(
+      c(
+        "The system prompt set on {.arg client} is ignored; commons builds
+         its own.",
+        i = "Pass it to the {.arg system_prompt} argument instead."
+      )
     )
   }
   data_sources <- as_data_sources(data_sources)

--- a/R/context-layer.R
+++ b/R/context-layer.R
@@ -4,24 +4,22 @@
 #' data source.
 #'
 #' Files are chunked and indexed with \pkg{ragnar} when the agent first
-#' searches its context. The `always` argument is for short facts that should
-#' be included in every system prompt.
+#' searches its context. Facts that should be in every prompt belong in the
+#' `system_prompt` passed to [commons()], not here.
 #'
 #' @param files Character vector of paths to text/markdown files to index.
-#' @param always Character vector of facts to inject into the system prompt on
-#'   every turn. Optional.
 #'
 #' @return A `commons_context_layer` object.
 #'
 #' @examples
-#' layer <- context_layer(
-#'   always = "Revenue excludes tax unless stated otherwise."
-#' )
+#' path <- tempfile(fileext = ".md")
+#' writeLines("Revenue excludes tax unless stated otherwise.", path)
+#' layer <- context_layer(files = path)
 #'
 #' @export
-context_layer <- function(files = character(), always = character()) {
-  if (!is.character(files) || !is.character(always)) {
-    cli::cli_abort("{.arg files} and {.arg always} must be character vectors.")
+context_layer <- function(files = character()) {
+  if (!is.character(files)) {
+    cli::cli_abort("{.arg files} must be a character vector.")
   }
 
   # Read eagerly so a bad path fails at construction; index lazily (see
@@ -34,7 +32,7 @@ context_layer <- function(files = character(), always = character()) {
     }
   }
 
-  new_context_layer(docs, always)
+  new_context_layer(docs)
 }
 
 # Dictionary prose doubles as searchable context, inserted at natural YAML
@@ -52,12 +50,12 @@ augment_context_layer <- function(context_layer, sources) {
   }
 
   layer <- context_layer %||% context_layer()
-  new_context_layer(c(layer$docs, chunks), layer$always)
+  new_context_layer(c(layer$docs, chunks))
 }
 
-new_context_layer <- function(docs, always) {
+new_context_layer <- function(docs) {
   structure(
-    list(docs = docs, always = always, cache = new.env(parent = emptyenv())),
+    list(docs = docs, cache = new.env(parent = emptyenv())),
     class = "commons_context_layer"
   )
 }

--- a/R/prompt.R
+++ b/R/prompt.R
@@ -1,26 +1,33 @@
-commons_system_prompt <- function(sources, context_layer) {
-  template <- paste(
-    readLines(
-      system.file("prompts/system-prompt.md", package = "commons"),
-      warn = FALSE
-    ),
-    collapse = "\n"
+commons_system_prompt <- function(sources, system_prompt) {
+  paste0(
+    trimws(system_prompt, which = "right"),
+    "\n\n# Available tables\n\n",
+    sources_tables_text(sources),
+    "\n",
+    dictionary_prompt_text(sources)
   )
+}
 
-  tables <- sources_tables_text(sources)
-
-  always <- if (!is.null(context_layer) && length(context_layer$always)) {
-    paste0(
-      "\n# Context\n\nThe following context may be relevant:\n\n",
-      paste(sprintf("- %s", context_layer$always), collapse = "\n")
+check_system_prompt <- function(system_prompt, call = rlang::caller_env()) {
+  if (!rlang::is_string(system_prompt)) {
+    cli::cli_abort(
+      "{.arg system_prompt} must be a single string, e.g. from
+       {.fn ellmer::interpolate_file}.",
+      call = call
     )
-  } else {
-    ""
   }
-
-  template <- fill_token(template, "{{TABLES}}", tables)
-  template <- fill_token(template, "{{DICTIONARY}}", dictionary_prompt_text(sources))
-  fill_token(template, "{{ALWAYS}}", always)
+  # A path here would silently become the literal prompt text.
+  if (!grepl("\n", system_prompt, fixed = TRUE) && file.exists(system_prompt)) {
+    suggestion <- sprintf('ellmer::interpolate_file("%s")', system_prompt)
+    cli::cli_abort(
+      c(
+        "{.arg system_prompt} must be prompt content, not a file path.",
+        i = "Did you mean {.code {suggestion}}?"
+      ),
+      call = call
+    )
+  }
+  invisible(system_prompt)
 }
 
 # Only dataset-wide dictionary content is ambient: description and details
@@ -97,7 +104,3 @@ table_bullets <- function(source) {
   paste(sprintf("- %s", list_tables(source)), collapse = "\n")
 }
 
-# Avoid regular expression handling in prompt fragments supplied by users.
-fill_token <- function(text, token, value) {
-  gsub(token, value, text, fixed = TRUE)
-}

--- a/inst/prompts/system-prompt.md
+++ b/inst/prompts/system-prompt.md
@@ -1,5 +1,5 @@
 You are a self-service data analyst for your organization. You answer questions
-about its data, accurately and concisely.
+about its data, accurately and concisely. Today's date is {{date}}.
 
 Do not announce tool calls; before your final response to the user, you should only output tool calls.
 
@@ -29,9 +29,3 @@ better than text, render one with `run_r`; plots are shown to the user.
 - Surface the answer directly and state any assumptions you made to reach it.
   Don't over-interpret or editorialize.
 - Be brief. Lead with the answer.
-
-# Available tables
-
-{{TABLES}}
-{{DICTIONARY}}
-{{ALWAYS}}

--- a/man/commons.Rd
+++ b/man/commons.Rd
@@ -10,6 +10,8 @@ commons(
   data_sources,
   context_layer = NULL,
   semantic_layer = NULL,
+  system_prompt = ellmer::interpolate_file(system.file("prompts/system-prompt.md",
+    package = "commons"), date = Sys.Date()),
   log = FALSE,
   share_with = NULL
 )
@@ -26,6 +28,29 @@ can take a source's connection as an argument named after the source; see
 \item{context_layer}{An optional \code{\link[=context_layer]{context_layer()}}.}
 
 \item{semantic_layer}{An optional \code{\link[=semantic_layer]{semantic_layer()}}.}
+
+\item{system_prompt}{The agent's system prompt, as a single string. The
+default interpolates the markdown prompt shipped with commons, filling
+its \code{{{date}}} keyword. To customize the prompt, copy that file into
+your project, edit freely, and interpolate it yourself:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{file.copy(
+  system.file("prompts/system-prompt.md", package = "commons"),
+  "system-prompt.md"
+)
+commons(
+  # ...
+  system_prompt = ellmer::interpolate_file(
+    "system-prompt.md",
+    date = Sys.Date()
+  )
+)
+}\if{html}{\out{</div>}}
+
+Pass values for any \code{{{keyword}}} tokens you add as arguments to
+\code{\link[ellmer:interpolate_file]{ellmer::interpolate_file()}}. commons appends documentation of the
+available tables and data dictionaries to the prompt itself; the file
+needn't (and shouldn't) describe them.}
 
 \item{log}{Whether to capture conversation trajectories with OpenTelemetry
 (default \code{FALSE}). When \code{TRUE}, commons enables GenAI message-content
@@ -160,6 +185,8 @@ rather than this method directly.
   data_sources,
   context_layer = NULL,
   semantic_layer = NULL,
+  system_prompt = ellmer::interpolate_file(system.file("prompts/system-prompt.md",
+    package = "commons"), date = Sys.Date()),
   log = FALSE,
   share_with = NULL
 )}
@@ -168,7 +195,7 @@ rather than this method directly.
   \subsection{Arguments}{
     \if{html}{\out{<div class="arguments">}}
     \describe{
-      \item{\code{client, data_sources, context_layer, semantic_layer, log, share_with}}{See \code{\link[=commons]{commons()}}.}
+      \item{\code{client, data_sources, context_layer, semantic_layer, system_prompt, log, share_with}}{See \code{\link[=commons]{commons()}}.}
     }
     \if{html}{\out{</div>}}
   }

--- a/man/commons.Rd
+++ b/man/commons.Rd
@@ -18,7 +18,8 @@ commons(
 }
 \arguments{
 \item{client}{An \link[ellmer:Chat]{ellmer::Chat} giving the provider and model to use, e.g.
-\code{\link[ellmer:chat_anthropic]{ellmer::chat_anthropic()}}.}
+\code{\link[ellmer:chat_anthropic]{ellmer::chat_anthropic()}}. A system prompt already set on the client is
+ignored, with a warning; use \code{system_prompt} instead.}
 
 \item{data_sources}{A \code{\link[=data_source]{data_source()}}, or a named list of them. Measures
 can take a source's connection as an argument named after the source; see

--- a/man/context_layer.Rd
+++ b/man/context_layer.Rd
@@ -4,13 +4,10 @@
 \alias{context_layer}
 \title{Create a context layer}
 \usage{
-context_layer(files = character(), always = character())
+context_layer(files = character())
 }
 \arguments{
 \item{files}{Character vector of paths to text/markdown files to index.}
-
-\item{always}{Character vector of facts to inject into the system prompt on
-every turn. Optional.}
 }
 \value{
 A \code{commons_context_layer} object.
@@ -21,12 +18,12 @@ data source.
 }
 \details{
 Files are chunked and indexed with \pkg{ragnar} when the agent first
-searches its context. The \code{always} argument is for short facts that should
-be included in every system prompt.
+searches its context. Facts that should be in every prompt belong in the
+\code{system_prompt} passed to \code{\link[=commons]{commons()}}, not here.
 }
 \examples{
-layer <- context_layer(
-  always = "Revenue excludes tax unless stated otherwise."
-)
+path <- tempfile(fileext = ".md")
+writeLines("Revenue excludes tax unless stated otherwise.", path)
+layer <- context_layer(files = path)
 
 }

--- a/tests/testthat/helper-commons.R
+++ b/tests/testthat/helper-commons.R
@@ -28,14 +28,16 @@ test_agent <- function(
   context_layer = NULL,
   semantic_layer = NULL,
   data_sources = list(sales_db = test_source()),
-  log = FALSE
+  log = FALSE,
+  ...
 ) {
   commons(
     test_client(),
     data_sources = data_sources,
     context_layer = context_layer,
     semantic_layer = semantic_layer,
-    log = log
+    log = log,
+    ...
   )
 }
 

--- a/tests/testthat/test-commons.R
+++ b/tests/testthat/test-commons.R
@@ -75,6 +75,16 @@ test_that("a custom system prompt replaces the packaged one", {
   expect_match(prompt, "- sales", fixed = TRUE)
 })
 
+test_that("a system prompt already set on the client warns", {
+  client <- test_client()
+  client$set_system_prompt("You are a pirate.")
+
+  expect_warning(
+    commons(client, data_sources = list(sales_db = test_source())),
+    "commons builds its own"
+  )
+})
+
 test_that("system_prompt is validated", {
   expect_error(
     test_agent(system_prompt = c("a", "b")),

--- a/tests/testthat/test-commons.R
+++ b/tests/testthat/test-commons.R
@@ -38,9 +38,8 @@ test_that("commons() returns a Chat subclass with the six fixed tools", {
   )
 })
 
-test_that("the system prompt includes tables, context, and measure workflow", {
+test_that("the system prompt includes tables, the date, and measure workflow", {
   agent <- test_agent(
-    context_layer = context_layer(always = "Booked revenue excludes tax."),
     semantic_layer = semantic_layer(
       measure(
         "order_count",
@@ -54,11 +53,40 @@ test_that("the system prompt includes tables, context, and measure workflow", {
 
   expect_match(prompt, "sales")
   expect_no_match(prompt, "order_count")
-  expect_match(prompt, "Booked revenue excludes tax")
+  expect_match(prompt, format(Sys.Date(), "%Y-%m-%d"), fixed = TRUE)
   expect_match(prompt, "your first tool call must be `search_measures`")
   expect_match(prompt, "Do not call `run_sql` or `describe_table`")
   expect_no_match(prompt, "tagged A")
   expect_no_match(prompt, "tagged B")
+})
+
+test_that("a custom system prompt replaces the packaged one", {
+  path <- withr::local_tempfile(fileext = ".md")
+  writeLines("You answer questions about {{org}}'s data.", path)
+
+  agent <- test_agent(
+    system_prompt = ellmer::interpolate_file(path, org = "Acme")
+  )
+  prompt <- agent$get_system_prompt()
+
+  expect_match(prompt, "about Acme's data", fixed = TRUE)
+  expect_no_match(prompt, "search_measures")
+  expect_match(prompt, "# Available tables", fixed = TRUE)
+  expect_match(prompt, "- sales", fixed = TRUE)
+})
+
+test_that("system_prompt is validated", {
+  expect_error(
+    test_agent(system_prompt = c("a", "b")),
+    "single string"
+  )
+
+  path <- withr::local_tempfile(fileext = ".md")
+  writeLines("A prompt.", path)
+  expect_error(
+    test_agent(system_prompt = path),
+    "not a file path"
+  )
 })
 
 test_that("the system prompt includes schema-qualified table labels", {

--- a/tests/testthat/test-context-layer.R
+++ b/tests/testthat/test-context-layer.R
@@ -26,11 +26,6 @@ test_that("context_search returns empty when nothing matches or store is empty",
   expect_length(context_search(context_layer(files = path), "zzzzz"), 0)
 })
 
-test_that("prompt facts are carried on the layer", {
-  layer <- context_layer(always = "Revenue excludes tax.")
-  expect_equal(layer$always, "Revenue excludes tax.")
-})
-
 test_that("context_layer strips YAML frontmatter before indexing", {
   path <- withr::local_tempfile(fileext = ".md")
   writeLines(

--- a/tests/testthat/test-data-dictionary.R
+++ b/tests/testthat/test-data-dictionary.R
@@ -110,7 +110,7 @@ test_that("data_source() rejects other dictionary inputs", {
 test_that("dictionary content lands in the system prompt", {
   skip_if_not_installed("yaml")
   src <- local_dict_source()
-  prompt <- commons_system_prompt(list(src), NULL)
+  prompt <- commons_system_prompt(list(src), "You are a data analyst.")
 
   expect_match(prompt, "# About the data", fixed = TRUE)
   expect_match(prompt, "- sales", fixed = TRUE)
@@ -243,13 +243,15 @@ test_that("dictionary prose is searchable via the context layer", {
   )
 })
 
-test_that("augmenting keeps existing context and always facts", {
+test_that("augmenting keeps existing context docs", {
   skip_if_not_installed("yaml")
-  layer <- context_layer(always = "Booked revenue excludes tax.")
+  path <- withr::local_tempfile(fileext = ".md")
+  writeLines("Booked revenue excludes tax.", path)
+  layer <- context_layer(files = path)
   augmented <- augment_context_layer(layer, list(local_dict_source()))
 
-  expect_equal(augmented$always, "Booked revenue excludes tax.")
-  expect_gt(length(augmented$docs), 0)
+  expect_true("Booked revenue excludes tax." %in% augmented$docs)
+  expect_gt(length(augmented$docs), length(layer$docs))
 })
 
 test_that("augmenting without dictionaries is a no-op", {

--- a/vignettes/commons.Rmd
+++ b/vignettes/commons.Rmd
@@ -35,6 +35,7 @@ A commons agent is easiest to maintain when the pieces live in separate files:
 |   |-- semantic_layer.R
 |   `-- context_layer.R
 |-- app.R
+|-- system-prompt.md
 `-- context/
     `-- metrics.md
 ```
@@ -200,7 +201,7 @@ Write the default as a call rather than a reference to a variable defined elsewh
 
 The context layer is text the agent can search when no measure fits. Use it for metric definitions, table grain, join notes, business terminology, caveats, and source material that helps the agent write fallback SQL responsibly.
 
-Good context sources include existing app code, report source, metric catalogs, analyst notes, relevant transcripts, and exported pages from systems such as Confluence. Structured table and column documentation is better attached to the data source as a dictionary (see above). Short facts that should always be in the prompt can go in `always`.
+Good context sources include existing app code, report source, metric catalogs, analyst notes, relevant transcripts, and exported pages from systems such as Confluence. Structured table and column documentation is better attached to the data source as a dictionary (see above). Facts that should be in every prompt belong in the system prompt file (see "Customizing the system prompt" below).
 
 ```r
 # R/context_layer.R
@@ -208,10 +209,6 @@ agent_context <- context_layer(
   files = c(
     "context/metrics.md",
     "context/table-notes.md"
-  ),
-  always = c(
-    "Revenue excludes tax unless stated otherwise.",
-    "The orders table is one row per order."
   )
 )
 ```
@@ -246,6 +243,44 @@ server <- function(input, output, session) {
 }
 
 shinyApp(ui, server)
+```
+
+## Customizing the system prompt
+
+The system prompt is a markdown file you own. commons ships a default; copy it into your project and edit it freely:
+
+```r
+file.copy(
+  system.file("prompts", "system-prompt.md", package = "commons"),
+  "system-prompt.md"
+)
+```
+
+Then interpolate your copy and pass the result to `system_prompt`:
+
+```r
+agent <- commons(
+  # ...
+  system_prompt = ellmer::interpolate_file(
+    "system-prompt.md",
+    date = Sys.Date()
+  )
+)
+```
+
+commons appends documentation of the available tables and data dictionaries to the prompt itself, so the file needn't describe them.
+
+`{{keyword}}` tokens in the file are filled by [`ellmer::interpolate_file()`](https://ellmer.tidyverse.org/reference/interpolate.html)'s arguments when the agent is created. The packaged prompt uses one keyword, `{{date}}`; keep passing `date = Sys.Date()` as long as your copy retains it, and supply values for any keywords you add the same way:
+
+```r
+agent <- commons(
+  # ...
+  system_prompt = ellmer::interpolate_file(
+    "system-prompt.md",
+    date = Sys.Date(),
+    fiscal_year_start = "February"
+  )
+)
 ```
 
 ## Logging trajectories

--- a/vignettes/commons.Rmd
+++ b/vignettes/commons.Rmd
@@ -255,7 +255,7 @@ file.copy(
   "system-prompt.md"
 )
 ```
-
+commons appends documentation of the available tables and data dictionaries to the prompt itself, so the file needn't describe them.
 Then interpolate your copy and pass the result to `system_prompt`:
 
 ```r
@@ -268,9 +268,8 @@ agent <- commons(
 )
 ```
 
-commons appends documentation of the available tables and data dictionaries to the prompt itself, so the file needn't describe them.
 
-`{{keyword}}` tokens in the file are filled by [`ellmer::interpolate_file()`](https://ellmer.tidyverse.org/reference/interpolate.html)'s arguments when the agent is created. The packaged prompt uses one keyword, `{{date}}`; keep passing `date = Sys.Date()` as long as your copy retains it, and supply values for any keywords you add the same way:
+`{{keyword}}` tokens in the file are filled by [`ellmer::interpolate_file()`](https://ellmer.tidyverse.org/reference/interpolate.html)'s arguments when the agent is created. The packaged prompt uses one keyword, `{{date}}`. Continue passing in `date = Sys.Date()` as long as your prompt copy retains the `{{date}}` keyword, and supply values for any additional keywords that you added to your prompt:
 
 ```r
 agent <- commons(


### PR DESCRIPTION
Closes #7, allowing users to edit the system prompt as they wish. Does so by introducing a `system_prompt` argument to `commons()` with default:

```
ellmer::interpolate_file(
    system.file("prompts/system-prompt.md", package = "commons"),
    date = Sys.Date()
  )
```

I considered just deferring to `ellmer::chat_*(system_prompt)` but don't want it to be too easy to mistakenly omit the default prompting from commons agents.

These no longer live in the system prompt text and are inlined manually after the prompt file is interpolated:

```
{{TABLES}}
{{DICTIONARY}}
{{ALWAYS}}
```