### PR TITLE
Fix Getting Started vignette verification pill rendering

### DIFF
--- a/vignettes/commons.Rmd
+++ b/vignettes/commons.Rmd
@@ -18,6 +18,7 @@ knitr::opts_chunk$set(
   comment = "#>",
   eval = FALSE
 )
+knitr::knit_meta_add(list(commons:::commons_chat_dependency()))
 ```
 
 This document explains the structure of a commons project and how to start building a commons agent.


### PR DESCRIPTION
The pills are currently not rendering correctly. This fixes the issue by registering the existing commons chat dependency with the vignette.