### PR TITLE
Implement lazy loading for pins

### DIFF
--- a/R/chat.R
+++ b/R/chat.R
@@ -54,10 +54,11 @@ commons_server <- function(id, client, ...) {
     attributes = list("commons.server.id" = id)
   )
 
-  # Build the context index during post-startup idle time (while the user
-  # reads the welcome message) rather than inside the first search. Errors are
-  # swallowed: the first search retries the build and surfaces the failure to
-  # the model.
+  # Build the context index and start the background pin-cache download
+  # during post-startup idle time (while the user reads the welcome message).
+  # Errors are swallowed: the first search retries the index build and
+  # surfaces the failure to the model, and an unwarmed pin is simply
+  # downloaded at its first use.
   later::later(function() {
     tryCatch(client$prewarm(), error = function(err) NULL)
   })

--- a/R/commons.R
+++ b/R/commons.R
@@ -289,8 +289,9 @@ Commons <- R6::R6Class(
         )
         context_store(layer)
       }
-      # One failing pin shouldn't stop the others from loading; it stays
-      # pending and is retried on demand.
+      # A pin that fails to read leaves the rest of its source pending, to be
+      # read on demand; wrap each source so one bad source can't stop the
+      # others from prewarming.
       for (source in private$sources) {
         tryCatch(source_ensure_all(source), error = function(err) NULL)
       }

--- a/R/commons.R
+++ b/R/commons.R
@@ -274,8 +274,9 @@ Commons <- R6::R6Class(
     },
 
     #' @description Build the context layer's search index ahead of the first
-    #'   `search_context` call, e.g. during idle time right after a Shiny
-    #'   session starts. [commons_server()] does this automatically.
+    #'   `search_context` call, and read any board tables not yet loaded into
+    #'   their data source, e.g. during idle time right after a Shiny session
+    #'   starts. [commons_server()] does this automatically.
     prewarm = function() {
       layer <- private$context_layer
       if (!is.null(layer) && length(layer$docs) > 0) {
@@ -287,6 +288,11 @@ Commons <- R6::R6Class(
           )
         )
         context_store(layer)
+      }
+      # One failing pin shouldn't stop the others from loading; it stays
+      # pending and is retried on demand.
+      for (source in private$sources) {
+        tryCatch(source_ensure_all(source), error = function(err) NULL)
       }
       invisible(self)
     }

--- a/R/commons.R
+++ b/R/commons.R
@@ -289,8 +289,6 @@ Commons <- R6::R6Class(
         )
         context_store(layer)
       }
-      # Best-effort: a pin that fails to read stays pending and is retried on
-      # demand, without stopping the other pins or sources from prewarming.
       for (source in private$sources) {
         source_prewarm(source)
       }

--- a/R/commons.R
+++ b/R/commons.R
@@ -274,9 +274,11 @@ Commons <- R6::R6Class(
     },
 
     #' @description Build the context layer's search index ahead of the first
-    #'   `search_context` call, and read any board tables not yet loaded into
-    #'   their data source, e.g. during idle time right after a Shiny session
-    #'   starts. [commons_server()] does this automatically.
+    #'   `search_context` call, and start a best-effort background download of
+    #'   any board pins not yet loaded, warming the pins cache so their first
+    #'   use is fast. Returns immediately; pins are still loaded into their
+    #'   data source on demand. [commons_server()] does this automatically,
+    #'   e.g. during idle time right after a Shiny session starts.
     prewarm = function() {
       layer <- private$context_layer
       if (!is.null(layer) && length(layer$docs) > 0) {

--- a/R/commons.R
+++ b/R/commons.R
@@ -289,11 +289,10 @@ Commons <- R6::R6Class(
         )
         context_store(layer)
       }
-      # A pin that fails to read leaves the rest of its source pending, to be
-      # read on demand; wrap each source so one bad source can't stop the
-      # others from prewarming.
+      # Best-effort: a pin that fails to read stays pending and is retried on
+      # demand, without stopping the other pins or sources from prewarming.
       for (source in private$sources) {
-        tryCatch(source_ensure_all(source), error = function(err) NULL)
+        source_prewarm(source)
       }
       invisible(self)
     }

--- a/R/data-source.R
+++ b/R/data-source.R
@@ -97,9 +97,6 @@ data_source <- function(..., tables = NULL, dictionary = NULL) {
   data_source_frames(dots, dictionary)
 }
 
-# The frames path: named data frames loaded directly into an in-process
-# DuckDB. Boards take their own path (data_source_board()), deferring each
-# pin's read until its table is first used.
 data_source_frames <- function(dots, dictionary, call = rlang::caller_env()) {
   check_named_frames(dots, call = call)
   local_commons_span(

--- a/R/data-source.R
+++ b/R/data-source.R
@@ -14,8 +14,10 @@
 #'   validated against the board at construction (a single listing call), but
 #'   each pin is downloaded only when its table is first used---by the
 #'   `describe_table` tool, a SQL query that references it, or a measure that
-#'   takes the source's connection. [commons_server()] reads any remaining
-#'   pins during idle time right after startup. A table reflects the pin's
+#'   takes the source's connection. [commons_server()] starts a background
+#'   process right after startup that downloads the remaining pins into the
+#'   local pins cache, so a first use typically only reads an
+#'   already-downloaded file. A table reflects the pin's
 #'   value at first use and is not refreshed for the lifetime of the data
 #'   source; if a pin can't be read (e.g. a network failure), the error
 #'   surfaces at that first use and the read is retried on the next one.
@@ -205,7 +207,9 @@ data_source_board <- function(
 
 # The deferred-read state a board source carries: the board plus the pins not
 # yet loaded (named character: table label -> pin name). Shared by every copy
-# of the source, so a read through one copy is seen by all.
+# of the source, so a read through one copy is seen by all. source_prewarm()
+# also stores its background downloader's handle here ($process), so every
+# copy sees at most one live warmer.
 new_pending_pins <- function(board, tables) {
   pending <- new.env(parent = emptyenv())
   pending$board <- board
@@ -340,17 +344,62 @@ source_ensure_all <- function(source, call = rlang::caller_env()) {
   source_ensure_tables(source, source$tables, call = call)
 }
 
-# Best-effort load of every pending pin, one at a time, tolerating a failure on
-# any one: it stays pending and is retried on demand. Used by prewarm(), where
-# a single bad pin must not stop the healthy ones from warming.
+# Prewarm doesn't load pins into DuckDB: dbWriteTable() must run in this
+# process (where the DuckDB lives) and would block every question asked during
+# the load, for minutes on a large board. Instead, warm the pins on-disk cache
+# in one background process, so the first on-demand pin_read() skips the
+# network and collapses to parse + dbWriteTable. The board is serialized to
+# the child as an argument, carrying its resolved cache path and auth, so the
+# child writes to the cache the parent reads even when the default cache
+# location would resolve differently (e.g. a deployment that repoints HOME).
+#
+# The handle lives on the shared pending env, so at most one child runs per
+# source. Once the child exits with pins still pending (a failed download, or
+# simply untouched tables), a later prewarm() respawns; already-cached pins
+# short-circuit in pins, so a respawn only retries genuine failures. A failed
+# spawn degrades to pure on-demand loading. Killing the child (source GC,
+# parent death via supervise) mid-write can leave a truncated cache file pins
+# won't re-download---the same hazard as interrupting pin_read() itself.
 source_prewarm <- function(source) {
-  if (is.null(source$pending)) {
+  pending <- source$pending
+  if (is.null(pending) || length(pending$pins) == 0) {
     return(invisible(source))
   }
-  for (table in names(source$pending$pins)) {
-    tryCatch(source_ensure_tables(source, table), error = function(err) NULL)
+  if (!is.null(pending$process) && pending$process$is_alive()) {
+    return(invisible(source))
   }
+  pending$process <- tryCatch(
+    callr::r_bg(
+      prewarm_downloads,
+      args = list(board = pending$board, pins = unique(unname(pending$pins))),
+      supervise = TRUE
+    ),
+    error = function(err) NULL
+  )
   invisible(source)
+}
+
+# Runs inside a background callr process, which resets this function's
+# environment to .GlobalEnv before serializing it: it must be self-contained,
+# referencing only base R and pins:: (the same constraint as the worker_*
+# functions in run-r.R). Best-effort: a failing pin is skipped so it can't
+# stop the healthy ones from warming; it stays pending in the parent, where
+# the first on-demand read surfaces the error and retries. The per-pin result
+# is never consumed in production but makes tests deterministic.
+prewarm_downloads <- function(board, pins) {
+  vapply(
+    pins,
+    function(pin) {
+      tryCatch(
+        {
+          pins::pin_download(board, pin)
+          TRUE
+        },
+        error = function(err) FALSE
+      )
+    },
+    logical(1)
+  )
 }
 
 # The pending tables a failed query actually references, read from DuckDB's

--- a/R/data-source.R
+++ b/R/data-source.R
@@ -10,7 +10,15 @@
 #' * Named data frames are loaded into an in-process DuckDB database. Use this
 #'   when the data isn't already in a database.
 #' * A `pins` board, e.g. [pins::board_connect()], is read into the same
-#'   in-process database: each pin in `tables` becomes a table.
+#'   in-process database: each pin in `tables` becomes a table. Pin names are
+#'   validated against the board at construction (a single listing call), but
+#'   each pin is downloaded only when its table is first used---by the
+#'   `describe_table` tool, a SQL query that references it, or a measure that
+#'   takes the source's connection. [commons_server()] reads any remaining
+#'   pins during idle time right after startup. A table reflects the pin's
+#'   value at first use and is not refreshed for the lifetime of the data
+#'   source; if a pin can't be read (e.g. a network failure), the error
+#'   surfaces at that first use and the read is retried on the next one.
 #'
 #' The resulting object gives the agent a DBI connection plus a table registry.
 #' Use [list_tables()] to list the registered tables.
@@ -89,10 +97,9 @@ data_source <- function(..., tables = NULL, dictionary = NULL) {
   data_source_frames(dots, dictionary)
 }
 
-# Shared by the top-level frames path and data_source_board(), which reads a
-# board's pins into data frames and loads them the same way. Called directly
-# rather than through data_source() so a board source emits one
-# commons_data_source_create span, not a duplicate nested one.
+# The frames path: named data frames loaded directly into an in-process
+# DuckDB. Boards take their own path (data_source_board()), deferring each
+# pin's read until its table is first used.
 data_source_frames <- function(dots, dictionary, call = rlang::caller_env()) {
   check_named_frames(dots, call = call)
   local_commons_span(
@@ -166,14 +173,43 @@ data_source_board <- function(
       call = call
     )
   }
+  duplicated_labels <- unique(names(tables)[duplicated(names(tables))])
+  if (length(duplicated_labels)) {
+    cli::cli_abort(
+      "{.arg tables} must not contain duplicate names: {.val {duplicated_labels}}.",
+      call = call
+    )
+  }
 
   local_commons_span(
-    "commons_data_source_read_board",
+    "commons_data_source_list_pins",
     attributes = list("commons.data_source.n_tables" = length(tables))
   )
-  frames <- lapply(tables, function(pin) pins::pin_read(board, pin))
-  names(frames) <- names(tables)
-  data_source_frames(frames, dictionary)
+  check_board_pins_exist(board, tables, call = call)
+
+  # Lock the connection down before any writes; lock_configuration() only
+  # freezes SET statements, so later dbWriteTable() from a deferred read still
+  # works.
+  con <- duckdb_connect()
+  duckdb_lock_down(con)
+
+  new_data_source(
+    con,
+    names(tables),
+    owned = TRUE,
+    dictionary = dictionary,
+    pending = new_pending_pins(board, tables)
+  )
+}
+
+# The deferred-read state a board source carries: the board plus the pins not
+# yet loaded (named character: table label -> pin name). Shared by every copy
+# of the source, so a read through one copy is seen by all.
+new_pending_pins <- function(board, tables) {
+  pending <- new.env(parent = emptyenv())
+  pending$board <- board
+  pending$pins <- tables
+  pending
 }
 
 #' List the tables an agent can query
@@ -193,7 +229,8 @@ new_data_source <- function(
   tables,
   owned,
   table_ids = table_ids_from_labels(tables),
-  dictionary = NULL
+  dictionary = NULL,
+  pending = NULL
 ) {
   # Disconnect only the DuckDB connection we created; a user-supplied connection
   # has its own owner and lifetime.
@@ -214,7 +251,8 @@ new_data_source <- function(
       tables = tables,
       table_ids = table_ids,
       handle = handle,
-      dictionary = dictionary
+      dictionary = dictionary,
+      pending = pending
     ),
     class = "commons_data_source"
   )
@@ -250,6 +288,73 @@ source_dialect <- function(source) {
   info$dbms.name %||% sub("_connection$", "", class(source$con)[[1]])
 }
 
+# Load any of `tables` still pending into the source's DuckDB, one pin at a
+# time. A pin leaves `pending` only after a successful read, so a network
+# failure surfaces to the caller and is retried on the next touch. A no-op for
+# frame and connection sources (no pending state) and for pins already loaded.
+source_ensure_tables <- function(source, tables, call = rlang::caller_env()) {
+  pending <- source$pending
+  if (is.null(pending)) {
+    return(invisible(source))
+  }
+  todo <- intersect(tables, names(pending$pins))
+  if (length(todo) == 0) {
+    return(invisible(source))
+  }
+
+  # Span moves here from construction: only emitted when a read actually
+  # happens, mirroring commons_data_source_list_tables on the connection path.
+  local_commons_span(
+    "commons_data_source_read_board",
+    attributes = list("commons.data_source.n_tables" = length(todo))
+  )
+  for (table in todo) {
+    pin <- pending$pins[[table]]
+    value <- tryCatch(
+      pins::pin_read(pending$board, pin),
+      error = function(err) {
+        cli::cli_abort(
+          "Failed to read pin {.val {pin}} for table {.val {table}}.",
+          parent = err,
+          call = call
+        )
+      }
+    )
+    if (!is.data.frame(value)) {
+      cli::cli_abort(
+        c(
+          "Pin {.val {pin}} for table {.val {table}} is not a data frame.",
+          i = "It is {.obj_type_friendly {value}}."
+        ),
+        call = call
+      )
+    }
+    DBI::dbWriteTable(source$con, table, as.data.frame(value), overwrite = TRUE)
+    pending$pins <- pending$pins[setdiff(names(pending$pins), table)]
+  }
+  invisible(source)
+}
+
+source_ensure_all <- function(source, call = rlang::caller_env()) {
+  source_ensure_tables(source, source$tables, call = call)
+}
+
+# Pending table names appearing as whole words in the SQL, matched
+# case-insensitively via word_pattern() (the idiom dictionary_sql_entries()
+# uses). A false positive just loads an extra table, which is harmless.
+pending_tables_in_sql <- function(source, sql) {
+  pending <- source$pending
+  if (is.null(pending)) {
+    return(character())
+  }
+  labels <- names(pending$pins)
+  labels[vapply(
+    labels,
+    function(table) grepl(word_pattern(table), sql, ignore.case = TRUE),
+    logical(1)
+  )]
+}
+
 source_describe <- function(source, table, n_sample = 5) {
   id <- source$table_ids[[table]]
   if (is.null(id)) {
@@ -258,6 +363,7 @@ source_describe <- function(source, table, n_sample = 5) {
       i = "Available tables: {.val {source$tables}}."
     ))
   }
+  source_ensure_tables(source, table)
 
   sample <- DBI::dbGetQuery(
     source$con,
@@ -277,7 +383,20 @@ source_describe <- function(source, table, n_sample = 5) {
 
 source_query <- function(source, sql) {
   check_query(sql)
-  DBI::dbGetQuery(source$con, sql)
+  source_ensure_tables(source, pending_tables_in_sql(source, sql))
+  tryCatch(
+    DBI::dbGetQuery(source$con, sql),
+    error = function(err) {
+      # Word matching can miss a table a query references (e.g. via an alias),
+      # so a query error while pins remain pending gets one retry after
+      # loading everything.
+      if (is.null(source$pending) || length(source$pending$pins) == 0) {
+        stop(err)
+      }
+      source_ensure_all(source)
+      DBI::dbGetQuery(source$con, sql)
+    }
+  )
 }
 
 # A keyword denylist, not a SQL parser: it anchors on the leading statement
@@ -500,6 +619,37 @@ check_table_ids_exist <- function(con, table_registry, call = rlang::caller_env(
     "{.arg tables} names table{?s} not on the connection: {.val {missing}}.",
     call = call
   )
+}
+
+# One pin_list() call instead of a pin_read() per pin: fail fast on a bad pin
+# name without paying to download anything. Connect's pin_list() returns
+# owner/name full names while users typically pass the bare name, so a listed
+# name matches either in full or by its post-slash suffix.
+check_board_pins_exist <- function(board, tables, call = rlang::caller_env()) {
+  listed <- tryCatch(
+    pins::pin_list(board),
+    error = function(err) {
+      cli::cli_abort(
+        "Failed to list pins on the board.",
+        parent = err,
+        call = call
+      )
+    }
+  )
+  suffixes <- sub("^.*/", "", listed)
+  exists <- vapply(
+    tables,
+    function(pin) pin %in% listed || pin %in% suffixes,
+    logical(1)
+  )
+  missing <- unique(unname(tables[!exists]))
+  if (length(missing)) {
+    cli::cli_abort(
+      "{.arg tables} names pin{?s} not on the board: {.val {missing}}.",
+      call = call
+    )
+  }
+  invisible(tables)
 }
 
 check_named_frames <- function(frames, call = rlang::caller_env()) {

--- a/R/data-source.R
+++ b/R/data-source.R
@@ -195,6 +195,7 @@ data_source_board <- function(
   # works.
   con <- duckdb_connect()
   duckdb_lock_down(con)
+  check_labels_free(con, names(tables), call = call)
 
   new_data_source(
     con,
@@ -357,9 +358,11 @@ source_prewarm <- function(source) {
 
 # The pending tables a failed query actually references, read from DuckDB's
 # own catalog error ("Table with name X does not exist!") rather than from the
-# SQL text. Matching the whole "does not exist" phrase---not the bare name,
-# which also appears in DuckDB's "Did you mean" suggestions---keeps a name in a
-# string literal, comment, or column reference from triggering a spurious read.
+# SQL text. Anchoring on the fixed surrounding phrase---not a bare-name match,
+# which would also fire on DuckDB's "Did you mean" suggestions---keeps a name
+# in a string literal, comment, or column reference from triggering a spurious
+# read. The phrase itself does the bounding, so a label that begins or ends in
+# punctuation (which \b can't wrap) still matches.
 pending_tables_in_error <- function(source, err) {
   pending <- source$pending
   if (is.null(pending)) {
@@ -371,7 +374,7 @@ pending_tables_in_error <- function(source, err) {
     labels,
     function(table) {
       grepl(
-        paste0("Table with name ", word_pattern(table), " does not exist"),
+        paste0("Table with name ", escape_regex(table), " does not exist"),
         msg,
         ignore.case = TRUE
       )
@@ -682,13 +685,22 @@ check_board_pins_exist <- function(board, tables, call = rlang::caller_env()) {
         return("ok")
       }
       n_suffix <- sum(suffixes == pin)
-      if (n_suffix == 0) {
-        "missing"
-      } else if (n_suffix > 1) {
-        "ambiguous"
-      } else {
-        "ok"
+      if (n_suffix > 1) {
+        return("ambiguous")
       }
+      if (n_suffix == 1) {
+        return("ok")
+      }
+      # pin_list() can be capped (Connect returns up to 1000 pins), so absence
+      # from it isn't proof the pin is missing. Confirm directly before
+      # rejecting, and stay lenient if the check itself errors---the board is
+      # reachable (pin_list() succeeded), so defer an odd per-pin failure to
+      # read time rather than blocking a valid setup.
+      exists <- tryCatch(
+        isTRUE(pins::pin_exists(board, pin)),
+        error = function(err) TRUE
+      )
+      if (exists) "ok" else "missing"
     },
     character(1)
   )
@@ -710,6 +722,44 @@ check_board_pins_exist <- function(board, tables, call = rlang::caller_env()) {
     )
   }
   invisible(tables)
+}
+
+# A fresh DuckDB already exposes system relations (duckdb_tables, sqlite_master,
+# pg_tables, information_schema.*, ...). A board label colliding with one is
+# unusable: the pin can't be written under that name (DuckDB won't drop the
+# built-in to overwrite it) and a query for it would silently read the built-in
+# instead. Probe with a zero-row SELECT before any pins are written---anything
+# that resolves here is a built-in---and reject the collisions.
+check_labels_free <- function(con, labels, call = rlang::caller_env()) {
+  taken <- labels[vapply(
+    labels,
+    function(label) {
+      tryCatch(
+        {
+          DBI::dbGetQuery(
+            con,
+            sprintf(
+              "SELECT 1 FROM %s WHERE 1 = 0",
+              DBI::dbQuoteIdentifier(con, label)
+            )
+          )
+          TRUE
+        },
+        error = function(err) FALSE
+      )
+    },
+    logical(1)
+  )]
+  if (length(taken)) {
+    cli::cli_abort(
+      c(
+        "{.arg tables} label{?s} {?collides/collide} with built-in database relation{?s}: {.val {taken}}.",
+        i = "{cli::qty(taken)}Rename the affected table{?s}."
+      ),
+      call = call
+    )
+  }
+  invisible(labels)
 }
 
 check_named_frames <- function(frames, call = rlang::caller_env()) {

--- a/R/data-source.R
+++ b/R/data-source.R
@@ -293,10 +293,8 @@ source_dialect <- function(source) {
   info$dbms.name %||% sub("_connection$", "", class(source$con)[[1]])
 }
 
-# Load any of `tables` still pending into the source's DuckDB, one pin at a
-# time. A pin leaves `pending` only after a successful read, so a network
-# failure surfaces to the caller and is retried on the next touch. A no-op for
-# frame and connection sources (no pending state) and for pins already loaded.
+# A pin leaves `pending` only after a successful read, so a failure surfaces
+# to the caller and the read is retried on the next touch.
 source_ensure_tables <- function(source, tables, call = rlang::caller_env()) {
   pending <- source$pending
   if (is.null(pending)) {
@@ -307,8 +305,6 @@ source_ensure_tables <- function(source, tables, call = rlang::caller_env()) {
     return(invisible(source))
   }
 
-  # Span moves here from construction: only emitted when a read actually
-  # happens, mirroring commons_data_source_list_tables on the connection path.
   local_commons_span(
     "commons_data_source_read_board",
     attributes = list("commons.data_source.n_tables" = length(todo))
@@ -344,22 +340,19 @@ source_ensure_all <- function(source, call = rlang::caller_env()) {
   source_ensure_tables(source, source$tables, call = call)
 }
 
-# Prewarm doesn't load pins into DuckDB: dbWriteTable() must run in this
-# process (where the DuckDB lives) and would block every question asked during
-# the load, for minutes on a large board. Instead, warm the pins on-disk cache
-# in one background process, so the first on-demand pin_read() skips the
-# network and collapses to parse + dbWriteTable. The board is serialized to
-# the child as an argument, carrying its resolved cache path and auth, so the
-# child writes to the cache the parent reads even when the default cache
-# location would resolve differently (e.g. a deployment that repoints HOME).
+# Warm the pins on-disk cache in a background process rather than loading into
+# DuckDB: dbWriteTable() must run in this process (where the DuckDB lives) and
+# would block every question asked during the load. The board is serialized to
+# the child, carrying its resolved cache path and auth, so the child writes to
+# the cache the parent reads even when the default cache location would
+# resolve differently (e.g. a deployment that repoints HOME).
 #
 # The handle lives on the shared pending env, so at most one child runs per
-# source. Once the child exits with pins still pending (a failed download, or
-# simply untouched tables), a later prewarm() respawns; already-cached pins
-# short-circuit in pins, so a respawn only retries genuine failures. A failed
-# spawn degrades to pure on-demand loading. Killing the child (source GC,
-# parent death via supervise) mid-write can leave a truncated cache file pins
-# won't re-download---the same hazard as interrupting pin_read() itself.
+# source; once it exits with pins still pending, a later prewarm() respawns,
+# and already-cached pins short-circuit so only genuine failures retry. A
+# failed spawn degrades to pure on-demand loading. Killing the child mid-write
+# can leave a truncated cache file pins won't re-download---the same hazard as
+# interrupting pin_read() itself.
 source_prewarm <- function(source) {
   pending <- source$pending
   if (is.null(pending) || length(pending$pins) == 0) {
@@ -379,13 +372,11 @@ source_prewarm <- function(source) {
   invisible(source)
 }
 
-# Runs inside a background callr process, which resets this function's
-# environment to .GlobalEnv before serializing it: it must be self-contained,
+# Runs inside a background callr process, so it must be self-contained,
 # referencing only base R and pins:: (the same constraint as the worker_*
 # functions in run-r.R). Best-effort: a failing pin is skipped so it can't
-# stop the healthy ones from warming; it stays pending in the parent, where
-# the first on-demand read surfaces the error and retries. The per-pin result
-# is never consumed in production but makes tests deterministic.
+# stop the rest from warming. The per-pin result is unused in production but
+# makes tests deterministic.
 prewarm_downloads <- function(board, pins) {
   vapply(
     pins,
@@ -462,12 +453,10 @@ source_query <- function(source, sql) {
   }
 
   # Let DuckDB resolve the query's table references and drive loading off the
-  # tables it reports missing: run the query, load the pending tables its error
-  # names, and retry. This loads only tables the query genuinely references---a
-  # name in a string literal or a bad column never pulls in an unrelated
-  # pin---and a genuine error (bad column, syntax) surfaces unchanged instead
-  # of being masked by an unrelated pin failure. Bounded by the number of
-  # pending tables: each pass either loads at least one or stops.
+  # tables it reports missing: run the query, load the pending tables its
+  # error names, and retry. A genuine error (bad column, syntax) surfaces
+  # unchanged, and each pass either loads at least one table or stops, so the
+  # loop is bounded.
   repeat {
     result <- tryCatch(
       DBI::dbGetQuery(source$con, sql),

--- a/R/data-source.R
+++ b/R/data-source.R
@@ -342,18 +342,40 @@ source_ensure_all <- function(source, call = rlang::caller_env()) {
   source_ensure_tables(source, source$tables, call = call)
 }
 
-# Pending table names appearing as whole words in the SQL, matched
-# case-insensitively via word_pattern() (the idiom dictionary_sql_entries()
-# uses). A false positive just loads an extra table, which is harmless.
-pending_tables_in_sql <- function(source, sql) {
+# Best-effort load of every pending pin, one at a time, tolerating a failure on
+# any one: it stays pending and is retried on demand. Used by prewarm(), where
+# a single bad pin must not stop the healthy ones from warming.
+source_prewarm <- function(source) {
+  if (is.null(source$pending)) {
+    return(invisible(source))
+  }
+  for (table in names(source$pending$pins)) {
+    tryCatch(source_ensure_tables(source, table), error = function(err) NULL)
+  }
+  invisible(source)
+}
+
+# The pending tables a failed query actually references, read from DuckDB's
+# own catalog error ("Table with name X does not exist!") rather than from the
+# SQL text. Matching the whole "does not exist" phrase---not the bare name,
+# which also appears in DuckDB's "Did you mean" suggestions---keeps a name in a
+# string literal, comment, or column reference from triggering a spurious read.
+pending_tables_in_error <- function(source, err) {
   pending <- source$pending
   if (is.null(pending)) {
     return(character())
   }
+  msg <- conditionMessage(err)
   labels <- names(pending$pins)
   labels[vapply(
     labels,
-    function(table) grepl(word_pattern(table), sql, ignore.case = TRUE),
+    function(table) {
+      grepl(
+        paste0("Table with name ", word_pattern(table), " does not exist"),
+        msg,
+        ignore.case = TRUE
+      )
+    },
     logical(1)
   )]
 }
@@ -386,22 +408,31 @@ source_describe <- function(source, table, n_sample = 5) {
 
 source_query <- function(source, sql) {
   check_query(sql)
-  source_ensure_tables(source, pending_tables_in_sql(source, sql))
-  tryCatch(
-    DBI::dbGetQuery(source$con, sql),
-    error = function(err) {
-      # A referenced table's name essentially always appears textually in the
-      # SQL, so pending_tables_in_sql() rarely misses one; this retry is
-      # defense against the unforeseen. It fires on any query error, including
-      # an unrelated one (e.g. a typo), but the cost is bounded: once
-      # source_ensure_all() empties `pending`, later errors just propagate.
-      if (is.null(source$pending) || length(source$pending$pins) == 0) {
-        stop(err)
-      }
-      source_ensure_all(source)
-      DBI::dbGetQuery(source$con, sql)
+  if (is.null(source$pending)) {
+    return(DBI::dbGetQuery(source$con, sql))
+  }
+
+  # Let DuckDB resolve the query's table references and drive loading off the
+  # tables it reports missing: run the query, load the pending tables its error
+  # names, and retry. This loads only tables the query genuinely references---a
+  # name in a string literal or a bad column never pulls in an unrelated
+  # pin---and a genuine error (bad column, syntax) surfaces unchanged instead
+  # of being masked by an unrelated pin failure. Bounded by the number of
+  # pending tables: each pass either loads at least one or stops.
+  repeat {
+    result <- tryCatch(
+      DBI::dbGetQuery(source$con, sql),
+      error = function(err) err
+    )
+    if (!inherits(result, "condition")) {
+      return(result)
     }
-  )
+    todo <- pending_tables_in_error(source, result)
+    if (length(todo) == 0) {
+      stop(result)
+    }
+    source_ensure_tables(source, todo)
+  }
 }
 
 # A keyword denylist, not a SQL parser: it anchors on the leading statement
@@ -629,10 +660,9 @@ check_table_ids_exist <- function(con, table_registry, call = rlang::caller_env(
 # One pin_list() call instead of a pin_read() per pin: fail fast on a bad pin
 # name without paying to download anything. Connect's pin_list() returns
 # owner/name full names while users typically pass the bare name, so a listed
-# name matches either in full or by its post-slash suffix. Suffix matching is a
-# heuristic: a bare name matches any owner's pin of that name, so a name that is
-# genuinely ambiguous or only resolves at read time surfaces when the pin is
-# actually read, not here.
+# name matches either in full or by its post-slash suffix. A bare name that
+# suffix-matches more than one owner's pin is ambiguous---pin_read() would
+# reject it---so flag it here and ask for the qualified form.
 check_board_pins_exist <- function(board, tables, call = rlang::caller_env()) {
   listed <- tryCatch(
     pins::pin_list(board),
@@ -645,15 +675,37 @@ check_board_pins_exist <- function(board, tables, call = rlang::caller_env()) {
     }
   )
   suffixes <- sub("^.*/", "", listed)
-  exists <- vapply(
+  status <- vapply(
     tables,
-    function(pin) pin %in% listed || pin %in% suffixes,
-    logical(1)
+    function(pin) {
+      if (pin %in% listed) {
+        return("ok")
+      }
+      n_suffix <- sum(suffixes == pin)
+      if (n_suffix == 0) {
+        "missing"
+      } else if (n_suffix > 1) {
+        "ambiguous"
+      } else {
+        "ok"
+      }
+    },
+    character(1)
   )
-  missing <- unique(unname(tables[!exists]))
+  missing <- unique(unname(tables[status == "missing"]))
   if (length(missing)) {
     cli::cli_abort(
       "{.arg tables} names pin{?s} not on the board: {.val {missing}}.",
+      call = call
+    )
+  }
+  ambiguous <- unique(unname(tables[status == "ambiguous"]))
+  if (length(ambiguous)) {
+    cli::cli_abort(
+      c(
+        "{.arg tables} names pin{?s} matching more than one pin on the board: {.val {ambiguous}}.",
+        i = "Use the full {.val owner/name} form to disambiguate."
+      ),
       call = call
     )
   }

--- a/R/data-source.R
+++ b/R/data-source.R
@@ -173,6 +173,9 @@ data_source_board <- function(
       call = call
     )
   }
+  if (length(tables) == 0) {
+    cli::cli_abort("{.arg tables} must name at least one pin.", call = call)
+  }
   duplicated_labels <- unique(names(tables)[duplicated(names(tables))])
   if (length(duplicated_labels)) {
     cli::cli_abort(
@@ -387,9 +390,11 @@ source_query <- function(source, sql) {
   tryCatch(
     DBI::dbGetQuery(source$con, sql),
     error = function(err) {
-      # Word matching can miss a table a query references (e.g. via an alias),
-      # so a query error while pins remain pending gets one retry after
-      # loading everything.
+      # A referenced table's name essentially always appears textually in the
+      # SQL, so pending_tables_in_sql() rarely misses one; this retry is
+      # defense against the unforeseen. It fires on any query error, including
+      # an unrelated one (e.g. a typo), but the cost is bounded: once
+      # source_ensure_all() empties `pending`, later errors just propagate.
       if (is.null(source$pending) || length(source$pending$pins) == 0) {
         stop(err)
       }
@@ -624,7 +629,10 @@ check_table_ids_exist <- function(con, table_registry, call = rlang::caller_env(
 # One pin_list() call instead of a pin_read() per pin: fail fast on a bad pin
 # name without paying to download anything. Connect's pin_list() returns
 # owner/name full names while users typically pass the bare name, so a listed
-# name matches either in full or by its post-slash suffix.
+# name matches either in full or by its post-slash suffix. Suffix matching is a
+# heuristic: a bare name matches any owner's pin of that name, so a name that is
+# genuinely ambiguous or only resolves at read time surfaces when the pin is
+# actually read, not here.
 check_board_pins_exist <- function(board, tables, call = rlang::caller_env()) {
   listed <- tryCatch(
     pins::pin_list(board),

--- a/R/tools.R
+++ b/R/tools.R
@@ -47,7 +47,8 @@ tool_call_measure <- function(private) {
         name,
         arguments,
         injections = private$injections,
-        handles = private$handles
+        handles = private$handles,
+        sources = private$sources
       )
     },
     # For small registries, we may eventually expose each measure schema upfront
@@ -157,7 +158,8 @@ call_measure_tool <- function(
   name,
   arguments,
   injections = list(),
-  handles = NULL
+  handles = NULL,
+  sources = list()
 ) {
   td <- registry[[name]]
   if (is.null(td)) {
@@ -169,6 +171,11 @@ call_measure_tool <- function(
     cli::cli_abort(c("No measure named {.val {name}}.", i = detail))
   }
   args <- validate_measure_args(td, parse_json_args(arguments))
+  # A measure takes a source's connection by the source's name; a board source
+  # must have its pins loaded before that connection can answer a query.
+  for (source_name in names(injections[[name]])) {
+    source_ensure_all(sources[[source_name]])
+  }
   value <- do.call(td, c(args, injections[[name]]))
   value <- collect_lazy_table(value)
   advert <- register_handle(handles, value)

--- a/R/utils.R
+++ b/R/utils.R
@@ -49,9 +49,14 @@ flatten_inline <- function(x) {
   trimws(gsub("\\s*\\n\\s*", " ", x))
 }
 
+# Escape any regex metacharacters in `x` so it matches literally.
+escape_regex <- function(x) {
+  gsub("([][{}()+*^$|\\\\?.])", "\\\\\\1", x)
+}
+
 # Match `x` as a whole word, escaping any regex metacharacters it contains.
 word_pattern <- function(x) {
-  paste0("\\b", gsub("([][{}()+*^$|\\\\?.])", "\\\\\\1", x), "\\b")
+  paste0("\\b", escape_regex(x), "\\b")
 }
 
 # Icons are decorative, so bsicons is optional.

--- a/R/utils.R
+++ b/R/utils.R
@@ -49,7 +49,6 @@ flatten_inline <- function(x) {
   trimws(gsub("\\s*\\n\\s*", " ", x))
 }
 
-# Escape any regex metacharacters in `x` so it matches literally.
 escape_regex <- function(x) {
   gsub("([][{}()+*^$|\\\\?.])", "\\\\\\1", x)
 }

--- a/man/commons.Rd
+++ b/man/commons.Rd
@@ -272,9 +272,11 @@ provide; not typically called directly.
 \if{latex}{\out{\hypertarget{method-Commons-prewarm}{}}}
 \subsection{\code{Commons$prewarm()}}{
   Build the context layer's search index ahead of the first
-\code{search_context} call, and read any board tables not yet loaded into
-their data source, e.g. during idle time right after a Shiny session
-starts. \code{\link[=commons_server]{commons_server()}} does this automatically.
+\code{search_context} call, and start a best-effort background download of
+any board pins not yet loaded, warming the pins cache so their first
+use is fast. Returns immediately; pins are still loaded into their
+data source on demand. \code{\link[=commons_server]{commons_server()}} does this automatically,
+e.g. during idle time right after a Shiny session starts.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Commons$prewarm()}

--- a/man/commons.Rd
+++ b/man/commons.Rd
@@ -272,8 +272,9 @@ provide; not typically called directly.
 \if{latex}{\out{\hypertarget{method-Commons-prewarm}{}}}
 \subsection{\code{Commons$prewarm()}}{
   Build the context layer's search index ahead of the first
-\code{search_context} call, e.g. during idle time right after a Shiny
-session starts. \code{\link[=commons_server]{commons_server()}} does this automatically.
+\code{search_context} call, and read any board tables not yet loaded into
+their data source, e.g. during idle time right after a Shiny session
+starts. \code{\link[=commons_server]{commons_server()}} does this automatically.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{Commons$prewarm()}

--- a/man/data_source.Rd
+++ b/man/data_source.Rd
@@ -47,8 +47,10 @@ in-process database: each pin in \code{tables} becomes a table. Pin names are
 validated against the board at construction (a single listing call), but
 each pin is downloaded only when its table is first used---by the
 \code{describe_table} tool, a SQL query that references it, or a measure that
-takes the source's connection. \code{\link[=commons_server]{commons_server()}} reads any remaining
-pins during idle time right after startup. A table reflects the pin's
+takes the source's connection. \code{\link[=commons_server]{commons_server()}} starts a background
+process right after startup that downloads the remaining pins into the
+local pins cache, so a first use typically only reads an
+already-downloaded file. A table reflects the pin's
 value at first use and is not refreshed for the lifetime of the data
 source; if a pin can't be read (e.g. a network failure), the error
 surfaces at that first use and the read is retried on the next one.

--- a/man/data_source.Rd
+++ b/man/data_source.Rd
@@ -43,7 +43,15 @@ the database directly.
 \item Named data frames are loaded into an in-process DuckDB database. Use this
 when the data isn't already in a database.
 \item A \code{pins} board, e.g. \code{\link[pins:board_connect]{pins::board_connect()}}, is read into the same
-in-process database: each pin in \code{tables} becomes a table.
+in-process database: each pin in \code{tables} becomes a table. Pin names are
+validated against the board at construction (a single listing call), but
+each pin is downloaded only when its table is first used---by the
+\code{describe_table} tool, a SQL query that references it, or a measure that
+takes the source's connection. \code{\link[=commons_server]{commons_server()}} reads any remaining
+pins during idle time right after startup. A table reflects the pin's
+value at first use and is not refreshed for the lifetime of the data
+source; if a pin can't be read (e.g. a network failure), the error
+surfaces at that first use and the read is retried on the next one.
 }
 
 The resulting object gives the agent a DBI connection plus a table registry.

--- a/tests/testthat/_snaps/data-source.md
+++ b/tests/testthat/_snaps/data-source.md
@@ -15,13 +15,30 @@
       Error in `data_source()`:
       ! `tables` names table not on the connection: "nope".
 
-# data_source reads a pins board into queryable tables
+# data_source validates board pin names at construction
+
+    Code
+      data_source(board, tables = c(orders = "team-orders", missing = "nope"))
+    Condition
+      Error in `data_source()`:
+      ! `tables` names pin not on the board: "nope".
+
+---
 
     Code
       data_source(board)
     Condition
       Error in `data_source()`:
       ! `tables` must be a named character vector of pin names.
+
+# a pin that isn't a data frame errors clearly
+
+    Code
+      source_describe(src, "cfg")
+    Condition
+      Error in `source_describe()`:
+      ! Pin "config" for table "cfg" is not a data frame.
+      i It is a list.
 
 # data_source rejects unnamed or non-data-frame input
 

--- a/tests/testthat/_snaps/data-source.md
+++ b/tests/testthat/_snaps/data-source.md
@@ -39,6 +39,23 @@
       Error in `data_source()`:
       ! `tables` must name at least one pin.
 
+# check_board_pins_exist resolves, flags missing, and flags ambiguous names
+
+    Code
+      check_board_pins_exist(board, c(x = "nope"))
+    Condition
+      Error:
+      ! `tables` names pin not on the board: "nope".
+
+---
+
+    Code
+      check_board_pins_exist(board, c(o = "orders"))
+    Condition
+      Error:
+      ! `tables` names pin matching more than one pin on the board: "orders".
+      i Use the full "owner/name" form to disambiguate.
+
 # a pin that isn't a data frame errors clearly
 
     Code

--- a/tests/testthat/_snaps/data-source.md
+++ b/tests/testthat/_snaps/data-source.md
@@ -15,6 +15,15 @@
       Error in `data_source()`:
       ! `tables` names table not on the connection: "nope".
 
+# data_source rejects a board label colliding with a built-in relation
+
+    Code
+      data_source(board, tables = c(duckdb_tables = "team-orders"))
+    Condition
+      Error in `data_source()`:
+      ! `tables` label collides with built-in database relation: "duckdb_tables".
+      i Rename the affected table.
+
 # data_source validates board pin names at construction
 
     Code
@@ -55,6 +64,14 @@
       Error:
       ! `tables` names pin matching more than one pin on the board: "orders".
       i Use the full "owner/name" form to disambiguate.
+
+# check_board_pins_exist accepts a pin absent from a capped listing
+
+    Code
+      check_board_pins_exist(board, c(x = "nope"))
+    Condition
+      Error:
+      ! `tables` names pin not on the board: "nope".
 
 # a pin that isn't a data frame errors clearly
 

--- a/tests/testthat/_snaps/data-source.md
+++ b/tests/testthat/_snaps/data-source.md
@@ -31,6 +31,14 @@
       Error in `data_source()`:
       ! `tables` must be a named character vector of pin names.
 
+---
+
+    Code
+      data_source(board, tables = stats::setNames(character(0), character(0)))
+    Condition
+      Error in `data_source()`:
+      ! `tables` must name at least one pin.
+
 # a pin that isn't a data frame errors clearly
 
     Code

--- a/tests/testthat/helper-commons.R
+++ b/tests/testthat/helper-commons.R
@@ -36,6 +36,15 @@ board_with_pins <- function(...) {
   board
 }
 
+# Bound the wait on a prewarm child so a wedged download can't hang the suite.
+wait_for_prewarm <- function(p, timeout_ms = 30000) {
+  p$wait(timeout_ms)
+  if (p$is_alive()) {
+    p$kill()
+    skip("prewarm child did not finish in time")
+  }
+}
+
 test_agent <- function(
   context_layer = NULL,
   semantic_layer = NULL,

--- a/tests/testthat/helper-commons.R
+++ b/tests/testthat/helper-commons.R
@@ -24,6 +24,18 @@ test_client <- function() {
   ellmer::chat_anthropic(model = "claude-sonnet-4-5")
 }
 
+# A board_temp() holding the given named values, each written as an rds pin.
+board_with_pins <- function(...) {
+  values <- rlang::list2(...)
+  board <- pins::board_temp()
+  suppressMessages(
+    for (nm in names(values)) {
+      pins::pin_write(board, values[[nm]], nm, type = "rds")
+    }
+  )
+  board
+}
+
 test_agent <- function(
   context_layer = NULL,
   semantic_layer = NULL,

--- a/tests/testthat/test-commons.R
+++ b/tests/testthat/test-commons.R
@@ -498,7 +498,6 @@ test_that("prewarm() warms board pins in the background without loading them", {
   )
   agent <- test_agent(data_sources = list(sales_db = src))
 
-  # Agent construction and system-prompt generation use only table labels.
   expect_length(DBI::dbListTables(src$con), 0)
 
   agent$prewarm()
@@ -512,37 +511,6 @@ test_that("prewarm() warms board pins in the background without loading them", {
   expect_setequal(names(src$pending$pins), c("orders", "reps"))
   source_describe(src, "orders")
   expect_equal(DBI::dbListTables(src$con), "orders")
-})
-
-test_that("prewarm() tolerates a failing pin and leaves everything pending", {
-  skip_if_not_installed("pins")
-
-  board <- board_with_pins(
-    "team-orders" = data.frame(id = 1:3),
-    "team-reps" = data.frame(rep = c("Ada", "Bo"))
-  )
-  src <- data_source(
-    board,
-    tables = c(orders = "team-orders", reps = "team-reps")
-  )
-  agent <- test_agent(data_sources = list(sales_db = src))
-
-  # One pin becomes unreadable; the other must still warm, and the failure
-  # surfaces only at the failed table's first use.
-  suppressMessages(pins::pin_delete(board, "team-orders"))
-
-  agent$prewarm()
-  p <- src$pending$process
-  withr::defer(p$kill())
-  wait_for_prewarm(p)
-  expect_equal(
-    p$get_result(),
-    c("team-orders" = FALSE, "team-reps" = TRUE)
-  )
-
-  expect_setequal(names(src$pending$pins), c("orders", "reps"))
-  expect_equal(nrow(source_describe(src, "reps")$sample), 2)
-  expect_error(source_describe(src, "orders"), "Failed to read pin")
 })
 
 test_that("a measure injected a board source loads its pins when it runs", {

--- a/tests/testthat/test-commons.R
+++ b/tests/testthat/test-commons.R
@@ -485,6 +485,60 @@ test_that("prewarm() records a cache hit without a build span", {
   expect_equal(prewarm_span$attributes[["commons.context.cache_hit"]], TRUE)
 })
 
+test_that("a board source loads no pins until prewarm()", {
+  skip_if_not_installed("pins")
+
+  board <- board_with_pins(
+    "team-orders" = data.frame(id = 1:3),
+    "team-reps" = data.frame(rep = c("Ada", "Bo"))
+  )
+  src <- data_source(
+    board,
+    tables = c(orders = "team-orders", reps = "team-reps")
+  )
+  agent <- test_agent(data_sources = list(sales_db = src))
+
+  # Agent construction and system-prompt generation use only table labels.
+  expect_length(DBI::dbListTables(src$con), 0)
+
+  agent$prewarm()
+  expect_setequal(DBI::dbListTables(src$con), c("orders", "reps"))
+})
+
+test_that("a measure injected a board source loads its pins when it runs", {
+  skip_if_not_installed("pins")
+
+  board <- board_with_pins("team-orders" = data.frame(id = 1:3))
+  src <- data_source(board, tables = c(orders = "team-orders"))
+
+  layer <- semantic_layer(
+    measure(
+      "order_count",
+      "Count of orders.",
+      function(warehouse) {
+        DBI::dbGetQuery(warehouse, "SELECT count(*) AS n FROM orders")$n
+      },
+      arguments = list()
+    )
+  )
+  agent <- test_agent(
+    semantic_layer = layer,
+    data_sources = list(warehouse = src)
+  )
+  expect_length(DBI::dbListTables(src$con), 0)
+
+  private <- agent$.__enclos_env__$private
+  res <- call_measure_tool(
+    private$registry,
+    "order_count",
+    "{}",
+    injections = private$injections,
+    sources = private$sources
+  )
+  expect_match(res@value, "3")
+  expect_equal(DBI::dbListTables(src$con), "orders")
+})
+
 test_that("commons() records an agent-creation span", {
   skip_if_not_installed("otelsdk")
 

--- a/tests/testthat/test-commons.R
+++ b/tests/testthat/test-commons.R
@@ -485,7 +485,7 @@ test_that("prewarm() records a cache hit without a build span", {
   expect_equal(prewarm_span$attributes[["commons.context.cache_hit"]], TRUE)
 })
 
-test_that("a board source loads no pins until prewarm()", {
+test_that("prewarm() warms board pins in the background without loading them", {
   skip_if_not_installed("pins")
 
   board <- board_with_pins(
@@ -502,10 +502,19 @@ test_that("a board source loads no pins until prewarm()", {
   expect_length(DBI::dbListTables(src$con), 0)
 
   agent$prewarm()
-  expect_setequal(DBI::dbListTables(src$con), c("orders", "reps"))
+  p <- src$pending$process
+  expect_s3_class(p, "r_process")
+  withr::defer(p$kill())
+  wait_for_prewarm(p)
+
+  # Warming fills the pins cache only; tables still load at first use.
+  expect_length(DBI::dbListTables(src$con), 0)
+  expect_setequal(names(src$pending$pins), c("orders", "reps"))
+  source_describe(src, "orders")
+  expect_equal(DBI::dbListTables(src$con), "orders")
 })
 
-test_that("prewarm() loads healthy pins even when one pin fails", {
+test_that("prewarm() tolerates a failing pin and leaves everything pending", {
   skip_if_not_installed("pins")
 
   board <- board_with_pins(
@@ -518,13 +527,22 @@ test_that("prewarm() loads healthy pins even when one pin fails", {
   )
   agent <- test_agent(data_sources = list(sales_db = src))
 
-  # One pin becomes unreadable; the other must still warm, and the failed one
-  # stays pending for an on-demand retry.
+  # One pin becomes unreadable; the other must still warm, and the failure
+  # surfaces only at the failed table's first use.
   suppressMessages(pins::pin_delete(board, "team-orders"))
 
   agent$prewarm()
-  expect_equal(DBI::dbListTables(src$con), "reps")
-  expect_equal(names(src$pending$pins), "orders")
+  p <- src$pending$process
+  withr::defer(p$kill())
+  wait_for_prewarm(p)
+  expect_equal(
+    p$get_result(),
+    c("team-orders" = FALSE, "team-reps" = TRUE)
+  )
+
+  expect_setequal(names(src$pending$pins), c("orders", "reps"))
+  expect_equal(nrow(source_describe(src, "reps")$sample), 2)
+  expect_error(source_describe(src, "orders"), "Failed to read pin")
 })
 
 test_that("a measure injected a board source loads its pins when it runs", {

--- a/tests/testthat/test-commons.R
+++ b/tests/testthat/test-commons.R
@@ -505,6 +505,28 @@ test_that("a board source loads no pins until prewarm()", {
   expect_setequal(DBI::dbListTables(src$con), c("orders", "reps"))
 })
 
+test_that("prewarm() loads healthy pins even when one pin fails", {
+  skip_if_not_installed("pins")
+
+  board <- board_with_pins(
+    "team-orders" = data.frame(id = 1:3),
+    "team-reps" = data.frame(rep = c("Ada", "Bo"))
+  )
+  src <- data_source(
+    board,
+    tables = c(orders = "team-orders", reps = "team-reps")
+  )
+  agent <- test_agent(data_sources = list(sales_db = src))
+
+  # One pin becomes unreadable; the other must still warm, and the failed one
+  # stays pending for an on-demand retry.
+  suppressMessages(pins::pin_delete(board, "team-orders"))
+
+  agent$prewarm()
+  expect_equal(DBI::dbListTables(src$con), "reps")
+  expect_equal(names(src$pending$pins), "orders")
+})
+
 test_that("a measure injected a board source loads its pins when it runs", {
   skip_if_not_installed("pins")
 

--- a/tests/testthat/test-data-source.R
+++ b/tests/testthat/test-data-source.R
@@ -226,6 +226,28 @@ test_that("source_query preserves a genuine query error, unmasked", {
   )
 })
 
+test_that("source_query loads a pin whose label ends in punctuation", {
+  skip_if_not_installed("pins")
+
+  board <- board_with_pins("team-orders" = data.frame(id = 1:3))
+  # The label ends in a non-word character, which \b can't wrap; the error
+  # matcher must still recognize DuckDB's missing-table error and load the pin.
+  src <- data_source(board, tables = c("orders-" = "team-orders"))
+
+  res <- source_query(src, 'SELECT count(*) AS n FROM "orders-"')
+  expect_equal(res$n, 3)
+})
+
+test_that("data_source rejects a board label colliding with a built-in relation", {
+  skip_if_not_installed("pins")
+
+  board <- board_with_pins("team-orders" = data.frame(id = 1:3))
+  expect_snapshot(
+    data_source(board, tables = c(duckdb_tables = "team-orders")),
+    error = TRUE
+  )
+})
+
 test_that("data_source validates board pin names at construction", {
   skip_if_not_installed("pins")
 
@@ -247,6 +269,7 @@ test_that("check_board_pins_exist resolves, flags missing, and flags ambiguous n
 
   local_mocked_bindings(
     pin_list = function(board) c("alice/orders", "bob/orders", "alice/reps"),
+    pin_exists = function(board, name) FALSE,
     .package = "pins"
   )
   board <- structure(list(), class = "pins_board")
@@ -258,6 +281,22 @@ test_that("check_board_pins_exist resolves, flags missing, and flags ambiguous n
   expect_snapshot(check_board_pins_exist(board, c(x = "nope")), error = TRUE)
   # A bare name that suffix-matches two owners' pins is ambiguous.
   expect_snapshot(check_board_pins_exist(board, c(o = "orders")), error = TRUE)
+})
+
+test_that("check_board_pins_exist accepts a pin absent from a capped listing", {
+  skip_if_not_installed("pins")
+
+  # pin_list() caps at 1000 on Connect; a valid pin past the cap must not be
+  # rejected as missing, but a genuinely absent one still is.
+  local_mocked_bindings(
+    pin_list = function(board) paste0("owner/pin", 1:1000),
+    pin_exists = function(board, name) name == "owner/past-cap",
+    .package = "pins"
+  )
+  board <- structure(list(), class = "pins_board")
+
+  expect_no_error(check_board_pins_exist(board, c(late = "owner/past-cap")))
+  expect_snapshot(check_board_pins_exist(board, c(x = "nope")), error = TRUE)
 })
 
 test_that("a failed pin read surfaces at use and is retried, not cached", {

--- a/tests/testthat/test-data-source.R
+++ b/tests/testthat/test-data-source.R
@@ -179,7 +179,6 @@ test_that("source_query loads the tables a query references", {
   expect_setequal(DBI::dbListTables(src$con), c("orders", "reps"))
   expect_equal(names(src$pending$pins), "regions")
 
-  # A repeated query reuses the loaded tables and leaves `regions` pending.
   source_query(src, "SELECT count(*) AS n FROM orders")
   expect_setequal(DBI::dbListTables(src$con), c("orders", "reps"))
   expect_equal(names(src$pending$pins), "regions")
@@ -216,8 +215,7 @@ test_that("source_query preserves a genuine query error, unmasked", {
     board,
     tables = c(orders = "team-orders", regions = "team-regions")
   )
-  # A bad column error must surface as itself, not be replaced by an unrelated
-  # pin's read failure.
+  # The deleted pin would error if read; the bad column must surface instead.
   suppressMessages(pins::pin_delete(board, "team-regions"))
 
   expect_error(
@@ -230,8 +228,6 @@ test_that("source_query loads a pin whose label ends in punctuation", {
   skip_if_not_installed("pins")
 
   board <- board_with_pins("team-orders" = data.frame(id = 1:3))
-  # The label ends in a non-word character, which \b can't wrap; the error
-  # matcher must still recognize DuckDB's missing-table error and load the pin.
   src <- data_source(board, tables = c("orders-" = "team-orders"))
 
   res <- source_query(src, 'SELECT count(*) AS n FROM "orders-"')
@@ -336,37 +332,6 @@ test_that("prewarm_downloads() downloads best-effort, tolerating a bad pin", {
     prewarm_downloads(board, c("team-orders", "team-reps")),
     c("team-orders" = FALSE, "team-reps" = TRUE)
   )
-})
-
-test_that("source_prewarm() downloads in the background, leaving pins pending", {
-  skip_if_not_installed("pins")
-
-  board <- board_with_pins(
-    "team-orders" = data.frame(id = 1:3),
-    "team-reps" = data.frame(rep = c("Ada", "Bo"))
-  )
-  src <- data_source(
-    board,
-    tables = c(orders = "team-orders", reps = "team-reps")
-  )
-
-  source_prewarm(src)
-  p <- src$pending$process
-  expect_s3_class(p, "r_process")
-  withr::defer(p$kill())
-  wait_for_prewarm(p)
-  expect_equal(
-    p$get_result(),
-    c("team-orders" = TRUE, "team-reps" = TRUE)
-  )
-
-  # Warming touches only the pins cache: DuckDB untouched, everything pending.
-  expect_length(DBI::dbListTables(src$con), 0)
-  expect_setequal(names(src$pending$pins), c("orders", "reps"))
-
-  # First touch still loads on demand.
-  source_describe(src, "orders")
-  expect_equal(DBI::dbListTables(src$con), "orders")
 })
 
 test_that("source_prewarm() spawns at most one live process per source", {

--- a/tests/testthat/test-data-source.R
+++ b/tests/testthat/test-data-source.R
@@ -123,19 +123,126 @@ test_that("duckdb_connect supports coexisting connections in one process", {
   )
 })
 
-test_that("data_source reads a pins board into queryable tables", {
+test_that("data_source defers reading a board's pins until first use", {
   skip_if_not_installed("pins")
 
-  board <- pins::board_temp()
-  suppressMessages(
-    pins::pin_write(board, data.frame(id = 1:3), "team-orders", type = "rds")
+  board <- board_with_pins(
+    "team-orders" = data.frame(id = 1:3),
+    "team-reps" = data.frame(rep = c("Ada", "Bo"))
   )
 
-  src <- data_source(board, tables = c(orders = "team-orders"))
-  expect_equal(list_tables(src), "orders")
-  expect_equal(nrow(source_query(src, "SELECT * FROM orders")), 3)
+  src <- data_source(
+    board,
+    tables = c(orders = "team-orders", reps = "team-reps")
+  )
+  expect_setequal(list_tables(src), c("orders", "reps"))
+  expect_length(DBI::dbListTables(src$con), 0)
+})
 
+test_that("source_describe loads only the table it describes", {
+  skip_if_not_installed("pins")
+
+  board <- board_with_pins(
+    "team-orders" = data.frame(id = 1:3),
+    "team-reps" = data.frame(rep = c("Ada", "Bo"))
+  )
+  src <- data_source(
+    board,
+    tables = c(orders = "team-orders", reps = "team-reps")
+  )
+
+  d <- source_describe(src, "orders")
+  expect_equal(d$schema$column, "id")
+  expect_equal(DBI::dbListTables(src$con), "orders")
+})
+
+test_that("source_query loads the tables a query references", {
+  skip_if_not_installed("pins")
+
+  board <- board_with_pins(
+    "team-orders" = data.frame(id = 1:3, rep = c("Ada", "Bo", "Ada")),
+    "team-reps" = data.frame(rep = c("Ada", "Bo"), team = c("x", "y")),
+    "team-regions" = data.frame(region = "EMEA")
+  )
+  src <- data_source(
+    board,
+    tables = c(orders = "team-orders", reps = "team-reps", regions = "team-regions")
+  )
+
+  # A join over two pending tables, one named in a different case and one
+  # quoted. The unreferenced `regions` table stays pending.
+  res <- source_query(
+    src,
+    'SELECT o.id, r.team FROM ORDERS o JOIN "reps" r ON o.rep = r.rep'
+  )
+  expect_equal(nrow(res), 3)
+  expect_setequal(DBI::dbListTables(src$con), c("orders", "reps"))
+  expect_equal(names(src$pending$pins), "regions")
+
+  # A repeated query reuses the loaded tables and leaves `regions` pending.
+  source_query(src, "SELECT count(*) AS n FROM orders")
+  expect_setequal(DBI::dbListTables(src$con), c("orders", "reps"))
+  expect_equal(names(src$pending$pins), "regions")
+})
+
+test_that("source_query loads a referenced table the matcher misses", {
+  skip_if_not_installed("pins")
+
+  board <- board_with_pins("team-orders" = data.frame(id = 1:3))
+  src <- data_source(board, tables = c(orders = "team-orders"))
+
+  # Force the word matcher to find nothing; the query still succeeds via the
+  # load-all-and-retry fallback.
+  local_mocked_bindings(pending_tables_in_sql = function(source, sql) character(0))
+  res <- source_query(src, "SELECT count(*) AS n FROM orders")
+  expect_equal(res$n, 3)
+})
+
+test_that("data_source validates board pin names at construction", {
+  skip_if_not_installed("pins")
+
+  board <- board_with_pins("team-orders" = data.frame(id = 1:3))
+
+  expect_snapshot(
+    data_source(board, tables = c(orders = "team-orders", missing = "nope")),
+    error = TRUE
+  )
   expect_snapshot(data_source(board), error = TRUE)
+})
+
+test_that("a failed pin read surfaces at use and is retried, not cached", {
+  skip_if_not_installed("pins")
+
+  board <- board_with_pins("team-orders" = data.frame(id = 1:3))
+  src <- data_source(board, tables = c(orders = "team-orders"))
+
+  suppressMessages(pins::pin_delete(board, "team-orders"))
+  expect_error(source_describe(src, "orders"), "Failed to read pin")
+
+  suppressMessages(
+    pins::pin_write(board, data.frame(id = 1:5), "team-orders", type = "rds")
+  )
+  expect_equal(nrow(source_describe(src, "orders")$sample), 5)
+})
+
+test_that("a pin that isn't a data frame errors clearly", {
+  skip_if_not_installed("pins")
+
+  board <- board_with_pins("config" = list(threshold = 1))
+  src <- data_source(board, tables = c(cfg = "config"))
+
+  expect_snapshot(source_describe(src, "cfg"), error = TRUE)
+})
+
+test_that("dbWriteTable works after duckdb_lock_down", {
+  con <- duckdb_connect()
+  withr::defer(DBI::dbDisconnect(con, shutdown = TRUE))
+  duckdb_lock_down(con)
+
+  expect_no_error(
+    DBI::dbWriteTable(con, "t", data.frame(x = 1:2), overwrite = TRUE)
+  )
+  expect_equal(DBI::dbGetQuery(con, "SELECT count(*) AS n FROM t")$n, 2)
 })
 
 test_that("data_source rejects unnamed or non-data-frame input", {
@@ -171,20 +278,31 @@ test_that("data_source spans record table counts for connections", {
   expect_equal(list_span$attributes[["commons.data_source.n_tables"]], 1L)
 })
 
-test_that("data_source spans record table counts for pins boards", {
+test_that("board construction records a list-pins span, not a read span", {
   skip_if_not_installed("otelsdk")
   skip_if_not_installed("pins")
 
-  board <- pins::board_temp()
-  suppressMessages(
-    pins::pin_write(board, data.frame(id = 1:3), "team-orders", type = "rds")
-  )
+  board <- board_with_pins("team-orders" = data.frame(id = 1:3))
 
   recorded <- otelsdk::with_otel_record(
     data_source(board, tables = c(orders = "team-orders"))
   )
   names <- vapply(recorded$traces, `[[`, character(1), "name")
-  expect_true("commons_data_source_read_board" %in% names)
+  expect_true("commons_data_source_list_pins" %in% names)
+  expect_false("commons_data_source_read_board" %in% names)
+  list_span <- recorded$traces[[which(names == "commons_data_source_list_pins")]]
+  expect_equal(list_span$attributes[["commons.data_source.n_tables"]], 1L)
+})
+
+test_that("reading a board table records a read-board span", {
+  skip_if_not_installed("otelsdk")
+  skip_if_not_installed("pins")
+
+  board <- board_with_pins("team-orders" = data.frame(id = 1:3))
+  src <- data_source(board, tables = c(orders = "team-orders"))
+
+  recorded <- otelsdk::with_otel_record(source_describe(src, "orders"))
+  names <- vapply(recorded$traces, `[[`, character(1), "name")
   read_span <- recorded$traces[[which(names == "commons_data_source_read_board")]]
   expect_equal(read_span$attributes[["commons.data_source.n_tables"]], 1L)
 })

--- a/tests/testthat/test-data-source.R
+++ b/tests/testthat/test-data-source.R
@@ -208,6 +208,10 @@ test_that("data_source validates board pin names at construction", {
     error = TRUE
   )
   expect_snapshot(data_source(board), error = TRUE)
+  expect_snapshot(
+    data_source(board, tables = stats::setNames(character(0), character(0))),
+    error = TRUE
+  )
 })
 
 test_that("a failed pin read surfaces at use and is retried, not cached", {

--- a/tests/testthat/test-data-source.R
+++ b/tests/testthat/test-data-source.R
@@ -323,6 +323,88 @@ test_that("a pin that isn't a data frame errors clearly", {
   expect_snapshot(source_describe(src, "cfg"), error = TRUE)
 })
 
+test_that("prewarm_downloads() downloads best-effort, tolerating a bad pin", {
+  skip_if_not_installed("pins")
+
+  board <- board_with_pins(
+    "team-orders" = data.frame(id = 1:3),
+    "team-reps" = data.frame(rep = c("Ada", "Bo"))
+  )
+  suppressMessages(pins::pin_delete(board, "team-orders"))
+
+  expect_equal(
+    prewarm_downloads(board, c("team-orders", "team-reps")),
+    c("team-orders" = FALSE, "team-reps" = TRUE)
+  )
+})
+
+test_that("source_prewarm() downloads in the background, leaving pins pending", {
+  skip_if_not_installed("pins")
+
+  board <- board_with_pins(
+    "team-orders" = data.frame(id = 1:3),
+    "team-reps" = data.frame(rep = c("Ada", "Bo"))
+  )
+  src <- data_source(
+    board,
+    tables = c(orders = "team-orders", reps = "team-reps")
+  )
+
+  source_prewarm(src)
+  p <- src$pending$process
+  expect_s3_class(p, "r_process")
+  withr::defer(p$kill())
+  wait_for_prewarm(p)
+  expect_equal(
+    p$get_result(),
+    c("team-orders" = TRUE, "team-reps" = TRUE)
+  )
+
+  # Warming touches only the pins cache: DuckDB untouched, everything pending.
+  expect_length(DBI::dbListTables(src$con), 0)
+  expect_setequal(names(src$pending$pins), c("orders", "reps"))
+
+  # First touch still loads on demand.
+  source_describe(src, "orders")
+  expect_equal(DBI::dbListTables(src$con), "orders")
+})
+
+test_that("source_prewarm() spawns at most one live process per source", {
+  skip_if_not_installed("pins")
+
+  local_mocked_bindings(prewarm_downloads = function(board, pins) Sys.sleep(30))
+  board <- board_with_pins("team-orders" = data.frame(id = 1:3))
+  src <- data_source(board, tables = c(orders = "team-orders"))
+
+  source_prewarm(src)
+  p <- src$pending$process
+  withr::defer(p$kill())
+  expect_true(p$is_alive())
+
+  # A second prewarm (e.g. another agent sharing the source) doesn't respawn.
+  source_prewarm(src)
+  expect_identical(src$pending$process, p)
+
+  # Once the child is gone with pins still pending, prewarm respawns.
+  p$kill()
+  p$wait(5000)
+  source_prewarm(src)
+  expect_false(identical(src$pending$process, p))
+  withr::defer(src$pending$process$kill())
+})
+
+test_that("source_prewarm() is a no-op without pending pins", {
+  expect_no_error(source_prewarm(test_source()))
+
+  skip_if_not_installed("pins")
+  board <- board_with_pins("team-orders" = data.frame(id = 1:3))
+  src <- data_source(board, tables = c(orders = "team-orders"))
+  source_ensure_all(src)
+
+  source_prewarm(src)
+  expect_null(src$pending$process)
+})
+
 test_that("dbWriteTable works after duckdb_lock_down", {
   con <- duckdb_connect()
   withr::defer(DBI::dbDisconnect(con, shutdown = TRUE))

--- a/tests/testthat/test-data-source.R
+++ b/tests/testthat/test-data-source.R
@@ -185,17 +185,45 @@ test_that("source_query loads the tables a query references", {
   expect_equal(names(src$pending$pins), "regions")
 })
 
-test_that("source_query loads a referenced table the matcher misses", {
+test_that("source_query doesn't read a pin named only in a string literal", {
   skip_if_not_installed("pins")
 
-  board <- board_with_pins("team-orders" = data.frame(id = 1:3))
-  src <- data_source(board, tables = c(orders = "team-orders"))
+  board <- board_with_pins(
+    "team-orders" = data.frame(id = 1:3),
+    "team-regions" = data.frame(region = "EMEA")
+  )
+  src <- data_source(
+    board,
+    tables = c(orders = "team-orders", regions = "team-regions")
+  )
+  # An unavailable pin that the query mentions only as a string literal must
+  # not be read, so the valid query over `orders` still succeeds.
+  suppressMessages(pins::pin_delete(board, "team-regions"))
 
-  # Force the word matcher to find nothing; the query still succeeds via the
-  # load-all-and-retry fallback.
-  local_mocked_bindings(pending_tables_in_sql = function(source, sql) character(0))
-  res <- source_query(src, "SELECT count(*) AS n FROM orders")
-  expect_equal(res$n, 3)
+  res <- source_query(src, "SELECT id, 'regions' AS label FROM orders")
+  expect_equal(nrow(res), 3)
+  expect_equal(names(src$pending$pins), "regions")
+})
+
+test_that("source_query preserves a genuine query error, unmasked", {
+  skip_if_not_installed("pins")
+
+  board <- board_with_pins(
+    "team-orders" = data.frame(id = 1:3),
+    "team-regions" = data.frame(region = "EMEA")
+  )
+  src <- data_source(
+    board,
+    tables = c(orders = "team-orders", regions = "team-regions")
+  )
+  # A bad column error must surface as itself, not be replaced by an unrelated
+  # pin's read failure.
+  suppressMessages(pins::pin_delete(board, "team-regions"))
+
+  expect_error(
+    source_query(src, "SELECT nope_col FROM orders"),
+    "nope_col"
+  )
 })
 
 test_that("data_source validates board pin names at construction", {
@@ -212,6 +240,24 @@ test_that("data_source validates board pin names at construction", {
     data_source(board, tables = stats::setNames(character(0), character(0))),
     error = TRUE
   )
+})
+
+test_that("check_board_pins_exist resolves, flags missing, and flags ambiguous names", {
+  skip_if_not_installed("pins")
+
+  local_mocked_bindings(
+    pin_list = function(board) c("alice/orders", "bob/orders", "alice/reps"),
+    .package = "pins"
+  )
+  board <- structure(list(), class = "pins_board")
+
+  # Full name and a unique suffix both resolve.
+  expect_no_error(check_board_pins_exist(board, c(o = "alice/orders")))
+  expect_no_error(check_board_pins_exist(board, c(r = "reps")))
+
+  expect_snapshot(check_board_pins_exist(board, c(x = "nope")), error = TRUE)
+  # A bare name that suffix-matches two owners' pins is ambiguous.
+  expect_snapshot(check_board_pins_exist(board, c(o = "orders")), error = TRUE)
 })
 
 test_that("a failed pin read surfaces at use and is retried, not cached", {


### PR DESCRIPTION
Closes #25. 

Previously, if you used a substantial number of pins as a data source, apps were slow to load because all pins were read into DuckDB tables at startup. 

With this PR, pins are read in lazily:

* `data_source()` with a specified `board` makes a single `pins::pin_list()` call to validate the pin names and returns without reading anything. A pin specified in `data_source()` that isn't in the returned listing triggers a `pins::pin_exists()` check before it's rejected (Connect caps `pins::pin_list()` at 1000 pins). 
* A prewarm feature that downloads as many pins as it can. `commons_server()` starts it during idle time right after startup. The downloads run in a background R process (`callr::r_bg()`) that calls `pins::pin_download()` for each unread pin, so prewarming can't block the main R process. Prewarming only fills the local pins cache. The tables don't get put into DuckDB until they are required (see next bullet), but those reads just parse the cached file and are fast.
*  A pin is read lazily the first time something requires it: a SQL query, the `describe_table` tool, or a measure.
   * For SQL queries, it works by 1) running the SQL the agent requested and 2) if DuckDB returns an error of the type "Table with name [X] does not exist", reading in that pin and retrying. This introduces some latency, but is pretty fast in practice, and is less messy and more correct than name-matching the tables in the SQL. 
   * `describe_table` loads just the one table it inspects. 
   * _Limitation:_ For measures, running a measure loads all of the source's pins, because the tables it queries can't be reliably or easily extracted from the R code. In practice, the hope is that prewarming has already downloaded necessary pins. One reason to keep it this way for now: if measures eventually live in `data-dict.yaml` files with explicit ties to specific tables, we can use those relationships to lazily load just the required pins.