### PR TITLE
load dev commons in example `app.R`

### DIFF
--- a/pkg-r/inst/app.R
+++ b/pkg-r/inst/app.R
@@ -1,5 +1,9 @@
 library(bslib)
-library(commons)
+if (interactive()) {
+  devtools::load_all("./pkg-r")
+} else {
+  library(commons)
+}
 library(shiny)
 library(shinychat)
 


### PR DESCRIPTION
This is a change that I keep making locally, done in a way that should preserve the Connect deployment just fine.