### PR TITLE
cap run_r worker memory

### DIFF
--- a/pkg-r/R/run-r.R
+++ b/pkg-r/R/run-r.R
@@ -927,6 +927,7 @@ worker_init <- function(
     sym,
     read_roots,
     write_roots,
+    # 8 GiB leaves ample headroom for light R; a lower Connect limit still applies.
     8 * 1024^3,
     sandbox_mode,
     preserve_fds,

--- a/pkg-r/R/run-r.R
+++ b/pkg-r/R/run-r.R
@@ -927,7 +927,7 @@ worker_init <- function(
     sym,
     read_roots,
     write_roots,
-    NULL,
+    8 * 1024^3,
     sandbox_mode,
     preserve_fds,
     network

--- a/pkg-r/src/sandbox.c
+++ b/pkg-r/src/sandbox.c
@@ -674,6 +674,16 @@ SEXP c_sandbox_engage(SEXP read_roots, SEXP rw_roots, SEXP memory_limit,
 
   if (memory_limit != R_NilValue) {
     rlim_t bytes = (rlim_t) REAL(memory_limit)[0];
+    struct rlimit inherited;
+    if (getrlimit(RLIMIT_AS, &inherited) != 0) {
+      Rf_error("getrlimit(RLIMIT_AS) failed: %s", strerror(errno));
+    }
+    if (inherited.rlim_cur != RLIM_INFINITY && inherited.rlim_cur < bytes) {
+      bytes = inherited.rlim_cur;
+    }
+    if (inherited.rlim_max != RLIM_INFINITY && inherited.rlim_max < bytes) {
+      bytes = inherited.rlim_max;
+    }
     struct rlimit lim = { .rlim_cur = bytes, .rlim_max = bytes };
     if (setrlimit(RLIMIT_AS, &lim) != 0) {
       Rf_error("setrlimit(RLIMIT_AS) failed: %s", strerror(errno));
@@ -778,11 +788,20 @@ SEXP c_sandbox_engage(SEXP read_roots, SEXP rw_roots, SEXP memory_limit,
   }
 
   if (memory_limit != R_NilValue) {
-    /* Accepted but not reliably enforced by the macOS kernel; kept for
-     * interface parity with the Linux branch. */
+    /* RLIMIT_AS is unavailable on some macOS versions. */
     rlim_t bytes = (rlim_t) REAL(memory_limit)[0];
+    struct rlimit inherited;
+    if (getrlimit(RLIMIT_AS, &inherited) != 0) {
+      Rf_error("getrlimit(RLIMIT_AS) failed: %s", strerror(errno));
+    }
+    if (inherited.rlim_cur != RLIM_INFINITY && inherited.rlim_cur < bytes) {
+      bytes = inherited.rlim_cur;
+    }
+    if (inherited.rlim_max != RLIM_INFINITY && inherited.rlim_max < bytes) {
+      bytes = inherited.rlim_max;
+    }
     struct rlimit lim = { .rlim_cur = bytes, .rlim_max = bytes };
-    if (setrlimit(RLIMIT_AS, &lim) != 0) {
+    if (setrlimit(RLIMIT_AS, &lim) != 0 && errno != EINVAL) {
       Rf_error("setrlimit(RLIMIT_AS) failed: %s", strerror(errno));
     }
   }

--- a/pkg-r/tests/testthat/test-sandbox.R
+++ b/pkg-r/tests/testthat/test-sandbox.R
@@ -208,11 +208,13 @@ sandboxed_worker_probes <- function(
           }
           status
         }),
-        address_space = as.double(system2(
-          "/bin/sh",
-          c("-c", shQuote("ulimit -v")),
-          stdout = TRUE
-        )),
+        address_space = if (identical(Sys.info()[["sysname"]], "Linux")) {
+          as.double(system2(
+            "/bin/sh",
+            c("-c", shQuote("ulimit -v")),
+            stdout = TRUE
+          ))
+        },
         compute = sum(1:10)
       )
     },

--- a/pkg-r/tests/testthat/test-sandbox.R
+++ b/pkg-r/tests/testthat/test-sandbox.R
@@ -208,6 +208,11 @@ sandboxed_worker_probes <- function(
           }
           status
         }),
+        address_space = as.double(system2(
+          "/bin/sh",
+          c("-c", shQuote("ulimit -v")),
+          stdout = TRUE
+        )),
         compute = sum(1:10)
       )
     },
@@ -232,6 +237,7 @@ test_that("an initialized worker is denied reads, writes, and sockets", {
   expect_equal(probes$subprocess, "denied")
   if (identical(Sys.info()[["sysname"]], "Linux")) {
     expect_equal(probes$exec, "allowed")
+    expect_lte(probes$address_space, 8 * 1024^2)
   }
   expect_equal(probes$compute, 55)
 })

--- a/pkg-r/vignettes/governance.Rmd
+++ b/pkg-r/vignettes/governance.Rmd
@@ -56,7 +56,7 @@ The code requested through `run_r()` does not run in the main application proces
 
 On Linux (which underlies [Posit Connect](https://posit.co/products/enterprise/connect)), commons combines a filesystem sandbox with seccomp system-call filters. It uses Landlock when the kernel supports it and otherwise falls back to unprivileged user and mount namespaces. If neither filesystem mechanism is available, or if seccomp is unavailable, commons refuses to create an agent.
 
-The filesystem sandbox gives the subprocess read access to R, installed packages, and required operating-system directories. It can write only to temporary directories used by the subprocess and its communication with the main R process. The seccomp filters prevent it from inspecting another process's memory or changing mount and namespace configuration.
+The filesystem sandbox gives the subprocess read access to R, installed packages, and required operating-system directories. It can write only to temporary directories used by the subprocess and its communication with the main R process. The seccomp filters prevent it from inspecting another process's memory or changing mount and namespace configuration. The Linux sandbox also caps the subprocess's virtual address space at 8 GiB; a lower limit inherited from Connect still applies.
 
 By default, the subprocess cannot create network sockets. An application author can opt in to unrestricted network access with `commons(network = "full")`; the filesystem sandbox remains in place, but R code can then contact services reachable from the deployment and transmit data from result handles. Only enable network access when that egress is required and acceptable.
 


### PR DESCRIPTION
Does not enforce any sort of subprocess limit for now. On that front, Connect gets us a good bit of the way there, and we don't have permissions to configure the worker cgroup limit.