### PR TITLE
remove `commons(system_prompt)` in favor of `instructions`

### DIFF
--- a/R/commons.R
+++ b/R/commons.R
@@ -10,7 +10,7 @@
 #'
 #' @param client An [ellmer::Chat] giving the provider and model to use, e.g.
 #'   [ellmer::chat_anthropic()]. A system prompt already set on the client is
-#'   ignored, with a warning; use `system_prompt` instead.
+#'   ignored, with a warning; use `instructions` to add to commons' prompt.
 #' @param data_sources A [data_source()], or a named list of them. Measures
 #'   can take a source's connection as an argument named after the source; see
 #'   [semantic_layer()]. When there are several sources, the `run_sql` and
@@ -18,41 +18,15 @@
 #' @param semantic_layer An optional [semantic_layer()].
 #' @param context_layer An optional [context_layer()].
 #' @param ... These dots are for future extensions and must be empty.
-#' @param system_prompt The agent's system-prompt template, as a single string
-#'   containing the template or the path to a template file. The default uses
-#'   the markdown prompt shipped with commons. To customize the full prompt,
-#'   copy that file into your project, edit it freely, and pass its path:
+#' @param instructions Optional instructions appended to commons' built-in
+#'   system prompt, as a single string or the path to a text or Markdown file.
 #'
 #'   ```r
-#'   file.copy(
-#'     system.file("prompts/system-prompt.md", package = "commons"),
-#'     "system-prompt.md"
-#'   )
 #'   commons(
 #'     # ...
-#'     system_prompt = "system-prompt.md"
+#'     instructions = "Use the organization's fiscal-year conventions."
 #'   )
 #'   ```
-#'
-#'   commons interpolates runtime facts and content, such as the number of data
-#'   sources and their table roster. The template owns the surrounding prose,
-#'   and may edit, remove, or reposition any section. Commons expressions open
-#'   with `{[` and close with `]}`, leaving ellmer's `{{ }}` delimiters
-#'   available for your own substitutions:
-#'
-#'   ```r
-#'   system_prompt <- ellmer::interpolate_file(
-#'     "system-prompt.md",
-#'     organization = "Acme"
-#'   )
-#'   commons(
-#'     # ...
-#'     system_prompt = as.character(system_prompt)
-#'   )
-#'   ```
-#'
-#'   A `{{organization}}` expression is resolved by ellmer, while commons'
-#'   template expressions remain untouched.
 #' @param network Whether the `run_r` session has network access. One of
 #'   `"none"` (the default) or `"full"`. The session requires Linux or macOS
 #'   and refuses to run without filesystem sandboxing.
@@ -132,7 +106,7 @@ commons <- function(
   semantic_layer = NULL,
   context_layer = NULL,
   ...,
-  system_prompt = system.file("prompts/system-prompt.md", package = "commons"),
+  instructions = NULL,
   network = c("none", "full"),
   log = FALSE,
   share_with = NULL
@@ -148,7 +122,7 @@ commons <- function(
       c(
         "The system prompt set on {.arg client} is ignored; commons builds
          its own.",
-        i = "Pass it to the {.arg system_prompt} argument instead."
+        i = "Use {.arg instructions} to add to commons' prompt."
       )
     )
   }
@@ -158,7 +132,7 @@ commons <- function(
   check_semantic_layer(semantic_layer)
   network <- rlang::arg_match(network)
   check_run_r_sandbox()
-  check_system_prompt(system_prompt)
+  check_instructions(instructions)
   rlang::check_bool(log)
   check_share_with(share_with)
 
@@ -168,7 +142,7 @@ commons <- function(
     context_layer = context_layer,
     semantic_layer = semantic_layer,
     network = network,
-    system_prompt = system_prompt,
+    instructions = instructions,
     log = log,
     share_with = share_with
   )
@@ -184,10 +158,7 @@ Commons <- R6::R6Class(
       semantic_layer = NULL,
       context_layer = NULL,
       ...,
-      system_prompt = system.file(
-        "prompts/system-prompt.md",
-        package = "commons"
-      ),
+      instructions = NULL,
       network = c("none", "full"),
       log = FALSE,
       share_with = NULL
@@ -243,8 +214,8 @@ Commons <- R6::R6Class(
       self$set_system_prompt(
         commons_system_prompt(
           private$sources,
-          system_prompt,
-          private$definitions
+          definitions = private$definitions,
+          instructions = instructions
         )
       )
     },

--- a/R/commons.R
+++ b/R/commons.R
@@ -18,7 +18,8 @@
 #' @param semantic_layer An optional [semantic_layer()].
 #' @param context_layer An optional [context_layer()].
 #' @param ... These dots are for future extensions and must be empty.
-#' @param instructions Optional instructions appended to commons' built-in
+#' @param instructions Optional instructions placed under an
+#'   `## Additional instructions` heading at the end of commons' built-in
 #'   system prompt, as a single string or the path to a text or Markdown file.
 #'
 #'   ```r

--- a/R/context-layer.R
+++ b/R/context-layer.R
@@ -5,7 +5,7 @@
 #'
 #' Files are chunked and indexed with \pkg{ragnar} when the agent first
 #' searches its context. Facts that should be in every prompt belong in the
-#' `system_prompt` passed to [commons()], not here.
+#' `instructions` passed to [commons()], not here.
 #'
 #' @param files Character vector of paths to text/markdown files to index.
 #'

--- a/R/prompt.R
+++ b/R/prompt.R
@@ -1,15 +1,16 @@
 commons_system_prompt <- function(
   sources,
-  system_prompt,
-  definitions = NULL
+  definitions = NULL,
+  instructions = NULL
 ) {
   definitions <- definitions %||% definitions_registry(sources)
-  template <- read_system_prompt(system_prompt)
-  data <- system_prompt_data(sources, definitions)
+  instructions <- read_instructions(instructions)
+  template <- read_system_prompt()
+  data <- system_prompt_data(sources, definitions, instructions)
   render_system_prompt(template, data)
 }
 
-system_prompt_data <- function(sources, definitions) {
+system_prompt_data <- function(sources, definitions, instructions = NULL) {
   dictionary_context <- dictionary_context_text(sources)
   glossary_context <- glossary_context_text(sources)
 
@@ -23,7 +24,9 @@ system_prompt_data <- function(sources, definitions) {
     tables = tables_text(sources),
     dictionary_context = dictionary_context,
     glossary_context = glossary_context,
-    definition_index = definition_index_text(definitions)
+    definition_index = definition_index_text(definitions),
+    has_instructions = nzchar(instructions %||% ""),
+    instructions = instructions %||% ""
   )
 }
 
@@ -46,36 +49,47 @@ render_system_prompt <- function(
   trimws(out)
 }
 
-check_system_prompt <- function(system_prompt, call = rlang::caller_env()) {
-  rlang::check_string(system_prompt, call = call)
-  if (looks_like_prompt_path(system_prompt) && !file.exists(system_prompt)) {
+check_instructions <- function(instructions, call = rlang::caller_env()) {
+  rlang::check_string(instructions, allow_null = TRUE, call = call)
+  if (is.null(instructions)) {
+    return(invisible(instructions))
+  }
+  if (looks_like_instructions_path(instructions) && !file.exists(instructions)) {
     cli::cli_abort(
-      "System-prompt file {.path {system_prompt}} does not exist.",
+      "Instructions file {.path {instructions}} does not exist.",
       call = call
     )
   }
-  invisible(system_prompt)
+  invisible(instructions)
 }
 
-read_system_prompt <- function(system_prompt) {
-  if (!file.exists(system_prompt)) {
-    return(system_prompt)
-  }
+read_system_prompt <- function() {
+  path <- system.file("prompts/system-prompt.md", package = "commons")
   paste(
-    readLines(system_prompt, warn = FALSE, encoding = "UTF-8"),
+    readLines(path, warn = FALSE, encoding = "UTF-8"),
     collapse = "\n"
   )
 }
 
-looks_like_prompt_path <- function(system_prompt) {
-  if (grepl("\n", system_prompt, fixed = TRUE)) {
+read_instructions <- function(instructions) {
+  if (is.null(instructions) || !file.exists(instructions)) {
+    return(instructions)
+  }
+  paste(
+    readLines(instructions, warn = FALSE, encoding = "UTF-8"),
+    collapse = "\n"
+  )
+}
+
+looks_like_instructions_path <- function(instructions) {
+  if (grepl("\n", instructions, fixed = TRUE)) {
     return(FALSE)
   }
 
-  extension <- tolower(tools::file_ext(system_prompt))
-  grepl("[/\\\\]", system_prompt) ||
+  extension <- tolower(tools::file_ext(instructions))
+  grepl("[/\\\\]", instructions) ||
     extension %in% c("md", "rmd", "txt", "prompt") ||
-    (nzchar(extension) && !grepl("[[:space:]]", system_prompt))
+    (nzchar(extension) && !grepl("[[:space:]]", instructions))
 }
 
 dictionary_context_text <- function(sources) {

--- a/R/prompt.R
+++ b/R/prompt.R
@@ -36,12 +36,7 @@ render_system_prompt <- function(
   call = rlang::caller_env()
 ) {
   envir <- list2env(data, parent = baseenv())
-  out <- glue::glue(
-    template,
-    .open = "{[",
-    .close = "]}",
-    .envir = envir
-  )
+  out <- glue::glue(template, .envir = envir)
   rlang::check_string(out, arg = "rendered system prompt", call = call)
   out <- as.character(out)
   out <- gsub("(?s)<!--.*?-->", "", out, perl = TRUE)

--- a/inst/prompts/README.md
+++ b/inst/prompts/README.md
@@ -14,9 +14,10 @@ construction balances a few goals:
 - Keep ambient context useful but bounded. Detailed table and definition
   context arrives through tools when needed.
 
-Commons template expressions use `{[` and `]}`. This leaves `{{ }}` available
-for governed-definition tokens. HTML comments are removed from the rendered
-prompt. App-authored instructions occupy the final section.
+Commons template expressions use glue's standard `{` and `}` delimiters.
+Literal braces in template prose are doubled. Expression results are inserted
+without recursive interpolation, preserving governed-definition tokens and
+app-authored instructions. HTML comments are removed from the rendered prompt.
 
 `citation-request.md` is delivered only when citations may be needed, rather
 than occupying every system prompt.

--- a/inst/prompts/README.md
+++ b/inst/prompts/README.md
@@ -15,8 +15,8 @@ construction balances a few goals:
   context arrives through tools when needed.
 
 Commons template expressions use `{[` and `]}`. This leaves `{{ }}` available
-for user substitutions and governed-definition tokens. HTML comments are
-removed from the rendered prompt.
+for governed-definition tokens. HTML comments are removed from the rendered
+prompt. App-authored instructions occupy the final section.
 
 `citation-request.md` is delivered only when citations may be needed, rather
 than occupying every system prompt.

--- a/inst/prompts/README.md
+++ b/inst/prompts/README.md
@@ -18,6 +18,8 @@ Commons template expressions use glue's standard `{` and `}` delimiters.
 Literal braces in template prose are doubled. Expression results are inserted
 without recursive interpolation, preserving governed-definition tokens and
 app-authored instructions. HTML comments are removed from the rendered prompt.
+App-authored instructions occupy the final `## Additional instructions`
+section.
 
 `citation-request.md` is delivered only when citations may be needed, rather
 than occupying every system prompt.

--- a/inst/prompts/system-prompt.md
+++ b/inst/prompts/system-prompt.md
@@ -4,7 +4,7 @@ Navigate data analysis with an openness to uncertainty and subtlety, and a commi
 
 Your primary audience consists of domain experts that are not necessarily coders or statisticians. While you answer questions by writing code, refrain from mentioning code explicitly. Let statistical reasoning inform the code you write, but communicate uncertainty in plain language. (By statistical reasoning we mean judging how much a result can be trusted—for instance recognizing when an estimate is too noisy to lean on—rather than running formal tests.)
 
-Today's date is {[date]}.
+Today's date is {date}.
 
 ## How to answer
 
@@ -33,32 +33,32 @@ Do not announce tool calls; before your final response to the user, you should o
 ## Available tables
 
 <!-- Multiple sources add a source argument to table tools. -->
-{[ if (has_multiple_sources) "Tables are grouped by data source. Pass the source's name as `source` to `describe_table` and `run_sql`." else "" ]}
+{if (has_multiple_sources) "Tables are grouped by data source. Pass the source's name as `source` to `describe_table` and `run_sql`." else ""}
 
-{[tables]}
+{tables}
 
 <!-- Dataset-wide dictionary content is ambient; table details arrive on first touch. -->
-{[ if (has_dictionary_context) "# About the data" else "" ]}
+{if (has_dictionary_context) "# About the data" else ""}
 
-{[ if (has_dictionary_context) dictionary_context else "" ]}
+{if (has_dictionary_context) dictionary_context else ""}
 
-{[ if (has_glossary_context) "Definitions of domain terms:" else "" ]}
+{if (has_glossary_context) "Definitions of domain terms:" else ""}
 
-{[ if (has_glossary_context) glossary_context else "" ]}
+{if (has_glossary_context) glossary_context else ""}
 
 <!-- Definitions stay discoverable by name while their full expressions arrive on first touch. -->
-{[ if (nzchar(definition_index) || !definitions_complete) r"(
+{if (nzchar(definition_index) || !definitions_complete) r"(
 
 ## Governed definitions
 
 Trusted calculations from the data dictionary are indexed here by table; each table's dictionary entry delivers its full definitions. Write them as `{{name}}` tokens anywhere in `run_sql` SQL (`{{table.name}}` when a name exists on several tables); each expands to its governed SQL before the query runs. Expansion can't add an alias, so write `SELECT {{name}} AS name`. Metric expressions are already aggregates—never wrap one in `SUM()` or another aggregate.
-)" else "" ]}
+)" else ""}
 
-{[definition_index]}
+{definition_index}
 
-{[ if (nzchar(definition_index) && definitions_complete) "This is the complete set of governed definitions." else "" ]}
-{[ if (!definitions_complete) "More definitions arrive with their tables' dictionary entries, via context search, and via `search_pool`." else "" ]}
+{if (nzchar(definition_index) && definitions_complete) "This is the complete set of governed definitions." else ""}
+{if (!definitions_complete) "More definitions arrive with their tables' dictionary entries, via context search, and via `search_pool`." else ""}
 
-{[ if (has_instructions) "## Additional instructions" else "" ]}
+{if (has_instructions) "## Additional instructions" else ""}
 
-{[instructions]}
+{instructions}

--- a/inst/prompts/system-prompt.md
+++ b/inst/prompts/system-prompt.md
@@ -58,3 +58,7 @@ Trusted calculations from the data dictionary are indexed here by table; each ta
 
 {[ if (nzchar(definition_index) && definitions_complete) "This is the complete set of governed definitions." else "" ]}
 {[ if (!definitions_complete) "More definitions arrive with their tables' dictionary entries, via context search, and via `search_pool`." else "" ]}
+
+{[ if (has_instructions) "## Additional instructions" else "" ]}
+
+{[instructions]}

--- a/man/commons.Rd
+++ b/man/commons.Rd
@@ -32,7 +32,8 @@ can take a source's connection as an argument named after the source; see
 
 \item{...}{These dots are for future extensions and must be empty.}
 
-\item{instructions}{Optional instructions appended to commons' built-in
+\item{instructions}{Optional instructions placed under an
+\verb{## Additional instructions} heading at the end of commons' built-in
 system prompt, as a single string or the path to a text or Markdown file.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{commons(

--- a/man/commons.Rd
+++ b/man/commons.Rd
@@ -10,7 +10,7 @@ commons(
   semantic_layer = NULL,
   context_layer = NULL,
   ...,
-  system_prompt = system.file("prompts/system-prompt.md", package = "commons"),
+  instructions = NULL,
   network = c("none", "full"),
   log = FALSE,
   share_with = NULL
@@ -19,7 +19,7 @@ commons(
 \arguments{
 \item{client}{An \link[ellmer:Chat]{ellmer::Chat} giving the provider and model to use, e.g.
 \code{\link[ellmer:chat_anthropic]{ellmer::chat_anthropic()}}. A system prompt already set on the client is
-ignored, with a warning; use \code{system_prompt} instead.}
+ignored, with a warning; use \code{instructions} to add to commons' prompt.}
 
 \item{data_sources}{A \code{\link[=data_source]{data_source()}}, or a named list of them. Measures
 can take a source's connection as an argument named after the source; see
@@ -32,39 +32,14 @@ can take a source's connection as an argument named after the source; see
 
 \item{...}{These dots are for future extensions and must be empty.}
 
-\item{system_prompt}{The agent's system-prompt template, as a single string
-containing the template or the path to a template file. The default uses
-the markdown prompt shipped with commons. To customize the full prompt,
-copy that file into your project, edit it freely, and pass its path:
+\item{instructions}{Optional instructions appended to commons' built-in
+system prompt, as a single string or the path to a text or Markdown file.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{file.copy(
-  system.file("prompts/system-prompt.md", package = "commons"),
-  "system-prompt.md"
-)
-commons(
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{commons(
   # ...
-  system_prompt = "system-prompt.md"
+  instructions = "Use the organization's fiscal-year conventions."
 )
-}\if{html}{\out{</div>}}
-
-commons interpolates runtime facts and content, such as the number of data
-sources and their table roster. The template owns the surrounding prose,
-and may edit, remove, or reposition any section. Commons expressions open
-with \verb{\{[} and close with \verb{]\}}, leaving ellmer's \code{{{ }}} delimiters
-available for your own substitutions:
-
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{system_prompt <- ellmer::interpolate_file(
-  "system-prompt.md",
-  organization = "Acme"
-)
-commons(
-  # ...
-  system_prompt = as.character(system_prompt)
-)
-}\if{html}{\out{</div>}}
-
-A \code{{{organization}}} expression is resolved by ellmer, while commons'
-template expressions remain untouched.}
+}\if{html}{\out{</div>}}}
 
 \item{network}{Whether the \code{run_r} session has network access. One of
 \code{"none"} (the default) or \code{"full"}. The session requires Linux or macOS

--- a/man/context_layer.Rd
+++ b/man/context_layer.Rd
@@ -19,7 +19,7 @@ data source.
 \details{
 Files are chunked and indexed with \pkg{ragnar} when the agent first
 searches its context. Facts that should be in every prompt belong in the
-\code{system_prompt} passed to \code{\link[=commons]{commons()}}, not here.
+\code{instructions} passed to \code{\link[=commons]{commons()}}, not here.
 }
 \examples{
 path <- tempfile(fileext = ".md")

--- a/tests/testthat/helper-commons.R
+++ b/tests/testthat/helper-commons.R
@@ -24,10 +24,6 @@ test_client <- function() {
   ellmer::chat_anthropic(model = "claude-sonnet-4-5")
 }
 
-default_system_prompt <- function() {
-  system.file("prompts/system-prompt.md", package = "commons")
-}
-
 # A board_temp() holding the given named values, each written as an rds pin.
 board_with_pins <- function(...) {
   values <- rlang::list2(...)

--- a/tests/testthat/test-commons.R
+++ b/tests/testthat/test-commons.R
@@ -136,29 +136,26 @@ test_that("the system prompt includes tables and the date", {
   expect_no_match(prompt, "tagged B")
 })
 
-test_that("a custom system-prompt template replaces the packaged one", {
-  path <- withr::local_tempfile(fileext = ".md")
-  writeLines(
-    c(
-      "You answer questions about {{organization}}'s data.",
-      "{[ if (!has_multiple_sources) \"One data source.\" else \"Several data sources.\" ]}",
-      "Tables:",
-      "{[tables]}"
-    ),
-    path
-  )
-
-  agent <- test_agent(
-    semantic_layer = semantic_layer(count_measure_tool()),
-    system_prompt = ellmer::interpolate_file(path, organization = "Acme")
-  )
+test_that("instructions are appended to the packaged system prompt", {
+  instructions <- "Use the organization's fiscal-year conventions."
+  agent <- test_agent(instructions = instructions)
   prompt <- agent$get_system_prompt()
 
-  expect_match(prompt, "about Acme's data", fixed = TRUE)
-  expect_match(prompt, "One data source", fixed = TRUE)
-  expect_match(prompt, "Tables:\n- sales", fixed = TRUE)
-  expect_no_match(prompt, "search_pool")
-  expect_no_match(prompt, "self-service data analyst", fixed = TRUE)
+  expect_match(prompt, "Your task is to thoughtfully", fixed = TRUE)
+  expect_match(
+    prompt,
+    paste("## Additional instructions", instructions, sep = "\n\n"),
+    fixed = TRUE
+  )
+  expect_true(endsWith(prompt, instructions))
+})
+
+test_that("instructions can be read from a file", {
+  path <- withr::local_tempfile(fileext = ".md")
+  writeLines("Prefer fiscal-year comparisons.", path)
+  prompt <- test_agent(instructions = path)$get_system_prompt()
+
+  expect_true(endsWith(prompt, "Prefer fiscal-year comparisons."))
 })
 
 test_that("a system prompt already set on the client warns", {
@@ -171,21 +168,14 @@ test_that("a system prompt already set on the client warns", {
   )
 })
 
-test_that("system_prompt is validated", {
+test_that("instructions are validated", {
   expect_error(
-    test_agent(system_prompt = c("a", "b")),
+    test_agent(instructions = c("a", "b")),
     "single string"
   )
 
-  path <- withr::local_tempfile(fileext = ".md")
-  writeLines("A prompt.", path)
-  expect_equal(
-    test_agent(system_prompt = path)$get_system_prompt(),
-    "A prompt."
-  )
-
   expect_error(
-    test_agent(system_prompt = "missing-prompt.md"),
+    test_agent(instructions = "missing-instructions.md"),
     "does not exist"
   )
 })

--- a/tests/testthat/test-data-dictionary.R
+++ b/tests/testthat/test-data-dictionary.R
@@ -110,7 +110,7 @@ test_that("data_source() rejects other dictionary inputs", {
 test_that("dictionary content lands in the system prompt", {
   skip_if_not_installed("yaml")
   src <- local_dict_source()
-  prompt <- commons_system_prompt(list(src), default_system_prompt())
+  prompt <- commons_system_prompt(list(src))
 
   expect_match(prompt, "# About the data", fixed = TRUE)
   expect_match(prompt, "- sales", fixed = TRUE)
@@ -125,7 +125,7 @@ test_that("multi-source prompts label dictionary blocks by source", {
     sales_db = local_dict_source(),
     crm = data_source(accounts = data.frame(id = 1))
   )
-  prompt <- commons_system_prompt(sources, default_system_prompt())
+  prompt <- commons_system_prompt(sources)
 
   expect_match(prompt, "## sales_db", fixed = TRUE)
   expect_match(prompt, "Revenue figures exclude tax", fixed = TRUE)

--- a/tests/testthat/test-definitions.R
+++ b/tests/testthat/test-definitions.R
@@ -249,8 +249,7 @@ test_that("the system prompt carries a governed-definitions index", {
   registry <- sales_registry(src)
   prompt <- commons_system_prompt(
     list(sales_db = src),
-    default_system_prompt(),
-    registry
+    definitions = registry
   )
   expect_match(prompt, "# Governed definitions", fixed = TRUE)
   expect_match(prompt, "Write them as `{{name}}` tokens", fixed = TRUE)
@@ -286,8 +285,7 @@ test_that("the prompt section caps like the glossary", {
   expect_true(definitions_overflow(registry))
   text <- commons_system_prompt(
     list(sales_db = definitions_source(many_definitions())),
-    default_system_prompt(),
-    registry
+    definitions = registry
   )
   expect_lt(nchar(text), 6000)
   expect_match(text, "More definitions arrive", fixed = TRUE)

--- a/tests/testthat/test-prompt.R
+++ b/tests/testthat/test-prompt.R
@@ -43,19 +43,23 @@ test_that("prompt templates validate their structure and values", {
   )
 })
 
-test_that("missing prompt paths are recognized", {
-  expect_error(check_system_prompt("missing-prompt.Rmd"), "does not exist")
+test_that("missing instruction paths are recognized", {
   expect_error(
-    check_system_prompt("missing-prompt.template"),
+    check_instructions("missing-instructions.Rmd"),
     "does not exist"
   )
-  expect_error(check_system_prompt("missing-dir/prompt"), "does not exist")
-  expect_no_error(check_system_prompt("You are a concise analyst."))
-  expect_no_error(check_system_prompt("Line one.\nLine two."))
+  expect_error(
+    check_instructions("missing-instructions.template"),
+    "does not exist"
+  )
+  expect_error(check_instructions("missing-dir/instructions"), "does not exist")
+  expect_no_error(check_instructions("Be concise."))
+  expect_no_error(check_instructions("Line one.\nLine two."))
+  expect_no_error(check_instructions(NULL))
 })
 
 test_that("the packaged prompt leaves no template markup", {
-  template <- read_system_prompt(default_system_prompt())
+  template <- read_system_prompt()
   prompt <- test_agent()$get_system_prompt()
 
   expect_match(template, "{{name}}", fixed = TRUE)
@@ -79,9 +83,18 @@ test_that("system prompt data contains facts and runtime content", {
       "tables",
       "dictionary_context",
       "glossary_context",
-      "definition_index"
+      "definition_index",
+      "has_instructions",
+      "instructions"
     )
   )
+})
+
+test_that("instructions are not interpreted as prompt template expressions", {
+  instructions <- "Use `{[tables]}` exactly as written."
+  prompt <- test_agent(instructions = instructions)$get_system_prompt()
+
+  expect_true(endsWith(prompt, instructions))
 })
 
 test_that("the packaged prompt omits run_r result handles", {

--- a/tests/testthat/test-prompt.R
+++ b/tests/testthat/test-prompt.R
@@ -1,9 +1,9 @@
 test_that("prompt templates select conditional sections", {
   template <- paste(
     "<!-- source-only note -->",
-    "{[ if (enabled) {",
+    "{if (enabled) {",
     "  if (nested) \"Enabled\\nNested\" else \"Enabled\\nNot nested\"",
-    "} else \"Disabled\" ]}",
+    "} else \"Disabled\"}",
     sep = "\n"
   )
 
@@ -18,27 +18,33 @@ test_that("prompt templates select conditional sections", {
 })
 
 test_that("prompt templates interpolate runtime data without recursion", {
-  template <- "Tables:\n{[tables]}\nUse `{[definition_token]}`."
+  template <- paste(
+    "Tables:\n{tables}\nUse `{definition_token}`.",
+    "Write a literal `{{{{name}}}}` token."
+  )
   data <- list(tables = "- sales\\daily\n- orders {{raw}}")
   data$definition_token <- "{{name}}"
 
   expect_equal(
     render_system_prompt(template, data),
-    "Tables:\n- sales\\daily\n- orders {{raw}}\nUse `{{name}}`."
+    paste(
+      "Tables:\n- sales\\daily\n- orders {{raw}}\nUse `{{name}}`.",
+      "Write a literal `{{name}}` token."
+    )
   )
 })
 
 test_that("prompt templates validate their structure and values", {
   expect_error(
-    render_system_prompt("{[ if (unknown) \"x\" else \"\" ]}", list()),
+    render_system_prompt("{if (unknown) \"x\" else \"\"}", list()),
     "object 'unknown' not found"
   )
   expect_error(
-    render_system_prompt("{[ if (yes) ]}", list(yes = TRUE)),
+    render_system_prompt("{if (yes) }", list(yes = TRUE)),
     "Failed to parse glue component"
   )
   expect_error(
-    render_system_prompt("{[tables]}", list(tables = c("a", "b"))),
+    render_system_prompt("{tables}", list(tables = c("a", "b"))),
     "single string"
   )
 })
@@ -64,7 +70,7 @@ test_that("the packaged prompt leaves no template markup", {
 
   expect_match(template, "{{name}}", fixed = TRUE)
   expect_no_match(prompt, "<!--", fixed = TRUE)
-  expect_no_match(prompt, "{[", fixed = TRUE)
+  expect_no_match(prompt, "{date}", fixed = TRUE)
   expect_no_match(prompt, "# Governed definitions", fixed = TRUE)
 })
 
@@ -91,7 +97,7 @@ test_that("system prompt data contains facts and runtime content", {
 })
 
 test_that("instructions are not interpreted as prompt template expressions", {
-  instructions <- "Use `{[tables]}` exactly as written."
+  instructions <- "Use `{tables}` exactly as written."
   prompt <- test_agent(instructions = instructions)$get_system_prompt()
 
   expect_true(endsWith(prompt, instructions))

--- a/vignettes/commons.Rmd
+++ b/vignettes/commons.Rmd
@@ -37,7 +37,7 @@ A commons agent is easiest to maintain when the pieces live in separate files:
 |   |-- semantic_layer.R
 |   `-- context_layer.R
 |-- app.R
-|-- system-prompt.md
+|-- instructions.md
 `-- context/
     `-- metrics.md
 ```


### PR DESCRIPTION
Closes #88.

For now, commons will own the system prompt and folks can append `## Additional Instructions` to it. 