### PR TITLE
add `commons.allow_unsafe_fallback` with a shim-based sandbox fallback

### DIFF
--- a/pkg-r/R/commons.R
+++ b/pkg-r/R/commons.R
@@ -29,8 +29,11 @@
 #'   )
 #'   ```
 #' @param network Whether the `run_r` session has network access. One of
-#'   `"none"` (the default) or `"full"`. The session requires Linux or macOS
-#'   and refuses to run without filesystem sandboxing.
+#'   `"none"` (the default) or `"full"`. The session uses OS sandboxing on
+#'   Linux and macOS. On unsupported hosts, local development can opt in to
+#'   best-effort R guardrails with
+#'   `options(commons.dangerously_disable_sandbox = TRUE)`. These guardrails
+#'   are not a security boundary.
 #' @param log Whether to capture conversation trajectories with OpenTelemetry
 #'   (default `FALSE`). When `TRUE`, commons enables GenAI message-content
 #'   capture in \pkg{ellmer} and tags each turn's spans with a conversation
@@ -132,7 +135,7 @@ commons <- function(
   semantic_layer <- semantic_layer %||% new_semantic_layer()
   check_semantic_layer(semantic_layer)
   network <- rlang::arg_match(network)
-  check_run_r_sandbox()
+  protection <- run_r_protection_mode()
   check_instructions(instructions)
   rlang::check_bool(log)
   check_share_with(share_with)
@@ -143,6 +146,7 @@ commons <- function(
     context_layer = context_layer,
     semantic_layer = semantic_layer,
     network = network,
+    protection = protection,
     instructions = instructions,
     log = log,
     share_with = share_with
@@ -166,6 +170,7 @@ Commons <- R6::R6Class(
       ...,
       instructions = NULL,
       network = c("none", "full"),
+      protection = run_r_protection_mode(),
       log = FALSE,
       share_with = NULL
     ) {
@@ -209,7 +214,7 @@ Commons <- R6::R6Class(
       )
 
       private$handles <- new_handle_store()
-      private$worker <- new_r_worker(network)
+      private$worker <- new_r_worker(network, protection)
       private$corpus <- build_citation_corpus(
         private$context_layer,
         private$registry,

--- a/pkg-r/R/commons.R
+++ b/pkg-r/R/commons.R
@@ -32,7 +32,7 @@
 #'   `"none"` (the default) or `"full"`. The session uses OS sandboxing on
 #'   Linux and macOS. On unsupported hosts, local development can opt in to
 #'   best-effort R guardrails with
-#'   `options(commons.dangerously_disable_sandbox = TRUE)`. These guardrails
+#'   `options(commons.allow_unsafe_fallback = TRUE)`. These guardrails
 #'   are not a security boundary.
 #' @param log Whether to capture conversation trajectories with OpenTelemetry
 #'   (default `FALSE`). When `TRUE`, commons enables GenAI message-content

--- a/pkg-r/R/run-r.R
+++ b/pkg-r/R/run-r.R
@@ -27,7 +27,9 @@ tool_run_r <- function(private) {
       )
     },
     paste(
-      "Run R code in your sandboxed R session to analyze results or render plots.",
+      # The model sees OS-sandbox framing even when Windows uses guardrails.
+      "Run R code in your OS-level sandboxed R session to analyze results or",
+      "render plots.",
       "R code and textual output are visible only to you; rendered plots are",
       "also shown to the user.",
       "The user cannot run code in this session themselves.",
@@ -93,7 +95,8 @@ run_r_tool <- function(worker, handles, code, fn_sources = character()) {
             code = code,
             new_handles = new_handles,
             plot_width = dims$width,
-            plot_height = dims$height
+            plot_height = dims$height,
+            guardrails = worker$guardrails
           )
         )
         worker$synced <- length(ids)
@@ -243,9 +246,12 @@ run_r_html <- function(code, segments) {
 
 # --- worker lifecycle --------------------------------------------------------
 
-new_r_worker <- function(network = "none") {
+new_r_worker <- function(network = "none", protection = "sandbox") {
+  protection <- rlang::arg_match(protection, c("sandbox", "guardrails"))
   worker <- new.env(parent = emptyenv())
   worker$network <- network
+  worker$protection <- protection
+  worker$guardrails <- NULL
   worker$rs <- NULL
   worker$synced <- 0L
   worker$tail <- NULL
@@ -284,9 +290,13 @@ worker_ensure <- function(worker, fn_sources = character()) {
       parent_tmp = tempdir(),
       work_dir = work_dir,
       dll_path = commons_dll_path(),
-      network = worker$network
+      network = worker$network,
+      protection = worker$protection
     )
   )
+  if (identical(worker$protection, "guardrails")) {
+    worker$guardrails <- worker_guardrails(work_dir, worker$network)
+  }
   # Defining sources at spawn (rather than syncing per call like handles)
   # means a respawned worker gets them again for free.
   if (length(fn_sources)) {
@@ -322,6 +332,7 @@ worker_close <- function(worker) {
   if (!is.null(worker$rs)) {
     try(worker$rs$close(), silent = TRUE)
     worker$rs <- NULL
+    worker$guardrails <- NULL
     worker$synced <- 0L
   }
   invisible(worker)
@@ -355,6 +366,370 @@ worker_scrubbed_env <- function(work_dir, single_thread = FALSE) {
     env[["OMP_NUM_THREADS"]] <- "1"
   }
   env
+}
+
+worker_guardrails <- function(work_dir, network = "none") {
+  normalize <- base::normalizePath
+  file_exists <- base::file.exists
+  dir_exists <- base::dir.exists
+  path_exists <- function(path) {
+    file_exists(path) || dir_exists(path)
+  }
+  canonical_path <- function(path) {
+    path <- path.expand(path)
+    if (!grepl("^([A-Za-z]:[/\\\\]|[/\\\\]{1,2})", path)) {
+      path <- file.path(getwd(), path)
+    }
+    suffix <- character()
+    # Resolving an existing ancestor exposes symlinks beneath nonexistent paths.
+    while (!path_exists(path) && !identical(dirname(path), path)) {
+      suffix <- c(basename(path), suffix)
+      path <- dirname(path)
+    }
+    path <- normalize(path, winslash = "/", mustWork = FALSE)
+    if (length(suffix)) {
+      path <- do.call(file.path, as.list(c(path, suffix)))
+    }
+    if (nchar(path) > 1L && !grepl("^[A-Za-z]:/$", path)) {
+      path <- sub("/+$", "", path)
+    }
+    path
+  }
+  canonical_paths <- function(paths) {
+    unique(vapply(paths, canonical_path, character(1), USE.NAMES = FALSE))
+  }
+  package_dirs <- unlist(
+    lapply(.libPaths(), base::list.dirs, recursive = FALSE, full.names = TRUE),
+    use.names = FALSE
+  )
+  read_roots <- canonical_paths(c(R.home(), .libPaths(), package_dirs, work_dir))
+  write_roots <- canonical_paths(work_dir)
+  windows <- identical(Sys.info()[["sysname"]], "Windows")
+
+  in_roots <- function(path, roots) {
+    if (windows) {
+      path <- tolower(path)
+      roots <- tolower(roots)
+    }
+    any(vapply(
+      roots,
+      function(root) {
+        identical(path, root) ||
+          identical(root, "/") ||
+          startsWith(path, paste0(root, "/"))
+      },
+      logical(1)
+    ))
+  }
+  deny <- function(kind, target = NULL) {
+    detail <- if (is.null(target)) "" else paste0(" to '", target, "'")
+    stop("commons run_r guardrails denied ", kind, detail, call. = FALSE)
+  }
+  check_path <- function(paths, access) {
+    if (is.null(paths)) {
+      return(invisible())
+    }
+    if (inherits(paths, "connection")) {
+      description <- tryCatch(
+        summary(paths)$description,
+        error = function(e) ""
+      )
+      if (
+        !nzchar(description) ||
+          description %in% c("stdin", "stdout", "stderr", "terminal") ||
+          startsWith(description, "textConnection") ||
+          startsWith(description, "rawConnection")
+      ) {
+        return(invisible())
+      }
+      paths <- description
+    }
+    paths <- as.character(paths)
+    paths <- paths[!is.na(paths) & nzchar(paths)]
+    for (path in paths) {
+      uri <- grepl("^[A-Za-z][A-Za-z0-9+.-]*:", path) &&
+        !grepl("^[A-Za-z]:[/\\\\]", path)
+      if (uri) {
+        if (startsWith(tolower(path), "file:")) {
+          deny(paste(access, "access"), path)
+        }
+        if (identical(network, "none")) {
+          deny("network access", path)
+        }
+        next
+      }
+      resolved <- canonical_path(path)
+      roots <- if (identical(access, "write")) write_roots else read_roots
+      if (!in_roots(resolved, roots)) {
+        deny(paste(access, "access"), path)
+      }
+    }
+    invisible()
+  }
+  namespace_function <- function(package, name) {
+    get(name, envir = asNamespace(package), inherits = FALSE)
+  }
+  matched_arguments <- function(original, args) {
+    call <- as.call(c(list(quote(.guarded_call)), args))
+    names(call) <- c("", names(args))
+    match.call(original, call, expand.dots = FALSE)
+  }
+  path_hook <- function(
+    package,
+    name,
+    access,
+    argument,
+    dots = FALSE,
+    exclude = character()
+  ) {
+    original <- namespace_function(package, name)
+    replacement <- function(...) {
+      args <- list(...)
+      if (identical(name, "load") && is.null(args$envir)) {
+        args$envir <- parent.frame()
+      }
+      matched <- matched_arguments(original, args)
+      paths <- if (dots) {
+        values <- as.list(matched$...)
+        value_names <- names(values)
+        if (is.null(value_names)) {
+          value_names <- rep("", length(values))
+        }
+        values <- values[!nzchar(value_names) | !value_names %in% exclude]
+        unlist(values, use.names = FALSE)
+      } else if (!is.null(matched[[argument]])) {
+        matched[[argument]]
+      } else {
+        NULL
+      }
+      check_path(paths, access)
+      do.call(original, args)
+    }
+    list(package = package, name = name, replacement = replacement)
+  }
+  named_path_hook <- function(package, name, access, argument, default = NULL) {
+    original <- namespace_function(package, name)
+    replacement <- function(...) {
+      args <- list(...)
+      path <- args[[argument]]
+      if (is.null(path)) {
+        path <- default
+      }
+      check_path(path, access)
+      do.call(original, args)
+    }
+    list(package = package, name = name, replacement = replacement)
+  }
+  pair_hook <- function(package, name, first_access, second_access) {
+    original <- namespace_function(package, name)
+    replacement <- function(...) {
+      args <- list(...)
+      matched <- matched_arguments(original, args)
+      formal_names <- names(formals(original))
+      check_path(matched[[formal_names[[1L]]]], first_access)
+      check_path(matched[[formal_names[[2L]]]], second_access)
+      do.call(original, args)
+    }
+    list(package = package, name = name, replacement = replacement)
+  }
+  arguments_hook <- function(package, name, accesses) {
+    original <- namespace_function(package, name)
+    replacement <- function(...) {
+      args <- list(...)
+      matched <- matched_arguments(original, args)
+      for (argument in names(accesses)) {
+        check_path(matched[[argument]], accesses[[argument]])
+      }
+      do.call(original, args)
+    }
+    list(package = package, name = name, replacement = replacement)
+  }
+  connection_hook <- function(name, open_argument = 2L) {
+    original <- namespace_function("base", name)
+    replacement <- function(...) {
+      args <- list(...)
+      matched <- matched_arguments(original, args)
+      description <- matched$description
+      open <- matched$open
+      if (is.null(description)) description <- ""
+      if (is.null(open)) open <- ""
+      access <- if (grepl("[wa+]", open)) "write" else "read"
+      check_path(description, access)
+      do.call(original, args)
+    }
+    list(package = "base", name = name, replacement = replacement)
+  }
+  open_connection_hook <- function() {
+    original <- namespace_function("base", "open.connection")
+    replacement <- function(con, open = "r", blocking = TRUE, ...) {
+      access <- if (grepl("[wa+]", open)) "write" else "read"
+      check_path(con, access)
+      original(con, open = open, blocking = blocking, ...)
+    }
+    list(
+      package = "base",
+      name = "open.connection",
+      replacement = replacement
+    )
+  }
+  save_hook <- function() {
+    original <- namespace_function("base", "save")
+    replacement <- function(
+      ...,
+      list = character(),
+      file = stop("'file' must be specified"),
+      ascii = FALSE,
+      version = NULL,
+      envir = parent.frame(),
+      compress = isTRUE(!ascii),
+      compression_level,
+      eval.promises = TRUE,
+      precheck = TRUE
+    ) {
+      check_path(file, "write")
+      dots <- as.list(substitute(list(...)))[-1L]
+      dot_names <- vapply(dots, deparse1, character(1))
+      args <- list(
+        list = unique(c(dot_names, list)),
+        file = file,
+        ascii = ascii,
+        version = version,
+        envir = envir,
+        compress = compress,
+        eval.promises = eval.promises,
+        precheck = precheck
+      )
+      if (!missing(compression_level)) {
+        args$compression_level <- compression_level
+      }
+      do.call(original, args)
+    }
+    list(package = "base", name = "save", replacement = replacement)
+  }
+  denied_hook <- function(package, name, kind) {
+    original <- namespace_function(package, name)
+    replacement <- function(...) {
+      deny(kind)
+      do.call(original, list(...))
+    }
+    list(package = package, name = name, replacement = replacement)
+  }
+
+  read_arguments <- c(
+    file.access = "names", list.files = "path", list.dirs = "path",
+    dir = "path", normalizePath = "path", setwd = "dir",
+    readLines = "con", readChar = "con", readBin = "con", scan = "file",
+    dget = "file", load = "file", readRDS = "file", source = "file",
+    sys.source = "file", parse = "file",
+    read.dcf = "file", readRenviron = "path", dyn.load = "x"
+  )
+  write_arguments <- c(
+    dir.create = "path", unlink = "x", Sys.chmod = "paths",
+    Sys.setFileTime = "path", sink = "file"
+  )
+  pair_access <- list(
+    file.rename = c("write", "write"),
+    file.copy = c("read", "write"),
+    file.append = c("write", "read"),
+    file.symlink = c("read", "write"),
+    file.link = c("read", "write")
+  )
+  hooks <- c(
+    list(
+      path_hook("base", "file.exists", "read", "...", dots = TRUE),
+      path_hook("base", "dir.exists", "read", "paths"),
+      path_hook(
+        "base", "file.info", "read", "...", dots = TRUE,
+        exclude = "extra_cols"
+      ),
+      path_hook("base", "Sys.readlink", "read", "paths"),
+      path_hook("base", "Sys.glob", "read", "paths"),
+      path_hook("base", "file.show", "read", "...", dots = TRUE)
+    ),
+    Map(
+      function(name, argument) path_hook("base", name, "read", argument),
+      names(read_arguments),
+      unname(read_arguments)
+    ),
+    list(
+      path_hook(
+        "base", "file.create", "write", "...", dots = TRUE,
+        exclude = "showWarnings"
+      ),
+      path_hook("base", "file.remove", "write", "...", dots = TRUE)
+    ),
+    Map(
+      function(name, argument) path_hook("base", name, "write", argument),
+      names(write_arguments),
+      unname(write_arguments)
+    ),
+    list(
+      path_hook("base", "writeLines", "write", "con"),
+      path_hook("base", "writeChar", "write", "con"),
+      path_hook("base", "writeBin", "write", "con"),
+      path_hook("base", "dput", "write", "file"),
+      path_hook("base", "saveRDS", "write", "file"),
+      path_hook("base", "write.dcf", "write", "file"),
+      named_path_hook("base", "cat", "write", "file", ""),
+      save_hook()
+    ),
+    Map(
+      function(name, access) {
+        pair_hook("base", name, access[[1L]], access[[2L]])
+      },
+      names(pair_access),
+      unname(pair_access)
+    ),
+    lapply(c("file", "gzfile", "bzfile", "xzfile", "fifo"), connection_hook),
+    list(
+      path_hook("base", "unz", "read", "description"),
+      open_connection_hook()
+    ),
+    lapply(
+      c("system", "system2", "pipe"),
+      function(name) denied_hook("base", name, "subprocess creation")
+    ),
+    list(denied_hook("utils", "browseURL", "subprocess creation"))
+  )
+  if (exists("shell", envir = baseenv(), inherits = FALSE)) {
+    hooks <- c(hooks, list(denied_hook("base", "shell", "subprocess creation")))
+  }
+  for (package in c("base", "utils")) {
+    namespace <- asNamespace(package)
+    if (exists("shell.exec", envir = namespace, inherits = FALSE)) {
+      hooks <- c(
+        hooks,
+        list(denied_hook(package, "shell.exec", "subprocess creation"))
+      )
+    }
+  }
+  if (identical(network, "none")) {
+    hooks <- c(
+      hooks,
+      lapply(
+        c("url", "socketConnection", "serverSocket", "socketAccept"),
+        function(name) denied_hook("base", name, "network access")
+      ),
+      lapply(
+        c("download.file", "url.show"),
+        function(name) denied_hook("utils", name, "network access")
+      )
+    )
+  } else {
+    hooks <- c(
+      hooks,
+      list(
+        connection_hook("url"),
+        pair_hook("utils", "download.file", "read", "write"),
+        arguments_hook(
+          "utils",
+          "url.show",
+          c(url = "read", file = "write")
+        )
+      )
+    )
+  }
+  hooks
 }
 
 # Close the worker after a quiet stretch; it respawns lazily on the next
@@ -470,11 +845,18 @@ worker_init <- function(
   work_dir,
   dll_path,
   network = "none",
+  protection = "sandbox",
   sandbox_mode = "auto"
 ) {
   setwd(work_dir)
   options(width = 80, cli.num_colors = 1)
-  # Every platform that runs worker code must engage a sandbox.
+  if (!protection %in% c("sandbox", "guardrails")) {
+    stop("unknown run_r protection mode: ", protection)
+  }
+  if (identical(protection, "guardrails")) {
+    requireNamespace("bit64", quietly = TRUE)
+    return(invisible(TRUE))
+  }
   sysname <- Sys.info()[["sysname"]]
   if (!sysname %in% c("Linux", "Darwin")) {
     stop(
@@ -563,7 +945,13 @@ worker_define_functions <- function(fn_sources) {
   invisible(TRUE)
 }
 
-worker_run_code <- function(code, new_handles, plot_width, plot_height) {
+worker_run_code <- function(
+  code,
+  new_handles,
+  plot_width,
+  plot_height,
+  guardrails = NULL
+) {
   for (id in names(new_handles)) {
     assign(id, new_handles[[id]], envir = globalenv())
   }
@@ -649,6 +1037,51 @@ worker_run_code <- function(code, new_handles, plot_width, plot_height) {
       }
     }
   )
+
+  if (!is.null(guardrails)) {
+    restore <- list()
+    on.exit({
+      for (item in rev(restore)) {
+        if (bindingIsLocked(item$name, item$environment)) {
+          unlockBinding(item$name, item$environment)
+        }
+        assign(item$name, item$original, envir = item$environment)
+        if (item$locked) {
+          lockBinding(item$name, item$environment)
+        }
+      }
+    }, add = TRUE)
+    for (hook in guardrails) {
+      namespace <- asNamespace(hook$package)
+      environments <- list(namespace)
+      attached_name <- paste0("package:", hook$package)
+      # Attached exports are copied bindings rather than namespace lookups.
+      if (attached_name %in% search()) {
+        attached <- as.environment(attached_name)
+        if (!identical(attached, namespace) &&
+          exists(hook$name, envir = attached, inherits = FALSE)) {
+          environments <- c(environments, list(attached))
+        }
+      }
+      for (environment in environments) {
+        original <- get(hook$name, envir = environment, inherits = FALSE)
+        locked <- bindingIsLocked(hook$name, environment)
+        if (locked) {
+          unlockBinding(hook$name, environment)
+        }
+        assign(hook$name, hook$replacement, envir = environment)
+        if (locked) {
+          lockBinding(hook$name, environment)
+        }
+        restore[[length(restore) + 1L]] <- list(
+          name = hook$name,
+          environment = environment,
+          original = original,
+          locked = locked
+        )
+      }
+    }
+  }
 
   evaluate::evaluate(
     code,

--- a/pkg-r/R/run-r.R
+++ b/pkg-r/R/run-r.R
@@ -28,8 +28,7 @@ tool_run_r <- function(private) {
     },
     paste(
       # The model sees OS-sandbox framing even when Windows uses guardrails.
-      "Run R code in your OS-level sandboxed R session to analyze results or",
-      "render plots.",
+      "Run R code in your sandboxed R session to analyze results or render plots.",
       "R code and textual output are visible only to you; rendered plots are",
       "also shown to the user.",
       "The user cannot run code in this session themselves.",
@@ -730,7 +729,12 @@ worker_guardrails <- function(work_dir, network = "none") {
       )
     )
   }
-  assign(".commons_guardrails", hooks, envir = globalenv())
+  attach(NULL, name = "commons:guardrails")
+  assign(
+    ".commons_guardrails",
+    hooks,
+    envir = as.environment("commons:guardrails")
+  )
   invisible(TRUE)
 }
 
@@ -1039,11 +1043,13 @@ worker_run_code <- function(
     }
   )
 
-  guardrails <- get0(
-    ".commons_guardrails",
-    envir = globalenv(),
-    inherits = FALSE
-  )
+  guardrails <- if ("commons:guardrails" %in% search()) {
+    get(
+      ".commons_guardrails",
+      envir = as.environment("commons:guardrails"),
+      inherits = FALSE
+    )
+  }
   if (!is.null(guardrails)) {
     restore <- list()
     on.exit({

--- a/pkg-r/R/run-r.R
+++ b/pkg-r/R/run-r.R
@@ -95,8 +95,7 @@ run_r_tool <- function(worker, handles, code, fn_sources = character()) {
             code = code,
             new_handles = new_handles,
             plot_width = dims$width,
-            plot_height = dims$height,
-            guardrails = worker$guardrails
+            plot_height = dims$height
           )
         )
         worker$synced <- length(ids)
@@ -251,7 +250,6 @@ new_r_worker <- function(network = "none", protection = "sandbox") {
   worker <- new.env(parent = emptyenv())
   worker$network <- network
   worker$protection <- protection
-  worker$guardrails <- NULL
   worker$rs <- NULL
   worker$synced <- 0L
   worker$tail <- NULL
@@ -295,7 +293,11 @@ worker_ensure <- function(worker, fn_sources = character()) {
     )
   )
   if (identical(worker$protection, "guardrails")) {
-    worker$guardrails <- worker_guardrails(work_dir, worker$network)
+    # Build hooks in the worker so their captured functions stay worker-local.
+    rs$run(
+      worker_guardrails,
+      args = list(work_dir = work_dir, network = worker$network)
+    )
   }
   # Defining sources at spawn (rather than syncing per call like handles)
   # means a respawned worker gets them again for free.
@@ -332,7 +334,6 @@ worker_close <- function(worker) {
   if (!is.null(worker$rs)) {
     try(worker$rs$close(), silent = TRUE)
     worker$rs <- NULL
-    worker$guardrails <- NULL
     worker$synced <- 0L
   }
   invisible(worker)
@@ -544,7 +545,7 @@ worker_guardrails <- function(work_dir, network = "none") {
     }
     list(package = package, name = name, replacement = replacement)
   }
-  connection_hook <- function(name, open_argument = 2L) {
+  connection_hook <- function(name) {
     original <- namespace_function("base", name)
     replacement <- function(...) {
       args <- list(...)
@@ -729,7 +730,8 @@ worker_guardrails <- function(work_dir, network = "none") {
       )
     )
   }
-  hooks
+  assign(".commons_guardrails", hooks, envir = globalenv())
+  invisible(TRUE)
 }
 
 # Close the worker after a quiet stretch; it respawns lazily on the next
@@ -949,8 +951,7 @@ worker_run_code <- function(
   code,
   new_handles,
   plot_width,
-  plot_height,
-  guardrails = NULL
+  plot_height
 ) {
   for (id in names(new_handles)) {
     assign(id, new_handles[[id]], envir = globalenv())
@@ -1038,6 +1039,11 @@ worker_run_code <- function(
     }
   )
 
+  guardrails <- get0(
+    ".commons_guardrails",
+    envir = globalenv(),
+    inherits = FALSE
+  )
   if (!is.null(guardrails)) {
     restore <- list()
     on.exit({

--- a/pkg-r/R/sandbox.R
+++ b/pkg-r/R/sandbox.R
@@ -12,33 +12,64 @@ sandbox_capabilities <- function() {
   )
 }
 
-check_run_r_sandbox <- function(
+run_r_protection_mode <- function(
   capabilities = sandbox_capabilities(),
   sysname = Sys.info()[["sysname"]],
+  allow_guardrails = isTRUE(getOption(
+    "commons.dangerously_disable_sandbox",
+    FALSE
+  )),
   call = rlang::caller_env()
 ) {
-  if (!identical(sysname, "Linux")) {
-    return(invisible())
+  sandbox_available <- switch(
+    sysname,
+    Linux = capabilities$seccomp &&
+      (capabilities$landlock_abi >= 1 || capabilities$userns),
+    Darwin = capabilities$seatbelt,
+    FALSE
+  )
+  if (sandbox_available) {
+    return("sandbox")
+  }
+  if (allow_guardrails) {
+    return("guardrails")
   }
 
-  if (!capabilities$seccomp) {
+  if (identical(sysname, "Linux") && !capabilities$seccomp) {
     cli::cli_abort(
-      "commons cannot sandbox the {.code run_r} session because this Linux
-       host does not support seccomp.",
+      c(
+        "commons cannot sandbox the {.code run_r} session because this Linux
+         host does not support seccomp.",
+        i = "For local development only, explicitly accept best-effort R
+             guardrails with
+             {.code options(commons.dangerously_disable_sandbox = TRUE)}."
+      ),
       call = call
     )
   }
-  if (capabilities$landlock_abi >= 1 || capabilities$userns) {
-    return(invisible())
+  if (identical(sysname, "Linux")) {
+    cli::cli_abort(
+      c(
+        "commons cannot sandbox the {.code run_r} session because this Linux
+         host offers neither Landlock nor unprivileged user namespaces.",
+        i = "Use a kernel with Landlock, or enable unprivileged user namespaces.",
+        i = "Check {.code sysctl user.max_user_namespaces} and, in a container,
+             its seccomp profile.",
+        i = "For local development only, explicitly accept best-effort R
+             guardrails with
+             {.code options(commons.dangerously_disable_sandbox = TRUE)}."
+      ),
+      call = call
+    )
   }
 
   cli::cli_abort(
     c(
-      "commons cannot sandbox the {.code run_r} session because this Linux
-       host offers neither Landlock nor unprivileged user namespaces.",
-      i = "Use a kernel with Landlock, or enable unprivileged user namespaces.",
-      i = "Check {.code sysctl user.max_user_namespaces} and, in a container,
-           its seccomp profile."
+      "commons cannot sandbox the {.code run_r} session on {sysname}.",
+      i = "For local development only, explicitly accept best-effort R
+           guardrails with
+           {.code options(commons.dangerously_disable_sandbox = TRUE)}.",
+      i = "These guardrails are not a security boundary."
     ),
     call = call
   )

--- a/pkg-r/R/sandbox.R
+++ b/pkg-r/R/sandbox.R
@@ -16,7 +16,7 @@ run_r_protection_mode <- function(
   capabilities = sandbox_capabilities(),
   sysname = Sys.info()[["sysname"]],
   allow_guardrails = isTRUE(getOption(
-    "commons.dangerously_disable_sandbox",
+    "commons.allow_unsafe_fallback",
     FALSE
   )),
   call = rlang::caller_env()
@@ -42,7 +42,7 @@ run_r_protection_mode <- function(
          host does not support seccomp.",
         i = "For local development only, explicitly accept best-effort R
              guardrails with
-             {.code options(commons.dangerously_disable_sandbox = TRUE)}."
+             {.code options(commons.allow_unsafe_fallback = TRUE)}."
       ),
       call = call
     )
@@ -57,7 +57,7 @@ run_r_protection_mode <- function(
              its seccomp profile.",
         i = "For local development only, explicitly accept best-effort R
              guardrails with
-             {.code options(commons.dangerously_disable_sandbox = TRUE)}."
+             {.code options(commons.allow_unsafe_fallback = TRUE)}."
       ),
       call = call
     )
@@ -68,7 +68,7 @@ run_r_protection_mode <- function(
       "commons cannot sandbox the {.code run_r} session on {sysname}.",
       i = "For local development only, explicitly accept best-effort R
            guardrails with
-           {.code options(commons.dangerously_disable_sandbox = TRUE)}.",
+           {.code options(commons.allow_unsafe_fallback = TRUE)}.",
       i = "These guardrails are not a security boundary."
     ),
     call = call

--- a/pkg-r/man/commons.Rd
+++ b/pkg-r/man/commons.Rd
@@ -46,7 +46,7 @@ system prompt, as a single string or the path to a text or Markdown file.
 \code{"none"} (the default) or \code{"full"}. The session uses OS sandboxing on
 Linux and macOS. On unsupported hosts, local development can opt in to
 best-effort R guardrails with
-\code{options(commons.dangerously_disable_sandbox = TRUE)}. These guardrails
+\code{options(commons.allow_unsafe_fallback = TRUE)}. These guardrails
 are not a security boundary.}
 
 \item{log}{Whether to capture conversation trajectories with OpenTelemetry

--- a/pkg-r/man/commons.Rd
+++ b/pkg-r/man/commons.Rd
@@ -43,8 +43,11 @@ system prompt, as a single string or the path to a text or Markdown file.
 }\if{html}{\out{</div>}}}
 
 \item{network}{Whether the \code{run_r} session has network access. One of
-\code{"none"} (the default) or \code{"full"}. The session requires Linux or macOS
-and refuses to run without filesystem sandboxing.}
+\code{"none"} (the default) or \code{"full"}. The session uses OS sandboxing on
+Linux and macOS. On unsupported hosts, local development can opt in to
+best-effort R guardrails with
+\code{options(commons.dangerously_disable_sandbox = TRUE)}. These guardrails
+are not a security boundary.}
 
 \item{log}{Whether to capture conversation trajectories with OpenTelemetry
 (default \code{FALSE}). When \code{TRUE}, commons enables GenAI message-content

--- a/pkg-r/tests/testthat/test-commons.R
+++ b/pkg-r/tests/testthat/test-commons.R
@@ -50,7 +50,7 @@ test_that("commons() configures run_r network access", {
   expect_true(S7::prop(full, "annotations")$open_world_hint)
 })
 
-test_that("run_r describes both protection modes as OS-level sandboxed", {
+test_that("run_r describes both protection modes as sandboxed", {
   sandboxed <- Commons$new(
     client = test_client(),
     data_sources = list(sales_db = test_source()),
@@ -65,7 +65,7 @@ test_that("run_r describes both protection modes as OS-level sandboxed", {
   guarded_description <- tool_description(agent_tool(guarded, "run_r"))
 
   expect_identical(guarded_description, sandboxed_description)
-  expect_match(guarded_description, "OS-level sandboxed", fixed = TRUE)
+  expect_match(guarded_description, "sandboxed R session", fixed = TRUE)
 })
 
 test_that("run_r describes which results are visible to the user", {

--- a/pkg-r/tests/testthat/test-commons.R
+++ b/pkg-r/tests/testthat/test-commons.R
@@ -50,6 +50,24 @@ test_that("commons() configures run_r network access", {
   expect_true(S7::prop(full, "annotations")$open_world_hint)
 })
 
+test_that("run_r describes both protection modes as OS-level sandboxed", {
+  sandboxed <- Commons$new(
+    client = test_client(),
+    data_sources = list(sales_db = test_source()),
+    protection = "sandbox"
+  )
+  guarded <- Commons$new(
+    client = test_client(),
+    data_sources = list(sales_db = test_source()),
+    protection = "guardrails"
+  )
+  sandboxed_description <- tool_description(agent_tool(sandboxed, "run_r"))
+  guarded_description <- tool_description(agent_tool(guarded, "run_r"))
+
+  expect_identical(guarded_description, sandboxed_description)
+  expect_match(guarded_description, "OS-level sandboxed", fixed = TRUE)
+})
+
 test_that("run_r describes which results are visible to the user", {
   description <- tool_description(agent_tool(test_agent(), "run_r"))
 

--- a/pkg-r/tests/testthat/test-run-r.R
+++ b/pkg-r/tests/testthat/test-run-r.R
@@ -240,6 +240,15 @@ test_that("concurrent run_r calls take turns on the worker", {
 test_that("guardrails allow computation and worker-local files", {
   worker <- local_guardrail_worker()
   store <- new_handle_store()
+  worker_ensure(worker)
+
+  expect_false(worker$rs$run(function() {
+    exists(".commons_guardrails", envir = globalenv(), inherits = FALSE)
+  }))
+  expect_true(worker$rs$run(function() {
+    ".commons_guardrails" %in%
+      ls(as.environment("commons:guardrails"), all.names = TRUE)
+  }))
 
   res <- sync_promise(run_r_tool(
     worker,

--- a/pkg-r/tests/testthat/test-run-r.R
+++ b/pkg-r/tests/testthat/test-run-r.R
@@ -7,6 +7,16 @@ local_worker <- function(env = parent.frame()) {
   worker
 }
 
+local_guardrail_worker <- function(network = "none", env = parent.frame()) {
+  worker <- new_r_worker(network, "guardrails")
+  withr::defer(worker_close(worker), envir = env)
+  worker
+}
+
+worker_read_lines <- function(worker, path) {
+  worker$rs$run(function(path) readLines(path), args = list(path = path))
+}
+
 test_that("run_r executes code against stored handles", {
   worker <- local_worker()
   store <- new_handle_store()
@@ -225,4 +235,168 @@ test_that("concurrent run_r calls take turns on the worker", {
 
   res <- sync_promise(promises::promise_all(p1, p2))
   expect_match(res[[2]]@value, "20")
+})
+
+test_that("guardrails allow computation and worker-local files", {
+  worker <- local_guardrail_worker()
+  store <- new_handle_store()
+
+  res <- sync_promise(run_r_tool(
+    worker,
+    store,
+    paste(
+      "copying <- readLines(file.path(R.home(), 'COPYING'), n = 1)",
+      "writeLines(copying, 'copying.txt')",
+      "parse(text = '1 + 1')",
+      "list.files(pattern = 'copying')",
+      "c(sum(1:10), length(readLines('copying.txt')))",
+      sep = "; "
+    )
+  ))
+
+  expect_match(res@value, "55")
+  expect_match(res@value, "1")
+})
+
+test_that("guardrails deny external filesystem access and subprocesses", {
+  worker <- local_guardrail_worker()
+  store <- new_handle_store()
+  outside <- withr::local_tempfile(tmpdir = dirname(tempdir()))
+  writeLines("secret", outside)
+
+  read <- sync_promise(run_r_tool(
+    worker,
+    store,
+    sprintf("readLines(%s)", encodeString(outside, quote = "\""))
+  ))
+  write <- sync_promise(run_r_tool(
+    worker,
+    store,
+    sprintf("writeLines('changed', %s)", encodeString(outside, quote = "\""))
+  ))
+  probe <- sync_promise(run_r_tool(
+    worker,
+    store,
+    sprintf("file.exists(%s)", encodeString(outside, quote = "\""))
+  ))
+  subprocess <- sync_promise(run_r_tool(
+    worker,
+    store,
+    "system2('R', '--version')"
+  ))
+  download <- sync_promise(run_r_tool(
+    worker,
+    store,
+    sprintf(
+      "download.file('https://example.com', %s)",
+      encodeString(outside, quote = "\"")
+    )
+  ))
+
+  expect_match(read@value, "denied read access", fixed = TRUE)
+  expect_match(write@value, "denied write access", fixed = TRUE)
+  expect_match(probe@value, "denied read access", fixed = TRUE)
+  expect_match(subprocess@value, "denied subprocess creation", fixed = TRUE)
+  expect_match(download@value, "denied network access", fixed = TRUE)
+  expect_identical(readLines(outside), "secret")
+})
+
+test_that("guardrails resolve symlinks and nonexistent descendants", {
+  worker <- local_guardrail_worker()
+  store <- new_handle_store()
+  worker_ensure(worker)
+  work_dir <- worker$rs$run(getwd)
+  outside <- withr::local_tempdir(tmpdir = dirname(tempdir()))
+  writeLines("secret", file.path(outside, "secret.txt"))
+  linked <- file.symlink(outside, file.path(work_dir, "outside-link"))
+  skip_if_not(linked, "cannot create symlinks")
+
+  read <- sync_promise(run_r_tool(
+    worker,
+    store,
+    "readLines('outside-link/secret.txt')"
+  ))
+  write <- sync_promise(run_r_tool(
+    worker,
+    store,
+    "writeLines('changed', 'outside-link/new/nested.txt')"
+  ))
+
+  expect_match(read@value, "denied read access", fixed = TRUE)
+  expect_match(write@value, "denied write access", fixed = TRUE)
+  expect_false(file.exists(file.path(outside, "new", "nested.txt")))
+})
+
+test_that("guardrails follow the configured network policy", {
+  restricted <- local_guardrail_worker()
+  full <- local_guardrail_worker("full")
+  store <- new_handle_store()
+
+  denied <- sync_promise(run_r_tool(
+    restricted,
+    store,
+    "con <- serverSocket(0); close(con)"
+  ))
+  allowed <- sync_promise(run_r_tool(
+    full,
+    store,
+    "con <- serverSocket(0); close(con); TRUE"
+  ))
+  outside <- withr::local_tempfile(tmpdir = dirname(tempdir()))
+  local_url <- paste0("file://", file.path(R.home(), "COPYING"))
+  local_file <- sync_promise(run_r_tool(
+    full,
+    store,
+    sprintf(
+      "download.file(%s, %s)",
+      encodeString(local_url, quote = "\""),
+      encodeString(outside, quote = "\"")
+    )
+  ))
+  external_destination <- sync_promise(run_r_tool(
+    full,
+    store,
+    sprintf(
+      "download.file('https://example.com', %s)",
+      encodeString(outside, quote = "\"")
+    )
+  ))
+
+  expect_match(denied@value, "denied network access", fixed = TRUE)
+  expect_match(allowed@value, "TRUE", fixed = TRUE)
+  expect_match(local_file@value, "denied read access", fixed = TRUE)
+  expect_match(
+    external_destination@value,
+    "denied write access",
+    fixed = TRUE
+  )
+})
+
+test_that("guardrails restore bindings after success and model errors", {
+  worker <- local_guardrail_worker()
+  store <- new_handle_store()
+  outside <- withr::local_tempfile(tmpdir = dirname(tempdir()))
+  writeLines("available after restoration", outside)
+
+  sync_promise(run_r_tool(worker, store, "sum(1:10)"))
+  expect_identical(
+    worker_read_lines(worker, outside),
+    "available after restoration"
+  )
+  expect_identical(
+    worker$rs$run(
+      function(url, path) {
+        suppressWarnings(download.file(url, path, quiet = TRUE))
+        readLines(path)
+      },
+      args = list(url = paste0("file://", outside), path = tempfile())
+    ),
+    "available after restoration"
+  )
+
+  sync_promise(run_r_tool(worker, store, "stop('boom')"))
+  expect_identical(
+    worker_read_lines(worker, outside),
+    "available after restoration"
+  )
 })

--- a/pkg-r/tests/testthat/test-sandbox.R
+++ b/pkg-r/tests/testthat/test-sandbox.R
@@ -50,16 +50,17 @@ test_that("unsupported hosts require an explicit guardrail opt-in", {
 
   expect_error(
     run_r_protection_mode(capabilities, "Windows", FALSE),
-    "commons.dangerously_disable_sandbox = TRUE",
+    "commons.allow_unsafe_fallback = TRUE",
     fixed = TRUE
   )
+  withr::local_options(commons.allow_unsafe_fallback = TRUE)
   expect_identical(
-    run_r_protection_mode(capabilities, "Windows", TRUE),
+    run_r_protection_mode(capabilities, "Windows"),
     "guardrails"
   )
   capabilities$seatbelt <- TRUE
   expect_identical(
-    run_r_protection_mode(capabilities, "Darwin", TRUE),
+    run_r_protection_mode(capabilities, "Darwin"),
     "sandbox"
   )
 })

--- a/pkg-r/tests/testthat/test-sandbox.R
+++ b/pkg-r/tests/testthat/test-sandbox.R
@@ -7,7 +7,7 @@ test_that("sandbox_capabilities reports all mechanisms", {
   expect_type(caps$userns, "logical")
 })
 
-test_that("check_run_r_sandbox rejects unsupported Linux hosts", {
+test_that("run_r protection rejects unsupported Linux hosts", {
   capabilities <- list(
     landlock_abi = 0L,
     seccomp = TRUE,
@@ -16,28 +16,52 @@ test_that("check_run_r_sandbox rejects unsupported Linux hosts", {
   )
 
   expect_error(
-    check_run_r_sandbox(capabilities, "Linux"),
+    run_r_protection_mode(capabilities, "Linux"),
     "neither Landlock nor unprivileged user namespaces"
   )
   capabilities$seccomp <- FALSE
   expect_error(
-    check_run_r_sandbox(capabilities, "Linux"),
+    run_r_protection_mode(capabilities, "Linux"),
     "does not support seccomp"
   )
 })
 
-test_that("check_run_r_sandbox accepts either Linux filesystem sandbox", {
+test_that("run_r protection accepts either Linux filesystem sandbox", {
   capabilities <- list(
     landlock_abi = 1L,
     seccomp = TRUE,
     seatbelt = FALSE,
     userns = FALSE
   )
-  expect_invisible(check_run_r_sandbox(capabilities, "Linux"))
+  expect_identical(run_r_protection_mode(capabilities, "Linux"), "sandbox")
 
   capabilities$landlock_abi <- 0L
   capabilities$userns <- TRUE
-  expect_invisible(check_run_r_sandbox(capabilities, "Linux"))
+  expect_identical(run_r_protection_mode(capabilities, "Linux"), "sandbox")
+})
+
+test_that("unsupported hosts require an explicit guardrail opt-in", {
+  capabilities <- list(
+    landlock_abi = 0L,
+    seccomp = FALSE,
+    seatbelt = FALSE,
+    userns = FALSE
+  )
+
+  expect_error(
+    run_r_protection_mode(capabilities, "Windows", FALSE),
+    "commons.dangerously_disable_sandbox = TRUE",
+    fixed = TRUE
+  )
+  expect_identical(
+    run_r_protection_mode(capabilities, "Windows", TRUE),
+    "guardrails"
+  )
+  capabilities$seatbelt <- TRUE
+  expect_identical(
+    run_r_protection_mode(capabilities, "Darwin", TRUE),
+    "sandbox"
+  )
 })
 
 test_that("worker_init refuses to run unsandboxed off Linux and macOS", {
@@ -68,6 +92,18 @@ test_that("worker_init errors without the compiled library", {
     ),
     "compiled library"
   )
+})
+
+test_that("worker_init permits the explicit guardrail mode", {
+  expect_true(callr::r(
+    worker_init,
+    args = list(
+      parent_tmp = tempdir(),
+      work_dir = tempdir(),
+      dll_path = NA_character_,
+      protection = "guardrails"
+    )
+  ))
 })
 
 sandboxed_worker_probes <- function(

--- a/pkg-r/vignettes/governance.Rmd
+++ b/pkg-r/vignettes/governance.Rmd
@@ -60,9 +60,9 @@ The filesystem sandbox gives the subprocess read access to R, installed packages
 
 By default, the subprocess cannot create network sockets. An application author can opt in to unrestricted network access with `commons(network = "full")`; the filesystem sandbox remains in place, but R code can then contact services reachable from the deployment and transmit data from result handles. Only enable network access when that egress is required and acceptable.
 
-For local development on macOS, commons applies a similar filesystem and network policy using Seatbelt. Deployed Connect applications run on Linux and use the Linux mechanisms described above. Windows has no OS-level `run_r()` sandbox.
+For local development on macOS, commons applies a similar filesystem and network policy using Seatbelt. Windows has no OS-level `run_r()` sandbox. Deployed Connect applications run on Linux and use the Linux mechanisms described above.
 
-By default, commons therefore refuses to create an agent when an OS-level sandbox is not available. An application author can enable a local-development fallback explicitly:
+By default, commons refuses to create an agent when an OS-level sandbox is not available. An application author can enable a local-development fallback explicitly:
 
 ```r
 options(commons.dangerously_disable_sandbox = TRUE)

--- a/pkg-r/vignettes/governance.Rmd
+++ b/pkg-r/vignettes/governance.Rmd
@@ -62,6 +62,27 @@ By default, the subprocess cannot create network sockets. An application author 
 
 For local development on macOS, commons applies a similar filesystem and network policy using Seatbelt. Deployed Connect applications run on Linux and use the Linux mechanisms described above.
 
+Windows has no OS-level `run_r()` sandbox. By default, commons therefore
+refuses to create an agent on Windows. An application author can enable a
+local-development fallback explicitly:
+
+```r
+options(commons.dangerously_disable_sandbox = TRUE)
+```
+
+The fallback places best-effort checks around ordinary R functions while
+model-authored code evaluates. It limits filesystem reads to R, installed
+packages, and the worker directory; limits writes to the worker directory;
+denies subprocess functions; and follows the requested network policy. These
+checks reduce accidental access and damage, but native code and other R
+mechanisms can bypass them. They are not a sandbox or security boundary and
+should not be enabled in a deployment.
+
+The model-facing `run_r()` description still calls this fallback an OS-level
+sandbox. This wording encourages the model to follow the same conservative
+filesystem and network expectations on every platform; it does not describe
+the fallback's actual security properties.
+
 ### Communication with the main app process
 
 The subprocess starts with a small allowlist of environment variables rather than inheriting the application's complete environment. In particular, API keys, session tokens, and database URLs are not inherited.

--- a/pkg-r/vignettes/governance.Rmd
+++ b/pkg-r/vignettes/governance.Rmd
@@ -60,17 +60,15 @@ The filesystem sandbox gives the subprocess read access to R, installed packages
 
 By default, the subprocess cannot create network sockets. An application author can opt in to unrestricted network access with `commons(network = "full")`; the filesystem sandbox remains in place, but R code can then contact services reachable from the deployment and transmit data from result handles. Only enable network access when that egress is required and acceptable.
 
-For local development on macOS, commons applies a similar filesystem and network policy using Seatbelt. Deployed Connect applications run on Linux and use the Linux mechanisms described above.
+For local development on macOS, commons applies a similar filesystem and network policy using Seatbelt. Deployed Connect applications run on Linux and use the Linux mechanisms described above. Windows has no OS-level `run_r()` sandbox.
 
-Windows has no OS-level `run_r()` sandbox. By default, commons therefore refuses to create an agent on Windows. An application author can enable a local-development fallback explicitly:
+By default, commons therefore refuses to create an agent when an OS-level sandbox is not available. An application author can enable a local-development fallback explicitly:
 
 ```r
 options(commons.dangerously_disable_sandbox = TRUE)
 ```
 
-The fallback places best-effort checks around ordinary R functions while model-authored code evaluates. It limits filesystem reads to R, installed packages, and the worker directory; limits writes to the worker directory; denies subprocess functions; and follows the requested network policy. These checks reduce accidental access and damage, but native code and other R mechanisms can bypass them. They are not a sandbox or security boundary and should not be enabled in a deployment.
-
-The model-facing `run_r()` description still calls this fallback an OS-level sandbox. This wording encourages the model to follow the same conservative filesystem and network expectations on every platform; it does not describe the fallback's actual security properties.
+The fallback places best-effort checks around ordinary R functions while model-authored code evaluates. It limits filesystem reads to R, installed packages, and the worker directory, limits writes to the worker directory, denies subprocess functions, and follows the requested network policy. These checks reduce accidental access and damage, but native code and other R mechanisms can bypass them. They are not a sandbox or security boundary and should not be enabled in a deployment.
 
 ### Communication with the main app process
 

--- a/pkg-r/vignettes/governance.Rmd
+++ b/pkg-r/vignettes/governance.Rmd
@@ -62,26 +62,15 @@ By default, the subprocess cannot create network sockets. An application author 
 
 For local development on macOS, commons applies a similar filesystem and network policy using Seatbelt. Deployed Connect applications run on Linux and use the Linux mechanisms described above.
 
-Windows has no OS-level `run_r()` sandbox. By default, commons therefore
-refuses to create an agent on Windows. An application author can enable a
-local-development fallback explicitly:
+Windows has no OS-level `run_r()` sandbox. By default, commons therefore refuses to create an agent on Windows. An application author can enable a local-development fallback explicitly:
 
 ```r
 options(commons.dangerously_disable_sandbox = TRUE)
 ```
 
-The fallback places best-effort checks around ordinary R functions while
-model-authored code evaluates. It limits filesystem reads to R, installed
-packages, and the worker directory; limits writes to the worker directory;
-denies subprocess functions; and follows the requested network policy. These
-checks reduce accidental access and damage, but native code and other R
-mechanisms can bypass them. They are not a sandbox or security boundary and
-should not be enabled in a deployment.
+The fallback places best-effort checks around ordinary R functions while model-authored code evaluates. It limits filesystem reads to R, installed packages, and the worker directory; limits writes to the worker directory; denies subprocess functions; and follows the requested network policy. These checks reduce accidental access and damage, but native code and other R mechanisms can bypass them. They are not a sandbox or security boundary and should not be enabled in a deployment.
 
-The model-facing `run_r()` description still calls this fallback an OS-level
-sandbox. This wording encourages the model to follow the same conservative
-filesystem and network expectations on every platform; it does not describe
-the fallback's actual security properties.
+The model-facing `run_r()` description still calls this fallback an OS-level sandbox. This wording encourages the model to follow the same conservative filesystem and network expectations on every platform; it does not describe the fallback's actual security properties.
 
 ### Communication with the main app process
 

--- a/pkg-r/vignettes/governance.Rmd
+++ b/pkg-r/vignettes/governance.Rmd
@@ -65,10 +65,12 @@ For local development on macOS, commons applies a similar filesystem and network
 By default, commons refuses to create an agent when an OS-level sandbox is not available. An application author can enable a local-development fallback explicitly:
 
 ```r
-options(commons.dangerously_disable_sandbox = TRUE)
+options(commons.allow_unsafe_fallback = TRUE)
 ```
 
-The fallback places best-effort checks around ordinary R functions while model-authored code evaluates. It limits filesystem reads to R, installed packages, and the worker directory, limits writes to the worker directory, denies subprocess functions, and follows the requested network policy. These checks reduce accidental access and damage, but native code and other R mechanisms can bypass them. They are not a sandbox or security boundary and should not be enabled in a deployment.
+commons always uses OS-level sandboxing when it is available. This option cannot disable or bypass it; it only permits commons to fall back to best-effort R guardrails when no OS-level sandbox is available.
+
+The fallback places checks around ordinary R functions while model-authored code evaluates. It limits filesystem reads to R, installed packages, and the worker directory, limits writes to the worker directory, denies subprocess functions, and follows the requested network policy. These checks reduce accidental access and damage, but native code and other R mechanisms can bypass them. They are not a sandbox or security boundary and should not be enabled in a deployment.
 
 ### Communication with the main app process
 


### PR DESCRIPTION
Closes #147.

For the deployment sandboxing, we've decided that the current Landlock + fallback bubblewrap-ish mechanism is good enough. One remaining issue, though, is the local dev experience for data scientists on Windows. This PR proposes continuing to fail-closed by default, but allowing users to set `options(commons.dangerously_disable_sandbox = TRUE)` to disable the OS-level sandbox in favor of a set of RStudio-style shims around R functions.