### PR TITLE
only show Details collapsible when a plot is present

### DIFF
--- a/R/run-r.R
+++ b/R/run-r.R
@@ -224,13 +224,20 @@ run_r_html <- function(code, segments) {
       )
     }
   }
-  details_html <- sprintf(
-    "<details class=\"commons-run-r-details\"><summary>Details</summary><pre><code class=\"language-r\">%s</code></pre></details>",
+  code_html <- sprintf(
+    "<pre class=\"commons-run-r-code\"><code class=\"language-r\">%s</code></pre>",
     html_escape(paste(c(code, output), collapse = "\n"))
   )
+  if (length(plot_html)) {
+    code_html <- paste0(
+      "<details class=\"commons-run-r-details\"><summary>Details</summary>",
+      code_html,
+      "</details>"
+    )
+  }
   sprintf(
     "<div class=\"commons-run-r-display\">%s</div>",
-    paste(c(details_html, plot_html), collapse = "\n")
+    paste(c(code_html, plot_html), collapse = "\n")
   )
 }
 

--- a/inst/www/commons-chat/commons-chat.css
+++ b/inst/www/commons-chat/commons-chat.css
@@ -292,10 +292,14 @@ shiny-chat-container
   text-transform: uppercase;
 }
 
-.commons-run-r-details > pre {
-  margin: 0.4rem 0 0;
+.commons-run-r-code {
+  margin: 0;
   overflow-x: auto;
   white-space: pre;
+}
+
+.commons-run-r-details > .commons-run-r-code {
+  margin-top: 0.4rem;
 }
 
 .commons-run-r-plot {

--- a/tests/testthat/test-run-r.R
+++ b/tests/testthat/test-run-r.R
@@ -18,6 +18,18 @@ test_that("run_r executes code against stored handles", {
   expect_match(res@value, "5650")
   expect_equal(res@extra$commons_tag, "B")
   expect_false(res@extra$display$open)
+  expect_match(
+    res@extra$display$html,
+    '<pre class="commons-run-r-code"><code class="language-r">',
+    fixed = TRUE
+  )
+  expect_match(res@extra$display$html, "#&gt; [1] 5650", fixed = TRUE)
+  expect_no_match(res@extra$display$html, "<details", fixed = TRUE)
+  expect_no_match(
+    res@extra$display$html,
+    "<summary>Details</summary>",
+    fixed = TRUE
+  )
 })
 
 test_that("run_r session state persists across calls, and handles sync lazily", {
@@ -69,6 +81,8 @@ test_that("run_r returns plots as images and opens the display", {
   expect_identical(res@extra$display$open, TRUE)
   expect_match(res@extra$display$html, "data:image/png;base64,")
   expect_match(res@extra$display$html, "commons-run-r-details")
+  expect_match(res@extra$display$html, "commons-run-r-code", fixed = TRUE)
+  expect_match(res@extra$display$html, "<summary>Details</summary>", fixed = TRUE)
 })
 
 test_that("run_r collapses code and output above plots", {
@@ -130,6 +144,35 @@ test_that("run_r surfaces errors from model code without failing the tool", {
 
   expect_s7_class(res, ellmer::ContentToolResult)
   expect_match(res@value, "Error: boom")
+  expect_false(res@extra$display$open)
+  expect_match(res@extra$display$html, "#&gt; boom", fixed = TRUE)
+  expect_match(res@extra$display$html, "commons-run-r-code", fixed = TRUE)
+  expect_no_match(res@extra$display$html, "<details", fixed = TRUE)
+})
+
+test_that("run_r displays code directly when it produces no output", {
+  worker <- local_worker()
+  store <- new_handle_store()
+
+  res <- sync_promise(run_r_tool(worker, store, "x <- 1"))
+
+  expect_match(res@value, "produced no output", fixed = TRUE)
+  expect_false(res@extra$display$open)
+  expect_match(res@extra$display$html, "x &lt;- 1", fixed = TRUE)
+  expect_match(res@extra$display$html, "commons-run-r-code", fixed = TRUE)
+  expect_no_match(res@extra$display$html, "#&gt;", fixed = TRUE)
+  expect_no_match(res@extra$display$html, "<details", fixed = TRUE)
+})
+
+test_that("run_r displays worker failures directly and escapes their HTML", {
+  res <- run_r_result("x <- '<unsafe>'", list(failure = "worker <broke>"))
+
+  expect_match(res@value, "Error: worker <broke>", fixed = TRUE)
+  expect_false(res@extra$display$open)
+  expect_match(res@extra$display$html, "&#39;&lt;unsafe&gt;&#39;", fixed = TRUE)
+  expect_match(res@extra$display$html, "#&gt; worker &lt;broke&gt;", fixed = TRUE)
+  expect_match(res@extra$display$html, "commons-run-r-code", fixed = TRUE)
+  expect_no_match(res@extra$display$html, "<details", fixed = TRUE)
 })
 
 test_that("the worker cannot see parent-only environment variables", {


### PR DESCRIPTION
Closes #102.

When a plot is present, show the tool result by default but hide code and (other) results in a collapsible.

When a plot is not present, hide the tool result and, when clicked open, show the code and results (notably, not in an inner Details collapsible).

This way, the user only needs to click once to see the code, regardless of plot or not.