### PR TITLE
ci: Add the Python release workflow and publishing metadata

### DIFF
--- a/.github/workflows/py-release.yaml
+++ b/.github/workflows/py-release.yaml
@@ -1,0 +1,39 @@
+name: py-release
+
+# Publishes pkg-py to PyPI via trusted publishing (OIDC); no API token is stored.
+# PyPI's publisher config for posit-commons names this file, so renaming it
+# breaks releases with an OIDC error until PyPI is updated to match.
+on:
+  push:
+    tags: ["py-v*"]
+
+permissions: read-all
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: pkg-py/uv.lock
+      - name: Build
+        working-directory: pkg-py
+        run: uv build
+      - name: Check the tag matches the built version
+        working-directory: pkg-py
+        run: |
+          expected="${GITHUB_REF_NAME#py-v}"
+          built="$(basename dist/*.whl | cut -d- -f2)"
+          if [ "$built" != "$expected" ]; then
+            echo "Tag ${GITHUB_REF_NAME} implies version ${expected}, but the wheel is ${built}." >&2
+            echo "Tags must spell the PEP 440 normalized version exactly." >&2
+            exit 1
+          fi
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: pkg-py/dist

--- a/pkg-py/LICENSE.md
+++ b/pkg-py/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2026 Posit Software, PBC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pkg-py/pyproject.toml
+++ b/pkg-py/pyproject.toml
@@ -8,6 +8,8 @@ readme = "README.md"
 # [tool.hatch.build.targets.wheel] below.
 # Upper bound tracks raghilda, which caps at <3.14 (posit-dev/raghilda#93).
 requires-python = ">=3.11,<3.14"
+license = "MIT"
+license-files = ["LICENSE.md"]
 classifiers = ["Development Status :: 2 - Pre-Alpha"]
 dependencies = [
     "chatlas>=0.21.2",
@@ -19,6 +21,10 @@ dependencies = [
     "jinja2>=3",
     "pyarrow>=17",
 ]
+
+[project.urls]
+Homepage = "https://github.com/posit-dev/commons"
+Issues = "https://github.com/posit-dev/commons/issues"
 
 [project.optional-dependencies]
 tracing = [


### PR DESCRIPTION
## Summary

Reserving `posit-commons` on PyPI needs a real release, because PyPI has no reservation mechanism and a pending trusted publisher does not hold a name either. This adds the workflow that does it: `py-release.yaml` publishes `pkg-py` on `py-v*` tags through trusted publishing. The first upload goes through a pending publisher, so no API token is ever created and none has to be revoked afterwards. That replaces the token-then-revoke sequence recorded in the tracking issue.

A guard between build and publish fails the run if the tag disagrees with the built version. PyPI does not allow re-uploading a version to correct it, so a mismatch would be permanent.

## Notes for the reviewer

The license and project URL metadata is outside the stated scope of reserving the name. It is here because `0.1.0.dev0` becomes a permanent public artifact the moment it uploads, and the current metadata declares no license at all. The license text is a per-package copy, matching what `pkg-r/` already does.

The release job has no GitHub environment gate. Anyone able to push a `py-v*` tag can publish, and tag pushes are not covered by branch protection. This was deferred rather than rejected, since adding an environment later is a one-field edit on the PyPI publisher config. Say so if you want it in place before the first release.

`pypa/gh-action-pypi-publish` is pinned to the mutable `release/v1` ref, consistent with the `@v6` pins on the existing actions in this repo.

Before any tag is pushed, the pending publisher has to exist on PyPI: project `posit-commons`, owner `posit-dev`, repository `commons`, workflow `py-release.yaml`, no environment.

Version stays at `0.1.0.dev0`. Note that a plain `pip install posit-commons` does install it, verified after publishing: resolvers only skip pre-releases when there is a stable version to prefer, and there is not one yet. The pre-release marking starts doing its job at the first stable release.

## Manual actions

I created a "pending publisher" on my account on PyPI:

<img width="1584" height="344" alt="image" src="https://github.com/user-attachments/assets/a36ee019-dc81-452c-ae7a-774591bb403c" />

Once the package is created, I'll add @simonpcouch and @cpsievert as backup owners to limit bus factor. 

## Testing

`pkg-py` checks are green (ruff, pyrefly, pytest) and `uv sync --locked` still resolves against the unchanged lockfile. Both artifacts build, `twine check` passes on each, and the wheel installs into a clean 3.11 venv with the expected name split and the new metadata present. The tag guard was exercised by hand against three tag spellings: it accepts `py-v0.1.0.dev0` and rejects `py-v0.1.0` and `py-v0.1.0-dev0`. The publish workflow itself cannot run until a tag is pushed.

Tracked locally as kata `4t9b`.

