### PR TITLE
sandbox the run_r worker on macOS via Seatbelt

### DIFF
--- a/R/run-r.R
+++ b/R/run-r.R
@@ -423,10 +423,12 @@ plot_dimensions <- function(ratio, longest_side) {
 worker_init <- function(parent_tmp, work_dir, dll_path) {
   setwd(work_dir)
   options(width = 80, cli.num_colors = 1)
-  # Off Linux there is no sandbox; run unsandboxed (local dev only). On Linux
-  # the sandbox must engage, so a missing compiled library is a hard error
-  # rather than a silent drop to unsandboxed execution.
-  if (!identical(Sys.info()[["sysname"]], "Linux")) {
+  # Only Linux (Landlock + seccomp) and macOS (Seatbelt) have sandbox
+  # implementations; elsewhere run unsandboxed (local dev only). Where a
+  # sandbox exists it must engage, so a missing compiled library is a hard
+  # error rather than a silent drop to unsandboxed execution.
+  sysname <- Sys.info()[["sysname"]]
+  if (!sysname %in% c("Linux", "Darwin")) {
     return(invisible(FALSE))
   }
   if (is.na(dll_path)) {
@@ -439,25 +441,36 @@ worker_init <- function(parent_tmp, work_dir, dll_path) {
   if (!("commons" %in% names(getLoadedDLLs()))) {
     dyn.load(dll_path)
   }
-  # Landlock resolves symlinks, and Connect's packrat library is a farm of
-  # symlinks into a shared cache, so grant the resolved package paths too.
+  resolve <- function(paths) {
+    vapply(
+      paths,
+      function(p) tryCatch(normalizePath(p), error = function(e) p),
+      character(1),
+      USE.NAMES = FALSE
+    )
+  }
+  # Both mechanisms match symlink-free paths: Connect's packrat library is a
+  # farm of symlinks into a shared cache, and macOS's /tmp and /var live
+  # under /private, so grant resolved paths alongside the originals.
   pkg_dirs <- list.dirs(.libPaths(), recursive = FALSE)
-  resolved <- vapply(
-    pkg_dirs,
-    function(p) tryCatch(normalizePath(p), error = function(e) p),
-    character(1),
-    USE.NAMES = FALSE
+  os_roots <- switch(
+    sysname,
+    Linux = c("/usr", "/lib", "/lib64", "/etc", "/opt/R"),
+    Darwin = c(
+      "/usr", "/bin", "/sbin", "/System", "/Library",
+      "/private/etc", "/private/var/db", "/opt", "/dev"
+    )
   )
   read_roots <- unique(c(
     R.home(),
     .libPaths(),
-    resolved,
-    "/usr", "/lib", "/lib64", "/etc", "/opt/R"
+    resolve(pkg_dirs),
+    os_roots
   ))
-  read_roots <- read_roots[dir.exists(read_roots)]
+  read_roots <- unique(resolve(read_roots[dir.exists(read_roots)]))
   # callr writes its per-call result files into the parent's tempdir, so the
   # worker must be able to write there for results to make it back.
-  write_roots <- unique(c(parent_tmp, work_dir))
+  write_roots <- unique(resolve(c(parent_tmp, work_dir)))
   sym <- getNativeSymbolInfo("c_sandbox_engage", PACKAGE = "commons")
   .Call(sym, read_roots, write_roots, NULL)
   invisible(TRUE)

--- a/R/sandbox.R
+++ b/R/sandbox.R
@@ -2,9 +2,6 @@
 # sandbox itself in worker_init() (run-r.R), calling the C symbol directly;
 # the parent process is never sandboxed.
 
-# Report what the running kernel supports: the Landlock ABI version (-1 when
-# unavailable), whether seccomp filters can be installed, and whether macOS
-# Seatbelt is available.
 sandbox_capabilities <- function() {
   caps <- .Call(c_sandbox_capabilities)
   list(

--- a/R/sandbox.R
+++ b/R/sandbox.R
@@ -3,8 +3,13 @@
 # the parent process is never sandboxed.
 
 # Report what the running kernel supports: the Landlock ABI version (-1 when
-# unavailable) and whether seccomp filters can be installed.
+# unavailable), whether seccomp filters can be installed, and whether macOS
+# Seatbelt is available.
 sandbox_capabilities <- function() {
   caps <- .Call(c_sandbox_capabilities)
-  list(landlock_abi = caps[[1]], seccomp = caps[[2]] > 0)
+  list(
+    landlock_abi = caps[[1]],
+    seccomp = caps[[2]] > 0,
+    seatbelt = caps[[3]] > 0
+  )
 }

--- a/src/sandbox.c
+++ b/src/sandbox.c
@@ -1,7 +1,8 @@
 /* Self-restriction bindings for the run_r worker process. These run once at
  * worker startup; enforcement thereafter is the kernel's, not this code's.
- * Landlock has no libc wrapper and seccomp requires prctl() with a BPF
- * program, so neither is reachable from R without this layer. */
+ * Landlock has no libc wrapper, seccomp requires prctl() with a BPF program,
+ * and macOS Seatbelt is only reachable through libSystem's sandbox_init(),
+ * so none of them is reachable from R without this layer. */
 
 #define _GNU_SOURCE
 
@@ -100,9 +101,10 @@ SEXP c_sandbox_capabilities(void) {
   long landlock_abi = syscall(__NR_landlock_create_ruleset, NULL, 0,
                               LL_CREATE_RULESET_VERSION);
   int seccomp_ok = prctl(PR_GET_SECCOMP, 0, 0, 0, 0) >= 0;
-  SEXP out = PROTECT(Rf_allocVector(INTSXP, 2));
+  SEXP out = PROTECT(Rf_allocVector(INTSXP, 3));
   INTEGER(out)[0] = (int) landlock_abi;
   INTEGER(out)[1] = seccomp_ok;
+  INTEGER(out)[2] = 0;
   UNPROTECT(1);
   return out;
 }
@@ -167,18 +169,121 @@ SEXP c_sandbox_engage(SEXP read_roots, SEXP rw_roots, SEXP memory_limit) {
   return R_NilValue;
 }
 
-#else /* not __linux__ */
+#elif defined(__APPLE__)
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/resource.h>
+
+/* Seatbelt's C entry points live in libSystem. <sandbox.h> declares them
+ * deprecated (since 10.8) with no replacement for unentitled processes;
+ * declaring them directly keeps the build warning-free. */
+extern int sandbox_init(const char *profile, uint64_t flags, char **errorbuf);
+extern void sandbox_free_error(char *errorbuf);
+
+static size_t append_str(char *buf, size_t size, size_t off, const char *s) {
+  size_t n = strlen(s);
+  if (off + n + 1 > size) {
+    Rf_error("run_r sandbox: profile buffer overflow");
+  }
+  memcpy(buf + off, s, n + 1);
+  return off + n;
+}
+
+static size_t append_subpaths(char *buf, size_t size, size_t off, SEXP roots) {
+  for (int i = 0; i < Rf_length(roots); i++) {
+    const char *path = CHAR(STRING_ELT(roots, i));
+    if (strpbrk(path, "\"\\") != NULL) {
+      Rf_error("cannot sandbox: root '%s' contains a quote or backslash",
+               path);
+    }
+    off = append_str(buf, size, off, " (subpath \"");
+    off = append_str(buf, size, off, path);
+    off = append_str(buf, size, off, "\")");
+  }
+  return off;
+}
 
 SEXP c_sandbox_capabilities(void) {
-  SEXP out = PROTECT(Rf_allocVector(INTSXP, 2));
+  SEXP out = PROTECT(Rf_allocVector(INTSXP, 3));
   INTEGER(out)[0] = -1;
   INTEGER(out)[1] = 0;
+  INTEGER(out)[2] = 1;
   UNPROTECT(1);
   return out;
 }
 
 SEXP c_sandbox_engage(SEXP read_roots, SEXP rw_roots, SEXP memory_limit) {
-  Rf_error("sandboxing is only supported on Linux");
+  if (memory_limit != R_NilValue) {
+    /* Accepted but not reliably enforced by the macOS kernel; kept for
+     * interface parity with the Linux branch. */
+    rlim_t bytes = (rlim_t) REAL(memory_limit)[0];
+    struct rlimit lim = { .rlim_cur = bytes, .rlim_max = bytes };
+    if (setrlimit(RLIMIT_AS, &lim) != 0) {
+      Rf_error("setrlimit(RLIMIT_AS) failed: %s", strerror(errno));
+    }
+  }
+
+  size_t size = 512;
+  for (int i = 0; i < Rf_length(read_roots); i++) {
+    size += strlen(CHAR(STRING_ELT(read_roots, i))) + 16;
+  }
+  for (int i = 0; i < Rf_length(rw_roots); i++) {
+    size += 2 * (strlen(CHAR(STRING_ELT(rw_roots, i))) + 16);
+  }
+  char *profile = R_alloc(size, 1);
+
+  /* Later rules take precedence in SBPL, so each blanket deny is followed by
+   * its allowlist; rw roots appear in both, mirroring Landlock's FS_V1_ALL.
+   * (deny network*) covers unix-domain sockets too, blocking DNS via
+   * mDNSResponder — parity with seccomp's blanket socket() denial.
+   * file-read-metadata stays allowed for path traversal: it exposes
+   * existence of files outside the roots, but not contents. */
+  size_t off = append_str(profile, size, 0,
+    "(version 1)\n"
+    "(allow default)\n"
+    "(deny network*)\n"
+    "(deny file-write*)\n"
+    "(allow file-write* (literal \"/dev/null\")");
+  off = append_subpaths(profile, size, off, rw_roots);
+  off = append_str(profile, size, off,
+    ")\n"
+    "(deny file-read*)\n"
+    "(allow file-read*");
+  off = append_subpaths(profile, size, off, read_roots);
+  off = append_subpaths(profile, size, off, rw_roots);
+  off = append_str(profile, size, off,
+    ")\n"
+    "(allow file-read-metadata)\n");
+
+  char *err = NULL;
+  if (sandbox_init(profile, 0, &err) != 0) {
+    char msg[512];
+    snprintf(msg, sizeof(msg), "%s", err ? err : "unknown error");
+    if (err) {
+      sandbox_free_error(err);
+    }
+    Rf_error("sandbox_init failed: %s", msg);
+  }
+
+  return R_NilValue;
+}
+
+#else /* not __linux__ or __APPLE__ */
+
+SEXP c_sandbox_capabilities(void) {
+  SEXP out = PROTECT(Rf_allocVector(INTSXP, 3));
+  INTEGER(out)[0] = -1;
+  INTEGER(out)[1] = 0;
+  INTEGER(out)[2] = 0;
+  UNPROTECT(1);
+  return out;
+}
+
+SEXP c_sandbox_engage(SEXP read_roots, SEXP rw_roots, SEXP memory_limit) {
+  Rf_error("sandboxing is only supported on Linux and macOS");
   return R_NilValue;
 }
 

--- a/tests/testthat/test-sandbox.R
+++ b/tests/testthat/test-sandbox.R
@@ -1,12 +1,13 @@
-test_that("sandbox_capabilities reports both mechanisms", {
+test_that("sandbox_capabilities reports all mechanisms", {
   caps <- sandbox_capabilities()
-  expect_named(caps, c("landlock_abi", "seccomp"))
+  expect_named(caps, c("landlock_abi", "seccomp", "seatbelt"))
   expect_type(caps$landlock_abi, "integer")
   expect_type(caps$seccomp, "logical")
+  expect_type(caps$seatbelt, "logical")
 })
 
-test_that("worker_init leaves the worker unsandboxed off Linux", {
-  skip_on_os("linux")
+test_that("worker_init leaves the worker unsandboxed off Linux and macOS", {
+  skip_on_os(c("linux", "mac"))
   res <- callr::r(
     worker_init,
     args = list(
@@ -18,9 +19,29 @@ test_that("worker_init leaves the worker unsandboxed off Linux", {
   expect_false(res)
 })
 
+test_that("worker_init errors without the compiled library", {
+  skip_on_os(c("windows", "solaris"))
+  expect_error(
+    callr::r(
+      worker_init,
+      args = list(
+        parent_tmp = tempdir(),
+        work_dir = tempdir(),
+        dll_path = NA_character_
+      )
+    ),
+    "compiled library"
+  )
+})
+
 test_that("an initialized worker is denied reads, writes, and sockets", {
-  skip_on_os(c("mac", "windows", "solaris"))
-  skip_if_not(sandbox_capabilities()$landlock_abi >= 1, "kernel lacks Landlock")
+  skip_on_os(c("windows", "solaris"))
+  if (identical(Sys.info()[["sysname"]], "Linux")) {
+    skip_if_not(
+      sandbox_capabilities()$landlock_abi >= 1,
+      "kernel lacks Landlock"
+    )
+  }
 
   outside <- file.path(dirname(tempdir()), paste0("canary-", Sys.getpid()))
   dir.create(outside)
@@ -67,13 +88,26 @@ test_that("an initialized worker is denied reads, writes, and sockets", {
         },
         socket = denied({
           con <- socketConnection(
-            "127.0.0.1",
-            port = 9,
+            "example.com",
+            port = 80,
             blocking = TRUE,
-            timeout = 1
+            timeout = 5
           )
           close(con)
         }),
+        subprocess = {
+          out <- suppressWarnings(system(
+            "curl -sS --max-time 5 https://example.com",
+            intern = TRUE,
+            ignore.stderr = TRUE
+          ))
+          status <- attr(out, "status")
+          if (length(out) > 0 && (is.null(status) || status == 0)) {
+            "allowed"
+          } else {
+            "denied"
+          }
+        },
         compute = sum(1:10)
       )
     },
@@ -83,5 +117,6 @@ test_that("an initialized worker is denied reads, writes, and sockets", {
   expect_equal(probes$read, "denied")
   expect_equal(probes$write, "denied")
   expect_equal(probes$socket, "denied")
+  expect_equal(probes$subprocess, "denied")
   expect_equal(probes$compute, 55)
 })


### PR DESCRIPTION
Closes #50.

> Adds an __APPLE__ branch to c_sandbox_engage() that self-restricts the worker with sandbox_init() and an SBPL profile mirroring the Linux restrictions: reads limited to R and system roots, writes limited to the work dir and parent tempdir (which need read access too, matching Landlock's FS_V1_ALL on rw roots), and no network — (deny network*) covers unix sockets, so DNS is blocked like seccomp's socket() denial. Roots are normalizePath()ed since Seatbelt matches canonical paths (/tmp and /var live under /private). The denial tests now run on macOS and probe real egress to example.com, including via a subprocess.