### PR TITLE
make measure source readable in run_r

### DIFF
--- a/R/commons.R
+++ b/R/commons.R
@@ -186,6 +186,7 @@ Commons <- R6::R6Class(
       private$context_layer <- augment_context_layer(context_layer, sources)
       private$first_touch <- new.env(parent = emptyenv())
       private$registry <- semantic_layer$measures
+      private$fn_sources <- semantic_layer$fn_sources
       private$injections <- resolve_injections(
         private$registry,
         measure_injectables(sources)
@@ -274,6 +275,7 @@ Commons <- R6::R6Class(
     sources = NULL,
     context_layer = NULL,
     registry = NULL,
+    fn_sources = NULL,
     injections = NULL,
     conversation_id = NULL,
     tracing = FALSE,

--- a/R/measures.R
+++ b/R/measures.R
@@ -27,6 +27,12 @@
 #' reference to a variable defined elsewhere, so the measure doesn't depend on
 #' where the semantic layer is created.
 #'
+#' The source of each measure, and of any helper functions defined alongside
+#' it in the semantic layer's files, is readable in the agent's `run_r`
+#' session: evaluating a measure's name there prints its definition. Only
+#' source text is shared with that session; the functions' environments (and
+#' any connections or credentials in them) are not.
+#'
 #' @return A `commons_semantic_layer` object.
 #'
 #' @seealso [measure()] to define a measure.
@@ -59,7 +65,8 @@
 #'
 #' @export
 semantic_layer <- function(...) {
-  measures <- expand_measures(rlang::list2(...), rlang::caller_env())
+  expanded <- expand_measures(rlang::list2(...), rlang::caller_env())
+  measures <- expanded$measures
 
   check_measures(measures)
   names(measures) <- vapply(measures, tool_name, character(1))
@@ -71,13 +78,22 @@ semantic_layer <- function(...) {
     )
   }
 
-  new_semantic_layer(measures)
+  # Measures that didn't come from files (so no harvested source) still get a
+  # readable, if comment-free, deparse.
+  fn_sources <- expanded$fn_sources
+  for (nm in setdiff(names(measures), names(fn_sources))) {
+    fn_sources[[nm]] <- fn_source_text(tool_fn(measures[[nm]]))
+  }
+
+  new_semantic_layer(measures, fn_sources)
 }
 
 # Expand each `...` element into measures: character vectors are read from disk,
 # lists of measures are spliced in, and a lone measure is kept as is. `env` is
 # the caller of semantic_layer(), so measures read from disk close over the data
-# the user defined there rather than only the global environment.
+# the user defined there rather than only the global environment. Function
+# sources harvested by read_measures() ride along as an attribute on each
+# measure list; they're gathered here before unlist() drops attributes.
 expand_measures <- function(args, env = rlang::caller_env()) {
   expanded <- lapply(args, function(arg) {
     if (is.character(arg)) {
@@ -88,7 +104,12 @@ expand_measures <- function(args, env = rlang::caller_env()) {
       list(arg)
     }
   })
-  unlist(expanded, recursive = FALSE) %||% list()
+  fn_sources <- unlist(lapply(expanded, attr, "fn_sources"))
+  fn_sources <- fn_sources[!duplicated(names(fn_sources))] %||% character()
+  list(
+    measures = unlist(expanded, recursive = FALSE) %||% list(),
+    fn_sources = fn_sources
+  )
 }
 
 #' Create a measure
@@ -169,9 +190,9 @@ resolve_injections <- function(registry, injectables, call = rlang::caller_env()
   })
 }
 
-new_semantic_layer <- function(measures = list()) {
+new_semantic_layer <- function(measures = list(), fn_sources = character()) {
   structure(
-    list(measures = measures),
+    list(measures = measures, fn_sources = fn_sources),
     class = "commons_semantic_layer"
   )
 }
@@ -342,6 +363,7 @@ coerce_arg <- function(td, nm, type, value, call = rlang::caller_env()) {
 
 # Isolate the ellmer internals used by registered measure tools.
 tool_name <- function(td) S7::prop(td, "name")
+tool_fn <- function(td) S7::S7_data(td)
 tool_description <- function(td) S7::prop(td, "description")
 tool_title <- function(td) {
   annotations <- S7::prop(td, "annotations")

--- a/R/read-measures.R
+++ b/R/read-measures.R
@@ -21,17 +21,43 @@ read_measures <- function(paths, env = globalenv()) {
   # Source every file into one shared env (in order) so a measure can call a
   # helper defined in a sibling file. The parsed block only reads tags. The env
   # inherits from `env` (the semantic_layer() caller) so measures can reference
-  # data defined there, not only in the global environment.
+  # data defined there, not only in the global environment. keep.source
+  # preserves srcrefs so measure sources ship to the run_r session verbatim,
+  # comments included.
   measure_env <- new.env(parent = env)
   for (file in files) {
-    sys.source(file, envir = measure_env)
+    sys.source(file, envir = measure_env, keep.source = TRUE)
   }
 
   measures <- unlist(
     lapply(files, function(file) read_measures_file(file, measure_env)),
     recursive = FALSE
   )
-  measures %||% list()
+  measures <- measures %||% list()
+  attr(measures, "fn_sources") <- env_fn_sources(measure_env)
+  measures
+}
+
+# Source text for every function defined by the semantic layer files —
+# measures and the helpers they call alike — so run_r can present them for
+# reading. Only text leaves the environment; closures never do.
+env_fn_sources <- function(env) {
+  out <- character()
+  for (nm in ls(env)) {
+    obj <- env[[nm]]
+    if (is.function(obj)) {
+      out[[nm]] <- fn_source_text(obj)
+    }
+  }
+  out
+}
+
+fn_source_text <- function(fn) {
+  src <- attr(fn, "srcref")
+  if (is.null(src)) {
+    return(paste(deparse(fn), collapse = "\n"))
+  }
+  paste(as.character(src), collapse = "\n")
 }
 
 resolve_measure_files <- function(paths, call = rlang::caller_env()) {

--- a/R/run-r.R
+++ b/R/run-r.R
@@ -2,7 +2,7 @@ tool_run_r <- function(private) {
   ellmer::tool(
     function(code) {
       promises::then(
-        run_r_tool(private$worker, private$handles, code),
+        run_r_tool(private$worker, private$handles, code, private$fn_sources),
         function(res) add_citation_request(res, private$citation_request)
       )
     },
@@ -12,6 +12,11 @@ tool_run_r <- function(private) {
       "The session persists across calls: variables you assign and packages",
       "you load remain available. Results from call_measure and run_sql are",
       "preloaded under their advertised handles (r1, r2, ...).",
+      "Measure definitions and their helper functions are predefined under",
+      "their own names: evaluate a measure's name to read its source.",
+      "These are source-only copies without their original environment or",
+      "database connections, so treat them as reference material; to compute",
+      "a measure, use call_measure.",
       "\n\nRules:",
       "\n- Work incrementally: each call should do one small, well-defined task.",
       "\n- Create at most one figure per call.",
@@ -38,11 +43,11 @@ tool_run_r <- function(private) {
 # Returns a promise so a long computation doesn't block other sessions'
 # chats. Calls are chained through worker$tail so concurrent tool calls
 # within a turn take turns on the single worker process.
-run_r_tool <- function(worker, handles, code) {
+run_r_tool <- function(worker, handles, code, fn_sources = character()) {
   task <- function(...) {
     tryCatch(
       {
-        worker_ensure(worker)
+        worker_ensure(worker, fn_sources)
         ids <- handle_ids(handles)
         new_ids <- ids[seq_along(ids) > worker$synced]
         new_handles <- lapply(
@@ -215,7 +220,7 @@ worker_tail <- function(worker) {
   worker$tail %||% promises::promise_resolve(NULL)
 }
 
-worker_ensure <- function(worker) {
+worker_ensure <- function(worker, fn_sources = character()) {
   if (!is.null(worker$rs) && worker$rs$is_alive()) {
     return(invisible(worker))
   }
@@ -238,6 +243,11 @@ worker_ensure <- function(worker) {
       dll_path = commons_dll_path()
     )
   )
+  # Defining sources at spawn (rather than syncing per call like handles)
+  # means a respawned worker gets them again for free.
+  if (length(fn_sources)) {
+    rs$run(worker_define_functions, args = list(fn_sources = fn_sources))
+  }
   worker$rs <- rs
   worker$synced <- 0L
   invisible(worker)
@@ -450,6 +460,20 @@ worker_init <- function(parent_tmp, work_dir, dll_path) {
   write_roots <- unique(c(parent_tmp, work_dir))
   sym <- getNativeSymbolInfo("c_sandbox_engage", PACKAGE = "commons")
   .Call(sym, read_roots, write_roots, NULL)
+  invisible(TRUE)
+}
+
+# Define measure/helper sources in the worker's global env so the model can
+# read them. Parsing with keep.source here (the worker is non-interactive, so
+# it defaults off) keeps comments when a function is printed.
+worker_define_functions <- function(fn_sources) {
+  for (nm in names(fn_sources)) {
+    fn <- eval(
+      parse(text = fn_sources[[nm]], keep.source = TRUE),
+      envir = globalenv()
+    )
+    assign(nm, fn, envir = globalenv())
+  }
   invisible(TRUE)
 }
 

--- a/man/semantic_layer.Rd
+++ b/man/semantic_layer.Rd
@@ -38,6 +38,12 @@ client, give the argument a default that builds the object, e.g.
 \code{board = pins::board_connect()}. Write the default as a call rather than a
 reference to a variable defined elsewhere, so the measure doesn't depend on
 where the semantic layer is created.
+
+The source of each measure, and of any helper functions defined alongside
+it in the semantic layer's files, is readable in the agent's \code{run_r}
+session: evaluating a measure's name there prints its definition. Only
+source text is shared with that session; the functions' environments (and
+any connections or credentials in them) are not.
 }
 \examples{
 semantic_layer(

--- a/tests/testthat/test-measures.R
+++ b/tests/testthat/test-measures.R
@@ -37,6 +37,28 @@ test_that("semantic_layer surfaces read_measures errors for bad paths", {
   expect_snapshot(semantic_layer("not a measure"), error = TRUE)
 })
 
+test_that("semantic_layer collects sources from files and inline measures", {
+  skip_if_not_installed("roxygen2")
+
+  path <- withr::local_tempfile(fileext = ".R")
+  writeLines(
+    c(
+      "double <- function(x) x * 2L",
+      "#' Counter",
+      "#' @description Counts.",
+      "#' @measure",
+      "counter <- function() double(1L)"
+    ),
+    path
+  )
+
+  layer <- semantic_layer(path, count_measure_tool())
+
+  expect_setequal(names(layer$fn_sources), c("double", "counter", "order_count"))
+  expect_match(layer$fn_sources[["double"]], "x * 2L", fixed = TRUE)
+  expect_match(layer$fn_sources[["order_count"]], "^function")
+})
+
 test_that("validate_measure_args coerces valid arguments", {
   td <- count_measure_tool()
   args <- validate_measure_args(

--- a/tests/testthat/test-read-measures.R
+++ b/tests/testthat/test-read-measures.R
@@ -264,6 +264,29 @@ test_that("read_measures produces measures usable in a semantic_layer", {
   expect_named(layer$measures, "order_count")
 })
 
+test_that("read_measures harvests measure and helper sources, comments included", {
+  skip_if_not_installed("roxygen2")
+
+  path <- measures_script(c(
+    "double <- function(x) {",
+    "  # helpers ride along",
+    "  x * 2L",
+    "}",
+    "",
+    "#' Count orders",
+    "#' @description Counts orders.",
+    "#' @measure",
+    "order_count <- function() double(1013L)"
+  ))
+
+  measures <- read_measures(path)
+
+  sources <- attr(measures, "fn_sources")
+  expect_named(sources, c("double", "order_count"))
+  expect_match(sources[["double"]], "# helpers ride along", fixed = TRUE)
+  expect_match(sources[["order_count"]], "double(1013L)", fixed = TRUE)
+})
+
 test_that("read_measures parses @provenance tags without changing the measure", {
   skip_if_not_installed("roxygen2")
 

--- a/tests/testthat/test-run-r.R
+++ b/tests/testthat/test-run-r.R
@@ -48,6 +48,18 @@ test_that("run_r returns plots as images and opens the display", {
   expect_match(res@extra$display$html, "commons-run-r-code")
 })
 
+test_that("run_r preloads measure sources for reading, comments included", {
+  worker <- local_worker()
+  store <- new_handle_store()
+  fn_sources <- c(order_count = "function() {\n  # count every order\n  6L\n}")
+
+  res <- sync_promise(run_r_tool(worker, store, "order_count", fn_sources))
+  expect_match(res@value, "# count every order", fixed = TRUE)
+
+  called <- sync_promise(run_r_tool(worker, store, "order_count()", fn_sources))
+  expect_match(called@value, "6")
+})
+
 test_that("run_r delivers the citation request when no fallback tool has", {
   agent <- test_agent()
   withr::defer(worker_close(agent$.__enclos_env__$private$worker))


### PR DESCRIPTION
Closes #8, closes #11.

The addition of the `run_r` tool made this much easier for us. The deparsed measures (as in, the R functions) are now pre-loaded into the agent's R environment, and the agent otherwise has read access to `.libPaths()`, so the agent can print out / explore e.g. both `new_logo_sales_cycle` and `dscoetools::get_tile_average_new_logo_sales_cycle_length()`.