### PR TITLE
reword user-facing tool descriptions

### DIFF
--- a/pkg-r/R/pool.R
+++ b/pkg-r/R/pool.R
@@ -140,7 +140,6 @@ call_metrics_impl <- function(
     metrics,
     dimensions,
     filters,
-    source_name,
     note = note,
     advert = advert,
     args = args
@@ -276,8 +275,7 @@ call_semantic_metrics <- function(
     handles,
     metrics,
     dimensions,
-    filters,
-    source_name
+    filters
   )
 }
 
@@ -288,7 +286,6 @@ metric_tool_result <- function(
   metrics,
   dimensions,
   filters,
-  source_name,
   note = NULL,
   advert = register_handle(handles, result),
   args = drop_nulls(list(
@@ -299,11 +296,7 @@ metric_tool_result <- function(
 ) {
   tool_result(
     paste(c(df_to_markdown(result), note, advert), collapse = "\n\n"),
-    title = sprintf(
-      "Metrics: %s%s",
-      html_escape(paste(metrics, collapse = ", ")),
-      source_label(source_name)
-    ),
+    title = "Ran a trusted calculation",
     icon = maybe_icon("shield-check"),
     markdown = sprintf("```sql\n%s\n```\n\n%s", sql, df_to_markdown(result)),
     html = measure_display_html(args, result),

--- a/pkg-r/R/run-r.R
+++ b/pkg-r/R/run-r.R
@@ -63,7 +63,7 @@ tool_run_r <- function(private) {
     ),
     name = "run_r",
     annotations = ellmer::tool_annotations(
-      title = "R code",
+      title = "Analyzing data",
       icon = maybe_icon("terminal"),
       read_only_hint = FALSE,
       open_world_hint = identical(private$worker$network, "full")
@@ -125,7 +125,7 @@ run_r_result <- function(code, res) {
   if (!is.null(res$failure)) {
     return(tool_result(
       sprintf("Error: %s", res$failure),
-      title = "Ran R code",
+      title = "Analyzed data",
       icon = maybe_icon("terminal"),
       html = run_r_html(code, list(list(type = "error", text = res$failure))),
       tag = "B",
@@ -139,7 +139,7 @@ run_r_result <- function(code, res) {
   )
   tool_result(
     run_r_value(segments),
-    title = "Ran R code",
+    title = "Analyzed data",
     icon = maybe_icon("terminal"),
     html = run_r_html(code, segments),
     tag = "B",

--- a/pkg-r/R/semantic-calculations.R
+++ b/pkg-r/R/semantic-calculations.R
@@ -189,11 +189,7 @@ call_calculation_impl <- function(
   advert <- register_handle(handles, result)
   tool_result(
     paste(c(df_to_markdown(result), advert), collapse = "\n\n"),
-    title = sprintf(
-      "Calculation: %s%s",
-      html_escape(calculation$key),
-      source_label(source_name)
-    ),
+    title = "Ran a trusted calculation",
     icon = maybe_icon("shield-check"),
     markdown = sprintf(
       "```sql\n%s\n```\n\n%s",

--- a/pkg-r/R/tools.R
+++ b/pkg-r/R/tools.R
@@ -44,7 +44,11 @@ tool_search_catalog <- function(private) {
     function(query, kinds = NULL, source = NULL) {
       src <- resolve_sql_source(private$sources, source)
       if (!catalog_searchable(src)) {
-        return("This data source does not have a searchable catalog.")
+        return(tool_result(
+          "This data source does not have a searchable catalog.",
+          title = "Searched for a trusted calculation",
+          icon = maybe_icon("search")
+        ))
       }
       results <- catalog_search(src, query, kinds)
       body <- if (length(results)) {
@@ -59,7 +63,7 @@ tool_search_catalog <- function(private) {
       }
       tool_result(
         body,
-        title = "Searched the data catalog",
+        title = "Searched for a trusted calculation",
         icon = maybe_icon("search"),
         markdown = body
       )
@@ -79,7 +83,7 @@ tool_search_catalog <- function(private) {
     ),
     name = "search_catalog",
     annotations = ellmer::tool_annotations(
-      title = "Search the data catalog",
+      title = "Searching for a trusted calculation",
       icon = maybe_icon("search"),
       read_only_hint = TRUE
     )
@@ -142,7 +146,7 @@ tool_search_pool <- function(private) {
       )
       tool_result(
         body,
-        title = "Searched the semantic layer",
+        title = "Searched for a trusted calculation",
         icon = maybe_icon("search")
       )
     },
@@ -166,7 +170,7 @@ tool_search_pool <- function(private) {
     ),
     name = "search_pool",
     annotations = ellmer::tool_annotations(
-      title = "Search the semantic layer",
+      title = "Searching for a trusted calculation",
       icon = maybe_icon("search"),
       read_only_hint = TRUE
     )
@@ -256,7 +260,7 @@ tool_call_metrics <- function(private) {
     ),
     name = "call_metrics",
     annotations = ellmer::tool_annotations(
-      title = "Metrics",
+      title = "Running a trusted calculation",
       icon = maybe_icon("shield-check"),
       read_only_hint = TRUE
     )
@@ -294,7 +298,7 @@ tool_call_calculation <- function(private) {
     ),
     name = "call_calculation",
     annotations = ellmer::tool_annotations(
-      title = "Trusted query",
+      title = "Running a trusted calculation",
       icon = maybe_icon("shield-check"),
       read_only_hint = TRUE
     )
@@ -331,7 +335,7 @@ tool_call_measure <- function(private) {
     ),
     name = "call_measure",
     annotations = ellmer::tool_annotations(
-      title = "Measure",
+      title = "Running a trusted calculation",
       icon = maybe_icon("shield-check"),
       read_only_hint = TRUE
     )
@@ -343,7 +347,12 @@ tool_search_context <- function(private) {
     function(query) {
       result <- search_context_tool(private$context_layer, query)
       if (!S7::S7_inherits(result, ellmer::ContentToolResult)) {
-        return(result)
+        return(tool_result(
+          result,
+          title = "Searched context",
+          icon = maybe_icon("book"),
+          markdown = result
+        ))
       }
       add_citation_request(result, private$citation_request)
     },
@@ -355,7 +364,7 @@ tool_search_context <- function(private) {
     ),
     name = "search_context",
     annotations = ellmer::tool_annotations(
-      title = "Search context",
+      title = "Searching context",
       icon = maybe_icon("book"),
       read_only_hint = TRUE
     )
@@ -398,7 +407,7 @@ tool_describe_table <- function(private) {
     ),
     name = "describe_table",
     annotations = ellmer::tool_annotations(
-      title = "Describe table",
+      title = "Inspecting a table",
       icon = maybe_icon("table"),
       read_only_hint = TRUE
     )
@@ -434,7 +443,7 @@ tool_run_sql <- function(private) {
     ),
     name = "run_sql",
     annotations = ellmer::tool_annotations(
-      title = "SQL",
+      title = "Retrieving data",
       icon = maybe_icon("code-square"),
       read_only_hint = TRUE
     )
@@ -495,7 +504,7 @@ call_measure_tool <- function(
   }
   value <- do.call(td, c(args, injections[[name]]))
   if (S7::S7_inherits(value, ellmer::ContentToolResult)) {
-    return(measure_content_tool_result(td, value, handles))
+    return(measure_content_tool_result(value, handles))
   }
   value <- collect_lazy_table(value)
   if (is_ggplot(value)) {
@@ -505,12 +514,12 @@ call_measure_tool <- function(
   if (is_gt_table(value)) {
     data <- recover_gt_table_data(value)
     advert <- register_handle(handles, data)
-    return(measure_gt_table_tool_result(td, args, value, data, advert))
+    return(measure_gt_table_tool_result(args, value, data, advert))
   }
   advert <- register_handle(handles, value)
   tool_result(
     paste(c(format_measure_value(value), advert), collapse = "\n\n"),
-    title = sprintf("Measure: %s", html_escape(tool_title(td))),
+    title = "Ran a trusted calculation",
     icon = maybe_icon("shield-check"),
     html = measure_display_html(args, value),
     tag = "A",
@@ -518,7 +527,7 @@ call_measure_tool <- function(
   )
 }
 
-measure_content_tool_result <- function(td, result, handles) {
+measure_content_tool_result <- function(result, handles) {
   data <- result@extra$data
   result@extra$data <- NULL
   display <- result@extra$display
@@ -535,7 +544,7 @@ measure_content_tool_result <- function(td, result, handles) {
     }
   }
 
-  title <- sprintf("Measure: %s", tool_title(td))
+  title <- "Ran a trusted calculation"
   icon <- maybe_icon("shield-check")
   if (is.null(display)) {
     display <- shinychat::tool_result_display(title = title, icon = icon)
@@ -599,7 +608,6 @@ measure_plot_tool_result <- function(td, args, value, advert) {
     return(measure_failure_result(
       args,
       advert,
-      title,
       conditionMessage(rendered),
       "a plot",
       "commons-measure-plot-error"
@@ -615,7 +623,7 @@ measure_plot_tool_result <- function(td, args, value, advert) {
   }
   tool_result(
     model_value,
-    title = sprintf("Measure: %s", html_escape(title)),
+    title = "Ran a trusted calculation",
     icon = maybe_icon("shield-check"),
     html = measure_display_with_result_html(
       args,
@@ -630,7 +638,6 @@ measure_plot_tool_result <- function(td, args, value, advert) {
 measure_failure_result <- function(
   args,
   advert,
-  title,
   message,
   result_type,
   class,
@@ -643,7 +650,7 @@ measure_failure_result <- function(
   )
   tool_result(
     paste(c(model_content, note, advert), collapse = "\n\n"),
-    title = sprintf("Measure: %s", html_escape(title)),
+    title = "Ran a trusted calculation",
     icon = maybe_icon("shield-check"),
     html = measure_display_with_result_html(
       args,
@@ -655,8 +662,7 @@ measure_failure_result <- function(
   )
 }
 
-measure_gt_table_tool_result <- function(td, args, value, data, advert) {
-  title <- tool_title(td)
+measure_gt_table_tool_result <- function(args, value, data, advert) {
   rendered <- tryCatch(
     render_gt_table(value),
     error = function(error) error
@@ -666,7 +672,6 @@ measure_gt_table_tool_result <- function(td, args, value, data, advert) {
     return(measure_failure_result(
       args,
       advert,
-      title,
       conditionMessage(rendered),
       "a gt table",
       "commons-measure-gt-table-error",
@@ -699,7 +704,7 @@ measure_gt_table_tool_result <- function(td, args, value, data, advert) {
       c(model_note, model_content, advert),
       collapse = "\n\n"
     ),
-    title = sprintf("Measure: %s", html_escape(title)),
+    title = "Ran a trusted calculation",
     icon = maybe_icon("shield-check"),
     html = display_html,
     tag = "A",
@@ -737,7 +742,7 @@ describe_table_tool <- function(
     body <- semantic_model_description_text(d)
     return(tool_result(
       body,
-      title = sprintf("Described %s%s", table, source_label(source_name)),
+      title = "Inspected a table",
       icon = maybe_icon("table"),
       markdown = body
     ))
@@ -782,7 +787,7 @@ describe_table_tool <- function(
   body <- paste(parts, collapse = "\n\n")
   tool_result(
     body,
-    title = sprintf("Described %s%s", table, source_label(source_name)),
+    title = "Inspected a table",
     icon = maybe_icon("table"),
     markdown = body
   )
@@ -804,7 +809,7 @@ run_sql_tool <- function(
   entries <- dictionary_sql_entries(source, sql, source_name, tracker)
   tool_result(
     paste(c(body, note, advert, entries), collapse = "\n\n"),
-    title = sprintf("Ran SQL%s", source_label(source_name)),
+    title = "Retrieved data",
     icon = maybe_icon("code-square"),
     markdown = display_md,
     tag = "B",
@@ -902,13 +907,6 @@ mark_table_touched <- function(tracker, source_name, table) {
 
 touch_key <- function(source_name, table) {
   paste(source_name %||% "", table, sep = "\n")
-}
-
-source_label <- function(source_name) {
-  if (is.null(source_name)) {
-    return("")
-  }
-  sprintf(" (%s)", html_escape(source_name))
 }
 
 tool_result <- function(

--- a/pkg-r/tests/testthat/test-calculations.R
+++ b/pkg-r/tests/testthat/test-calculations.R
@@ -108,6 +108,7 @@ test_that("trusted calculation execution is tagged after DBI binding", {
 
   expect_equal(get_handle(handles, "r1")$bound_value, 2)
   expect_equal(result@extra$commons_tag, "A")
+  expect_equal(result@extra$display$title, "Ran a trusted calculation")
 })
 
 test_that("trusted calculations are searchable and earn their tools", {

--- a/pkg-r/tests/testthat/test-commons.R
+++ b/pkg-r/tests/testthat/test-commons.R
@@ -76,6 +76,12 @@ test_that("run_r describes which results are visible to the user", {
   expect_match(description, "user cannot run code in this session")
 })
 
+test_that("search_context uses a completed title without a context layer", {
+  result <- agent_tool(test_agent(), "search_context")("anything")
+
+  expect_equal(result@extra$display$title, "Searched context")
+})
+
 test_that("call_measure describes how to handle visible results", {
   agent <- test_agent(
     semantic_layer = semantic_layer(count_measure_tool())
@@ -262,7 +268,6 @@ test_that("run_sql and describe_table route to the named source", {
   describe <- agent_tool(agent, "describe_table")
   res <- describe("orders", source = "b")
   expect_match(res@value, "integer")
-  expect_match(S7::prop(res, "extra")$display$title, "(b)", fixed = TRUE)
 })
 
 test_that("run_sql delivers one citation reminder per user turn", {

--- a/pkg-r/tests/testthat/test-run-r.R
+++ b/pkg-r/tests/testthat/test-run-r.R
@@ -178,6 +178,7 @@ test_that("run_r displays worker failures directly and escapes their HTML", {
   res <- run_r_result("x <- '<unsafe>'", list(failure = "worker <broke>"))
 
   expect_match(res@value, "Error: worker <broke>", fixed = TRUE)
+  expect_equal(res@extra$display$title, "Analyzed data")
   expect_false(res@extra$display$open)
   expect_match(res@extra$display$html, "&#39;&lt;unsafe&gt;&#39;", fixed = TRUE)
   expect_match(res@extra$display$html, "#&gt; worker &lt;broke&gt;", fixed = TRUE)

--- a/pkg-r/tests/testthat/test-semantic-models.R
+++ b/pkg-r/tests/testthat/test-semantic-models.R
@@ -260,6 +260,7 @@ test_that("lazy semantic metrics hydrate from qualified names", {
 
   expect_match(query, "FROM SEMANTIC_VIEW", fixed = TRUE)
   expect_equal(result@extra$commons_tag, "A")
+  expect_equal(result@extra$display$title, "Ran a trusted calculation")
 })
 
 test_that("semantic stubs earn fixed execution tools", {

--- a/pkg-r/tests/testthat/test-tools.R
+++ b/pkg-r/tests/testthat/test-tools.R
@@ -12,7 +12,7 @@ test_that("call_measure_tool runs a measure and tags the result", {
   expect_s7_class(res, ellmer::ContentToolResult)
   expect_equal(res@value, "2")
   expect_equal(res@extra$commons_tag, "A")
-  expect_equal(res@extra$display$title, "Measure: order count")
+  expect_equal(res@extra$display$title, "Ran a trusted calculation")
   expect_false(res@extra$display$show_request)
   expect_match(res@extra$display$html, "Region:")
   expect_match(res@extra$display$html, "EMEA")
@@ -22,7 +22,7 @@ test_that("call_measure_tool runs a measure and tags the result", {
   expect_match(res@extra$display$html, "2")
 })
 
-test_that("call_measure_tool uses measure display titles", {
+test_that("call_measure_tool uses the trusted calculation result title", {
   registry <- list(
     order_count = measure(
       "order_count",
@@ -34,7 +34,7 @@ test_that("call_measure_tool uses measure display titles", {
 
   res <- call_measure_tool(registry, "order_count", "{}")
 
-  expect_equal(res@extra$display$title, "Measure: Order count")
+  expect_equal(res@extra$display$title, "Ran a trusted calculation")
   expect_match(res@extra$display$html, "No arguments")
 })
 
@@ -116,7 +116,7 @@ test_that("call_measure_tool supports custom ContentToolResult values", {
   expect_identical(res@extra$display$open, TRUE)
   expect_identical(
     res@extra$display$title,
-    "Measure: Adverse events & outcomes"
+    "Ran a trusted calculation"
   )
   expect_equal(res@extra$commons_tag, "A")
 })
@@ -150,7 +150,7 @@ test_that("call_measure_tool preserves image content in ContentToolResult", {
   )
   expect_identical(get_handle(store, "r1"), data)
   expect_null(res@extra$data)
-  expect_identical(res@extra$display$title, "Measure: image")
+  expect_identical(res@extra$display$title, "Ran a trusted calculation")
 })
 
 test_that("call_measure_tool preserves custom ContentToolResult errors", {
@@ -320,7 +320,7 @@ test_that("run_sql_tool runs SQL and tags the result", {
   expect_s7_class(res, ellmer::ContentToolResult)
   expect_match(res@value, "6")
   expect_equal(res@extra$commons_tag, "B")
-  expect_equal(res@extra$display$title, "Ran SQL")
+  expect_equal(res@extra$display$title, "Retrieved data")
   expect_false(res@extra$display$open)
   expect_false(res@extra$display$show_request)
   expect_match(res@extra$display$markdown, "```sql")
@@ -353,6 +353,7 @@ test_that("format_measure_value collects a lazy dbplyr table", {
 
 test_that("describe_table_tool reports columns and samples", {
   res <- describe_table_tool(test_source(), "sales")
+  expect_equal(res@extra$display$title, "Inspected a table")
   expect_match(res@value, "order_id")
   expect_match(res@value, "Sample summary")
   expect_match(


### PR DESCRIPTION
Closes #77.

# Tool titles

| Tool | Previous | Now (with two different tenses) |
|---|---|---|
| Catalog search | Search the data catalog | Searching for a trusted calculation |
| Semantic search | Search the semantic layer | Searching for a trusted calculation |
| Metrics | Metrics | Running a trusted calculation |
| Calculation | Trusted query | Running a trusted calculation |
| Measure | Measure | Running a trusted calculation |
| Context search | Search context | Searching context |
| Table description | Describe table | Inspecting a table |
| SQL | SQL | Retrieving data |
| R | R code | Analyzing data |


> https://github.com/user-attachments/assets/a72ab227-957a-4831-a897-254f1f682f8f

