### PR TITLE
fix `read_trajectories()`

### DIFF
--- a/R/connect.R
+++ b/R/connect.R
@@ -43,7 +43,8 @@ connect_req <- function(client, ...) {
 }
 
 # Fetch trace rows for a content item as raw OTLP NDJSON lines, paging until
-# the X-Total-Count header is exhausted or `enough(lines)` returns TRUE.
+# the X-Total-Count header is exhausted. On servers with a single trace store,
+# `enough(lines)` can stop paging early.
 # Connect returns rows newest-first by span start time and filters `from`/`to`
 # on span start time over `[from, to)`.
 connect_trace_lines <- function(
@@ -74,17 +75,22 @@ connect_trace_lines <- function(
     )
     if (is.null(resp)) {
       return(connect_job_trace_lines(
-        client, guid, from, enough, page_size, call
+        client, guid, from, page_size, call
       ))
     }
-    version <- version %||% connect_server_version(resp)
+    version <- version %||% connect_server_version(
+      httr2::resp_header(resp, "Server")
+    )
     page <- resp_trace_lines(resp)
     lines <- c(lines, page)
     total <- suppressWarnings(
       as.integer(httr2::resp_header(resp, "X-Total-Count"))
     )
     offset <- offset + length(page)
-    if (length(lines) > 0 && !is.null(enough) && enough(lines)) {
+    if (
+      !is.null(version) && version < numeric_version("2026.07.0") &&
+        length(lines) > 0 && !is.null(enough) && enough(lines)
+    ) {
       return(lines)
     }
     if (length(page) == 0 || is.na(total) || offset >= total) {
@@ -94,7 +100,7 @@ connect_trace_lines <- function(
   # Connect 2026.07 moved new traces without migrating the per-job files.
   if (is.null(version) || version >= numeric_version("2026.07.0")) {
     lines <- connect_job_trace_lines(
-      client, guid, from, enough, page_size, call, lines
+      client, guid, from, page_size, call, lines
     )
   }
   unique(lines)
@@ -104,7 +110,6 @@ connect_job_trace_lines <- function(
   client,
   guid,
   from,
-  enough,
   page_size,
   call,
   lines = character()
@@ -116,9 +121,6 @@ connect_job_trace_lines <- function(
     httr2_http_401 = function(err) trace_access_abort(err, call),
     httr2_http_403 = function(err) trace_access_abort(err, call)
   )
-  starts <- vapply(jobs, function(job) job$start_time %||% "", character(1))
-  jobs <- jobs[order(starts, decreasing = TRUE)]
-
   for (job in jobs) {
     offset <- 0
     repeat {
@@ -143,9 +145,6 @@ connect_job_trace_lines <- function(
         as.integer(httr2::resp_header(resp, "X-Total-Count"))
       )
       offset <- offset + length(page)
-      if (length(lines) > 0 && !is.null(enough) && enough(lines)) {
-        return(unique(lines))
-      }
       if (length(page) == 0 || is.na(total) || offset >= total) {
         break
       }
@@ -163,8 +162,7 @@ resp_trace_lines <- function(resp) {
   page[nzchar(page)]
 }
 
-connect_server_version <- function(resp) {
-  server <- httr2::resp_header(resp, "Server")
+connect_server_version <- function(server) {
   if (is.null(server)) {
     return(NULL)
   }

--- a/R/connect.R
+++ b/R/connect.R
@@ -57,6 +57,7 @@ connect_trace_lines <- function(
 ) {
   lines <- character()
   offset <- 0
+  version <- NULL
   repeat {
     resp <- tryCatch(
       connect_req(client, "content", guid, "traces") |>
@@ -68,24 +69,111 @@ connect_trace_lines <- function(
         ) |>
         httr2::req_perform(),
       httr2_http_401 = function(err) trace_access_abort(err, call),
-      httr2_http_403 = function(err) trace_access_abort(err, call)
+      httr2_http_403 = function(err) trace_access_abort(err, call),
+      httr2_http_404 = function(err) NULL
     )
-    page <- httr2::resp_body_string(resp)
-    page <- strsplit(page, "\n", fixed = TRUE)[[1]]
-    page <- page[nzchar(page)]
+    if (is.null(resp)) {
+      return(connect_job_trace_lines(
+        client, guid, from, enough, page_size, call
+      ))
+    }
+    version <- version %||% connect_server_version(resp)
+    page <- resp_trace_lines(resp)
     lines <- c(lines, page)
     total <- suppressWarnings(
       as.integer(httr2::resp_header(resp, "X-Total-Count"))
     )
     offset <- offset + length(page)
+    if (length(lines) > 0 && !is.null(enough) && enough(lines)) {
+      return(lines)
+    }
     if (length(page) == 0 || is.na(total) || offset >= total) {
       break
     }
-    if (!is.null(enough) && enough(lines)) {
-      break
+  }
+  # Connect 2026.07 moved new traces without migrating the per-job files.
+  if (is.null(version) || version >= numeric_version("2026.07.0")) {
+    lines <- connect_job_trace_lines(
+      client, guid, from, enough, page_size, call, lines
+    )
+  }
+  unique(lines)
+}
+
+connect_job_trace_lines <- function(
+  client,
+  guid,
+  from,
+  enough,
+  page_size,
+  call,
+  lines = character()
+) {
+  jobs <- tryCatch(
+    connect_req(client, "content", guid, "jobs") |>
+      httr2::req_perform() |>
+      httr2::resp_body_json(),
+    httr2_http_401 = function(err) trace_access_abort(err, call),
+    httr2_http_403 = function(err) trace_access_abort(err, call)
+  )
+  starts <- vapply(jobs, function(job) job$start_time %||% "", character(1))
+  jobs <- jobs[order(starts, decreasing = TRUE)]
+
+  for (job in jobs) {
+    offset <- 0
+    repeat {
+      resp <- tryCatch(
+        connect_req(client, "content", guid, "jobs", job$key, "traces") |>
+          httr2::req_url_query(
+            limit = page_size,
+            offset = offset,
+            since = connect_window_param(from, -3600)
+          ) |>
+          httr2::req_perform(),
+        httr2_http_401 = function(err) trace_access_abort(err, call),
+        httr2_http_403 = function(err) trace_access_abort(err, call),
+        httr2_http_404 = function(err) NULL
+      )
+      if (is.null(resp)) {
+        break
+      }
+      page <- resp_trace_lines(resp)
+      lines <- c(lines, page)
+      total <- suppressWarnings(
+        as.integer(httr2::resp_header(resp, "X-Total-Count"))
+      )
+      offset <- offset + length(page)
+      if (length(lines) > 0 && !is.null(enough) && enough(lines)) {
+        return(unique(lines))
+      }
+      if (length(page) == 0 || is.na(total) || offset >= total) {
+        break
+      }
     }
   }
   lines
+}
+
+resp_trace_lines <- function(resp) {
+  if (!httr2::resp_has_body(resp)) {
+    return(character())
+  }
+  page <- httr2::resp_body_string(resp)
+  page <- strsplit(page, "\n", fixed = TRUE)[[1]]
+  page[nzchar(page)]
+}
+
+connect_server_version <- function(resp) {
+  server <- httr2::resp_header(resp, "Server")
+  if (is.null(server)) {
+    return(NULL)
+  }
+  match <- regexec("Posit Connect v([0-9]+(?:\\.[0-9]+){1,2})", server)
+  version <- regmatches(server, match)[[1]]
+  if (length(version) == 0) {
+    return(NULL)
+  }
+  numeric_version(version[[2]])
 }
 
 # Connect silently ignores timestamps it can't parse, including any without

--- a/R/connect.R
+++ b/R/connect.R
@@ -121,36 +121,76 @@ connect_job_trace_lines <- function(
     httr2_http_401 = function(err) trace_access_abort(err, call),
     httr2_http_403 = function(err) trace_access_abort(err, call)
   )
-  for (job in jobs) {
-    offset <- 0
-    repeat {
-      resp <- tryCatch(
-        connect_req(client, "content", guid, "jobs", job$key, "traces") |>
-          httr2::req_url_query(
-            limit = page_size,
-            offset = offset,
-            since = connect_window_param(from, -3600)
-          ) |>
-          httr2::req_perform(),
-        httr2_http_401 = function(err) trace_access_abort(err, call),
-        httr2_http_403 = function(err) trace_access_abort(err, call),
-        httr2_http_404 = function(err) NULL
+  job_keys <- vapply(jobs, function(job) job$key, character(1))
+  offsets <- integer(length(job_keys))
+  max_active <- 20
+
+  while (length(job_keys) > 0) {
+    requests <- vector("list", length(job_keys))
+    for (i in seq_along(job_keys)) {
+      requests[[i]] <- connect_job_trace_req(
+        job_key = job_keys[[i]],
+        offset = offsets[[i]],
+        client = client,
+        guid = guid,
+        from = from,
+        page_size = page_size,
+        max_active = max_active
       )
-      if (is.null(resp)) {
-        break
+    }
+    responses <- httr2::req_perform_parallel(
+      requests,
+      on_error = "continue",
+      progress = FALSE,
+      max_active = max_active
+    )
+    next_job_keys <- character()
+    next_offsets <- integer()
+
+    for (i in seq_along(responses)) {
+      resp <- responses[[i]]
+      if (inherits(resp, c("httr2_http_401", "httr2_http_403"))) {
+        trace_access_abort(resp, call)
+      }
+      if (inherits(resp, "httr2_http_404")) {
+        next
+      }
+      if (inherits(resp, "condition")) {
+        rlang::cnd_signal(resp)
       }
       page <- resp_trace_lines(resp)
       lines <- c(lines, page)
       total <- suppressWarnings(
         as.integer(httr2::resp_header(resp, "X-Total-Count"))
       )
-      offset <- offset + length(page)
-      if (length(page) == 0 || is.na(total) || offset >= total) {
-        break
+      offset <- offsets[[i]] + length(page)
+      if (length(page) > 0 && !is.na(total) && offset < total) {
+        next_job_keys <- c(next_job_keys, job_keys[[i]])
+        next_offsets <- c(next_offsets, offset)
       }
     }
+    job_keys <- next_job_keys
+    offsets <- next_offsets
   }
   lines
+}
+
+connect_job_trace_req <- function(
+  job_key,
+  offset,
+  client,
+  guid,
+  from,
+  page_size,
+  max_active
+) {
+  connect_req(client, "content", guid, "jobs", job_key, "traces") |>
+    httr2::req_url_query(
+      limit = page_size,
+      offset = offset,
+      since = connect_window_param(from, -3600)
+    ) |>
+    httr2::req_throttle(capacity = max_active, fill_time_s = 0.5)
 }
 
 resp_trace_lines <- function(resp) {

--- a/R/tracing.R
+++ b/R/tracing.R
@@ -100,25 +100,8 @@ repair_connect_trace_routing <- function() {
     paste0("job.key=", job_key)
   )
   Sys.setenv(OTEL_RESOURCE_ATTRIBUTES = paste(pairs, collapse = ","))
-  repair_otelsdk_resource_attributes(guid, job_key)
   reset_otel_tracer_provider()
   refresh_ellmer_otel_cache()
-  invisible(TRUE)
-}
-
-repair_otelsdk_resource_attributes <- function(guid, job_key) {
-  if (!isNamespaceLoaded("otelsdk")) {
-    return(invisible(FALSE))
-  }
-
-  the <- asNamespace("otelsdk")$the
-  if (!is.environment(the) || !is.list(the$default_resource_attributes)) {
-    return(invisible(FALSE))
-  }
-
-  # otelsdk snapshots its environment before commons can repair it.
-  the$default_resource_attributes[["content.guid"]] <- guid
-  the$default_resource_attributes[["job.key"]] <- job_key
   invisible(TRUE)
 }
 

--- a/R/tracing.R
+++ b/R/tracing.R
@@ -17,6 +17,7 @@ new_trajectory_tracing <- function(
 ) {
   rlang::check_bool(log, call = call)
   check_share_with(share_with, call = call)
+  repair_connect_trace_routing()
 
   if (!log) {
     if (!is.null(share_with)) {
@@ -65,6 +66,60 @@ new_trajectory_tracing <- function(
   }
 
   TRUE
+}
+
+# Connect 2026.07 can overwrite content routing with its server attributes.
+repair_connect_trace_routing <- function() {
+  if (!is_connect_runtime() || !is_installed("otel")) {
+    return(invisible(FALSE))
+  }
+
+  guid <- Sys.getenv("CONNECT_CONTENT_GUID")
+  job_key <- Sys.getenv("CONNECT_CONTENT_JOB_KEY")
+  if (!nzchar(guid) || !nzchar(job_key)) {
+    return(invisible(FALSE))
+  }
+
+  current <- Sys.getenv("OTEL_RESOURCE_ATTRIBUTES")
+  pairs <- strsplit(current, ",", fixed = TRUE)[[1]]
+  pairs <- pairs[nzchar(pairs)]
+  names <- sub("=.*$", "", pairs)
+  values <- sub("^[^=]*=", "", pairs)
+
+  correctly_routed <-
+    any(names == "content.guid" & values == guid) &&
+      any(names == "job.key" & values == job_key)
+  if (correctly_routed) {
+    return(invisible(FALSE))
+  }
+
+  pairs <- pairs[!names %in% c("content.guid", "job.key")]
+  pairs <- c(
+    pairs,
+    paste0("content.guid=", guid),
+    paste0("job.key=", job_key)
+  )
+  Sys.setenv(OTEL_RESOURCE_ATTRIBUTES = paste(pairs, collapse = ","))
+  repair_otelsdk_resource_attributes(guid, job_key)
+  reset_otel_tracer_provider()
+  refresh_ellmer_otel_cache()
+  invisible(TRUE)
+}
+
+repair_otelsdk_resource_attributes <- function(guid, job_key) {
+  if (!isNamespaceLoaded("otelsdk")) {
+    return(invisible(FALSE))
+  }
+
+  the <- asNamespace("otelsdk")$the
+  if (!is.environment(the) || !is.list(the$default_resource_attributes)) {
+    return(invisible(FALSE))
+  }
+
+  # otelsdk snapshots its environment before commons can repair it.
+  the$default_resource_attributes[["content.guid"]] <- guid
+  the$default_resource_attributes[["job.key"]] <- job_key
+  invisible(TRUE)
 }
 
 # Start and activate a span for the calling frame's lifetime, ending when it

--- a/tests/testthat/test-connect.R
+++ b/tests/testthat/test-connect.R
@@ -61,129 +61,54 @@ test_that("connect_trace_lines pages until the total is exhausted", {
 })
 
 test_that("connect_trace_lines reads collector and legacy stores", {
-  local_mocked_bindings(
-    connect_req = function(client, ...) structure(list(), class = "fake_req"),
-    connect_job_trace_lines = function(
-      client, guid, from, enough, page_size, call, lines
-    ) {
-      c(lines, "legacy")
+  httr2::local_mocked_responses(function(req) {
+    url <- req$url
+    if (grepl("/jobs/job/traces", url, fixed = TRUE)) {
+      return(httr2::new_response(
+        "GET", url, 200L,
+        list(`X-Total-Count` = "1"), charToRaw("legacy"), request = req
+      ))
     }
-  )
-  local_mocked_bindings(
-    req_url_query = function(req, ...) req,
-    req_perform = function(req, ...) 1,
-    resp_has_body = function(resp) TRUE,
-    resp_body_string = function(resp) "current",
-    resp_header = function(resp, name) {
-      if (name == "Server") "Posit Connect v2026.07.0" else "1"
-    },
-    .package = "httr2"
-  )
+    if (grepl("/jobs", url, fixed = TRUE)) {
+      return(httr2::new_response(
+        "GET", url, 200L,
+        list(`Content-Type` = "application/json"),
+        charToRaw('[{"key":"job"}]'),
+        request = req
+      ))
+    }
+    httr2::new_response(
+      "GET", url, 200L,
+      list(Server = "Posit Connect v2026.07.0", `X-Total-Count` = "1"),
+      charToRaw("current"), request = req
+    )
+  })
 
-  lines <- connect_trace_lines(list(server = "s", api_key = "k"), "guid")
+  lines <- connect_trace_lines(
+    list(server = "https://connect.example.com", api_key = "k"),
+    "guid",
+    enough = function(lines) TRUE
+  )
 
   expect_equal(lines, c("current", "legacy"))
 })
 
-test_that("connect_trace_lines handles an empty collector response", {
-  local_mocked_bindings(
-    connect_req = function(client, ...) structure(list(), class = "fake_req"),
-    connect_job_trace_lines = function(
-      client, guid, from, enough, page_size, call, lines
-    ) {
-      c(lines, "legacy")
-    }
-  )
-  local_mocked_bindings(
-    req_url_query = function(req, ...) req,
-    req_perform = function(req, ...) 1,
-    resp_has_body = function(resp) FALSE,
-    resp_header = function(resp, name) {
-      if (name == "Server") "Posit Connect v2026.07.0" else "0"
-    },
-    .package = "httr2"
-  )
-
-  lines <- connect_trace_lines(list(server = "s", api_key = "k"), "guid")
-
-  expect_equal(lines, "legacy")
-})
-
 test_that("connect_trace_lines falls back when the content endpoint is absent", {
-  local_mocked_bindings(
-    connect_req = function(client, ...) structure(list(), class = "fake_req"),
-    connect_job_trace_lines = function(...) "legacy"
-  )
-  local_mocked_bindings(
-    req_url_query = function(req, ...) req,
-    req_perform = function(req, ...) {
-      rlang::abort("HTTP 404 Not Found.", class = "httr2_http_404")
-    },
-    .package = "httr2"
-  )
+  local_mocked_bindings(connect_job_trace_lines = function(...) "legacy")
+  httr2::local_mocked_responses(function(req) {
+    httr2::new_response(
+      "GET", req$url, 404L, list(), raw(), request = req
+    )
+  })
 
-  lines <- connect_trace_lines(list(server = "s", api_key = "k"), "guid")
-
-  expect_equal(lines, "legacy")
-})
-
-test_that("connect_job_trace_lines reads jobs newest-first", {
-  local_mocked_bindings(
-    connect_req = function(client, ...) list(path = list(...))
+  lines <- connect_trace_lines(
+    list(server = "https://connect.example.com", api_key = "k"), "guid"
   )
-  local_mocked_bindings(
-    req_url_query = function(req, ...) req,
-    req_perform = function(req, ...) req,
-    resp_body_json = function(resp, ...) list(
-      list(key = "older", start_time = "2026-01-01T00:00:00Z"),
-      list(key = "newer", start_time = "2026-01-02T00:00:00Z")
-    ),
-    resp_has_body = function(resp) TRUE,
-    resp_body_string = function(resp) paste0(resp$path[[4]], "-line"),
-    resp_header = function(resp, name) "1",
-    .package = "httr2"
-  )
-
-  lines <- connect_job_trace_lines(
-    list(server = "s", api_key = "k"),
-    "guid",
-    NULL,
-    NULL,
-    1000,
-    rlang::current_env(),
-    "current"
-  )
-
-  expect_equal(lines, c("current", "newer-line", "older-line"))
-})
-
-test_that("connect_trace_lines trusts the content endpoint before 2026.07", {
-  local_mocked_bindings(
-    connect_req = function(client, ...) structure(list(), class = "fake_req"),
-    connect_job_trace_lines = function(...) stop("legacy endpoint called")
-  )
-  local_mocked_bindings(
-    req_url_query = function(req, ...) req,
-    req_perform = function(req, ...) 1,
-    resp_has_body = function(resp) TRUE,
-    resp_body_string = function(resp) "legacy",
-    resp_header = function(resp, name) {
-      if (name == "Server") "Posit Connect v2026.06.1" else "1"
-    },
-    .package = "httr2"
-  )
-
-  lines <- connect_trace_lines(list(server = "s", api_key = "k"), "guid")
 
   expect_equal(lines, "legacy")
 })
 
 test_that("connect_server_version parses Connect response headers", {
-  local_mocked_bindings(
-    resp_header = function(resp, name) resp,
-    .package = "httr2"
-  )
-
   expect_equal(
     connect_server_version("Posit Connect v2026.07.0"),
     numeric_version("2026.07.0")

--- a/tests/testthat/test-connect.R
+++ b/tests/testthat/test-connect.R
@@ -44,10 +44,13 @@ test_that("connect_trace_lines pages until the total is exhausted", {
       state$calls <- state$calls + 1
       state$calls
     },
+    resp_has_body = function(resp) TRUE,
     resp_body_string = function(resp) {
       paste(pages[[resp]], collapse = "\n")
     },
-    resp_header = function(resp, name) "3",
+    resp_header = function(resp, name) {
+      if (name == "Server") "Posit Connect v2026.06.1" else "3"
+    },
     .package = "httr2"
   )
 
@@ -55,6 +58,137 @@ test_that("connect_trace_lines pages until the total is exhausted", {
 
   expect_equal(lines, c("line1", "line2", "line3"))
   expect_equal(state$calls, 2)
+})
+
+test_that("connect_trace_lines reads collector and legacy stores", {
+  local_mocked_bindings(
+    connect_req = function(client, ...) structure(list(), class = "fake_req"),
+    connect_job_trace_lines = function(
+      client, guid, from, enough, page_size, call, lines
+    ) {
+      c(lines, "legacy")
+    }
+  )
+  local_mocked_bindings(
+    req_url_query = function(req, ...) req,
+    req_perform = function(req, ...) 1,
+    resp_has_body = function(resp) TRUE,
+    resp_body_string = function(resp) "current",
+    resp_header = function(resp, name) {
+      if (name == "Server") "Posit Connect v2026.07.0" else "1"
+    },
+    .package = "httr2"
+  )
+
+  lines <- connect_trace_lines(list(server = "s", api_key = "k"), "guid")
+
+  expect_equal(lines, c("current", "legacy"))
+})
+
+test_that("connect_trace_lines handles an empty collector response", {
+  local_mocked_bindings(
+    connect_req = function(client, ...) structure(list(), class = "fake_req"),
+    connect_job_trace_lines = function(
+      client, guid, from, enough, page_size, call, lines
+    ) {
+      c(lines, "legacy")
+    }
+  )
+  local_mocked_bindings(
+    req_url_query = function(req, ...) req,
+    req_perform = function(req, ...) 1,
+    resp_has_body = function(resp) FALSE,
+    resp_header = function(resp, name) {
+      if (name == "Server") "Posit Connect v2026.07.0" else "0"
+    },
+    .package = "httr2"
+  )
+
+  lines <- connect_trace_lines(list(server = "s", api_key = "k"), "guid")
+
+  expect_equal(lines, "legacy")
+})
+
+test_that("connect_trace_lines falls back when the content endpoint is absent", {
+  local_mocked_bindings(
+    connect_req = function(client, ...) structure(list(), class = "fake_req"),
+    connect_job_trace_lines = function(...) "legacy"
+  )
+  local_mocked_bindings(
+    req_url_query = function(req, ...) req,
+    req_perform = function(req, ...) {
+      rlang::abort("HTTP 404 Not Found.", class = "httr2_http_404")
+    },
+    .package = "httr2"
+  )
+
+  lines <- connect_trace_lines(list(server = "s", api_key = "k"), "guid")
+
+  expect_equal(lines, "legacy")
+})
+
+test_that("connect_job_trace_lines reads jobs newest-first", {
+  local_mocked_bindings(
+    connect_req = function(client, ...) list(path = list(...))
+  )
+  local_mocked_bindings(
+    req_url_query = function(req, ...) req,
+    req_perform = function(req, ...) req,
+    resp_body_json = function(resp, ...) list(
+      list(key = "older", start_time = "2026-01-01T00:00:00Z"),
+      list(key = "newer", start_time = "2026-01-02T00:00:00Z")
+    ),
+    resp_has_body = function(resp) TRUE,
+    resp_body_string = function(resp) paste0(resp$path[[4]], "-line"),
+    resp_header = function(resp, name) "1",
+    .package = "httr2"
+  )
+
+  lines <- connect_job_trace_lines(
+    list(server = "s", api_key = "k"),
+    "guid",
+    NULL,
+    NULL,
+    1000,
+    rlang::current_env(),
+    "current"
+  )
+
+  expect_equal(lines, c("current", "newer-line", "older-line"))
+})
+
+test_that("connect_trace_lines trusts the content endpoint before 2026.07", {
+  local_mocked_bindings(
+    connect_req = function(client, ...) structure(list(), class = "fake_req"),
+    connect_job_trace_lines = function(...) stop("legacy endpoint called")
+  )
+  local_mocked_bindings(
+    req_url_query = function(req, ...) req,
+    req_perform = function(req, ...) 1,
+    resp_has_body = function(resp) TRUE,
+    resp_body_string = function(resp) "legacy",
+    resp_header = function(resp, name) {
+      if (name == "Server") "Posit Connect v2026.06.1" else "1"
+    },
+    .package = "httr2"
+  )
+
+  lines <- connect_trace_lines(list(server = "s", api_key = "k"), "guid")
+
+  expect_equal(lines, "legacy")
+})
+
+test_that("connect_server_version parses Connect response headers", {
+  local_mocked_bindings(
+    resp_header = function(resp, name) resp,
+    .package = "httr2"
+  )
+
+  expect_equal(
+    connect_server_version("Posit Connect v2026.07.0"),
+    numeric_version("2026.07.0")
+  )
+  expect_null(connect_server_version("nginx"))
 })
 
 test_that("connect_trace_lines explains auth failures on the traces endpoint", {

--- a/tests/testthat/test-tracing.R
+++ b/tests/testthat/test-tracing.R
@@ -96,54 +96,6 @@ test_that("an already-on observability setting warns about the restart", {
   expect_equal(state$patched, 0)
 })
 
-test_that("Connect trace routing replaces stale content attributes", {
-  withr::local_envvar(c(
-    CONNECT_CONTENT_GUID = "59b1b5c3-a010-455f-853a-114fe7be5285",
-    CONNECT_CONTENT_JOB_KEY = "newjob",
-    OTEL_RESOURCE_ATTRIBUTES = paste0(
-      "content.guid=old-guid,job.key=oldjob,",
-      "k8s.namespace.name=datascience"
-    )
-  ))
-  local_mocked_bindings(
-    is_installed = function(pkg) TRUE,
-    reset_otel_tracer_provider = function() NULL,
-    refresh_ellmer_otel_cache = function() NULL
-  )
-
-  expect_true(repair_connect_trace_routing())
-  expect_equal(
-    Sys.getenv("OTEL_RESOURCE_ATTRIBUTES"),
-    paste0(
-      "k8s.namespace.name=datascience,",
-      "content.guid=59b1b5c3-a010-455f-853a-114fe7be5285,",
-      "job.key=newjob"
-    )
-  )
-})
-
-test_that("Connect trace routing leaves correct attributes alone", {
-  attributes <- paste0(
-    "content.id=18910,",
-    "content.guid=59b1b5c3-a010-455f-853a-114fe7be5285,",
-    "job.key=ocNixD62q2V8Zrpg"
-  )
-  withr::local_envvar(c(
-    CONNECT_CONTENT_GUID = "59b1b5c3-a010-455f-853a-114fe7be5285",
-    CONNECT_CONTENT_JOB_KEY = "ocNixD62q2V8Zrpg",
-    OTEL_RESOURCE_ATTRIBUTES = attributes
-  ))
-  reset <- FALSE
-  local_mocked_bindings(
-    is_installed = function(pkg) TRUE,
-    reset_otel_tracer_provider = function() reset <<- TRUE
-  )
-
-  expect_false(repair_connect_trace_routing())
-  expect_false(reset)
-  expect_equal(Sys.getenv("OTEL_RESOURCE_ATTRIBUTES"), attributes)
-})
-
 test_that("enable_local_tracing configures the file exporter when unset", {
   skip_if_not_installed("otelsdk")
   dir <- withr::local_tempdir()

--- a/tests/testthat/test-tracing.R
+++ b/tests/testthat/test-tracing.R
@@ -96,6 +96,124 @@ test_that("an already-on observability setting warns about the restart", {
   expect_equal(state$patched, 0)
 })
 
+test_that("Connect trace routing adds content attributes", {
+  withr::local_envvar(c(
+    CONNECT_CONTENT_GUID = "59b1b5c3-a010-455f-853a-114fe7be5285",
+    CONNECT_CONTENT_JOB_KEY = "ocNixD62q2V8Zrpg",
+    OTEL_RESOURCE_ATTRIBUTES = paste0(
+      "k8s.namespace.name=datascience,",
+      "k8s.pod.name=connect-pod"
+    )
+  ))
+  state <- new.env()
+  state$sdk_repairs <- 0
+  state$provider_resets <- 0
+  state$ellmer_refreshes <- 0
+  local_mocked_bindings(
+    is_installed = function(pkg) TRUE,
+    repair_otelsdk_resource_attributes = function(guid, job_key) {
+      state$sdk_repairs <- state$sdk_repairs + 1
+    },
+    reset_otel_tracer_provider = function() {
+      state$provider_resets <- state$provider_resets + 1
+    },
+    refresh_ellmer_otel_cache = function() {
+      state$ellmer_refreshes <- state$ellmer_refreshes + 1
+    }
+  )
+
+  expect_true(repair_connect_trace_routing())
+  expect_equal(
+    Sys.getenv("OTEL_RESOURCE_ATTRIBUTES"),
+    paste0(
+      "k8s.namespace.name=datascience,k8s.pod.name=connect-pod,",
+      "content.guid=59b1b5c3-a010-455f-853a-114fe7be5285,",
+      "job.key=ocNixD62q2V8Zrpg"
+    )
+  )
+  expect_equal(state$sdk_repairs, 1)
+  expect_equal(state$provider_resets, 1)
+  expect_equal(state$ellmer_refreshes, 1)
+})
+
+test_that("Connect trace routing replaces stale content attributes", {
+  withr::local_envvar(c(
+    CONNECT_CONTENT_GUID = "59b1b5c3-a010-455f-853a-114fe7be5285",
+    CONNECT_CONTENT_JOB_KEY = "newjob",
+    OTEL_RESOURCE_ATTRIBUTES = paste0(
+      "content.guid=old-guid,job.key=oldjob,",
+      "k8s.namespace.name=datascience"
+    )
+  ))
+  local_mocked_bindings(
+    is_installed = function(pkg) TRUE,
+    repair_otelsdk_resource_attributes = function(...) NULL,
+    reset_otel_tracer_provider = function() NULL,
+    refresh_ellmer_otel_cache = function() NULL
+  )
+
+  expect_true(repair_connect_trace_routing())
+  expect_equal(
+    Sys.getenv("OTEL_RESOURCE_ATTRIBUTES"),
+    paste0(
+      "k8s.namespace.name=datascience,",
+      "content.guid=59b1b5c3-a010-455f-853a-114fe7be5285,",
+      "job.key=newjob"
+    )
+  )
+})
+
+test_that("Connect trace routing leaves correct attributes alone", {
+  attributes <- paste0(
+    "content.id=18910,",
+    "content.guid=59b1b5c3-a010-455f-853a-114fe7be5285,",
+    "job.key=ocNixD62q2V8Zrpg"
+  )
+  withr::local_envvar(c(
+    CONNECT_CONTENT_GUID = "59b1b5c3-a010-455f-853a-114fe7be5285",
+    CONNECT_CONTENT_JOB_KEY = "ocNixD62q2V8Zrpg",
+    OTEL_RESOURCE_ATTRIBUTES = attributes
+  ))
+  reset <- FALSE
+  local_mocked_bindings(
+    is_installed = function(pkg) TRUE,
+    reset_otel_tracer_provider = function() reset <<- TRUE
+  )
+
+  expect_false(repair_connect_trace_routing())
+  expect_false(reset)
+  expect_equal(Sys.getenv("OTEL_RESOURCE_ATTRIBUTES"), attributes)
+})
+
+test_that("Connect trace routing repairs loaded otelsdk resources", {
+  skip_if_not_installed("otelsdk")
+  the <- asNamespace("otelsdk")$the
+  original <- the$default_resource_attributes
+  withr::defer(the$default_resource_attributes <- original)
+
+  expect_true(repair_otelsdk_resource_attributes("content-guid", "job-key"))
+  expect_equal(
+    the$default_resource_attributes[["content.guid"]],
+    "content-guid"
+  )
+  expect_equal(the$default_resource_attributes[["job.key"]], "job-key")
+})
+
+test_that("Connect trace routing requires a content GUID and job key", {
+  withr::local_envvar(c(
+    POSIT_PRODUCT = NA,
+    CONNECT_CONTENT_GUID = NA,
+    CONNECT_CONTENT_JOB_KEY = NA,
+    OTEL_RESOURCE_ATTRIBUTES = "k8s.namespace.name=datascience"
+  ))
+
+  expect_false(repair_connect_trace_routing())
+  expect_equal(
+    Sys.getenv("OTEL_RESOURCE_ATTRIBUTES"),
+    "k8s.namespace.name=datascience"
+  )
+})
+
 test_that("enable_local_tracing configures the file exporter when unset", {
   skip_if_not_installed("otelsdk")
   dir <- withr::local_tempdir()
@@ -260,6 +378,10 @@ test_that("the internals the tracing hacks rely on still exist", {
   the <- asNamespace("otel")[["the"]]
   expect_true(is.environment(the))
   expect_true(exists("tracer_provider", envir = the, inherits = FALSE))
+
+  sdk_the <- asNamespace("otelsdk")[["the"]]
+  expect_true(is.environment(sdk_the))
+  expect_true(is.list(sdk_the$default_resource_attributes))
 })
 
 test_that("local_commons_span is a no-op without otel", {

--- a/tests/testthat/test-tracing.R
+++ b/tests/testthat/test-tracing.R
@@ -96,46 +96,6 @@ test_that("an already-on observability setting warns about the restart", {
   expect_equal(state$patched, 0)
 })
 
-test_that("Connect trace routing adds content attributes", {
-  withr::local_envvar(c(
-    CONNECT_CONTENT_GUID = "59b1b5c3-a010-455f-853a-114fe7be5285",
-    CONNECT_CONTENT_JOB_KEY = "ocNixD62q2V8Zrpg",
-    OTEL_RESOURCE_ATTRIBUTES = paste0(
-      "k8s.namespace.name=datascience,",
-      "k8s.pod.name=connect-pod"
-    )
-  ))
-  state <- new.env()
-  state$sdk_repairs <- 0
-  state$provider_resets <- 0
-  state$ellmer_refreshes <- 0
-  local_mocked_bindings(
-    is_installed = function(pkg) TRUE,
-    repair_otelsdk_resource_attributes = function(guid, job_key) {
-      state$sdk_repairs <- state$sdk_repairs + 1
-    },
-    reset_otel_tracer_provider = function() {
-      state$provider_resets <- state$provider_resets + 1
-    },
-    refresh_ellmer_otel_cache = function() {
-      state$ellmer_refreshes <- state$ellmer_refreshes + 1
-    }
-  )
-
-  expect_true(repair_connect_trace_routing())
-  expect_equal(
-    Sys.getenv("OTEL_RESOURCE_ATTRIBUTES"),
-    paste0(
-      "k8s.namespace.name=datascience,k8s.pod.name=connect-pod,",
-      "content.guid=59b1b5c3-a010-455f-853a-114fe7be5285,",
-      "job.key=ocNixD62q2V8Zrpg"
-    )
-  )
-  expect_equal(state$sdk_repairs, 1)
-  expect_equal(state$provider_resets, 1)
-  expect_equal(state$ellmer_refreshes, 1)
-})
-
 test_that("Connect trace routing replaces stale content attributes", {
   withr::local_envvar(c(
     CONNECT_CONTENT_GUID = "59b1b5c3-a010-455f-853a-114fe7be5285",
@@ -147,7 +107,6 @@ test_that("Connect trace routing replaces stale content attributes", {
   ))
   local_mocked_bindings(
     is_installed = function(pkg) TRUE,
-    repair_otelsdk_resource_attributes = function(...) NULL,
     reset_otel_tracer_provider = function() NULL,
     refresh_ellmer_otel_cache = function() NULL
   )
@@ -183,35 +142,6 @@ test_that("Connect trace routing leaves correct attributes alone", {
   expect_false(repair_connect_trace_routing())
   expect_false(reset)
   expect_equal(Sys.getenv("OTEL_RESOURCE_ATTRIBUTES"), attributes)
-})
-
-test_that("Connect trace routing repairs loaded otelsdk resources", {
-  skip_if_not_installed("otelsdk")
-  the <- asNamespace("otelsdk")$the
-  original <- the$default_resource_attributes
-  withr::defer(the$default_resource_attributes <- original)
-
-  expect_true(repair_otelsdk_resource_attributes("content-guid", "job-key"))
-  expect_equal(
-    the$default_resource_attributes[["content.guid"]],
-    "content-guid"
-  )
-  expect_equal(the$default_resource_attributes[["job.key"]], "job-key")
-})
-
-test_that("Connect trace routing requires a content GUID and job key", {
-  withr::local_envvar(c(
-    POSIT_PRODUCT = NA,
-    CONNECT_CONTENT_GUID = NA,
-    CONNECT_CONTENT_JOB_KEY = NA,
-    OTEL_RESOURCE_ATTRIBUTES = "k8s.namespace.name=datascience"
-  ))
-
-  expect_false(repair_connect_trace_routing())
-  expect_equal(
-    Sys.getenv("OTEL_RESOURCE_ATTRIBUTES"),
-    "k8s.namespace.name=datascience"
-  )
 })
 
 test_that("enable_local_tracing configures the file exporter when unset", {
@@ -378,10 +308,6 @@ test_that("the internals the tracing hacks rely on still exist", {
   the <- asNamespace("otel")[["the"]]
   expect_true(is.environment(the))
   expect_true(exists("tracer_provider", envir = the, inherits = FALSE))
-
-  sdk_the <- asNamespace("otelsdk")[["the"]]
-  expect_true(is.environment(sdk_the))
-  expect_true(is.list(sdk_the$default_resource_attributes))
 })
 
 test_that("local_commons_span is a no-op without otel", {


### PR DESCRIPTION
Closes #60. First commit migrates to the new place where the traces will now live, second commit is a hotfix for a dev Connect issue (41838 on Connect).