### PR TITLE
enable agent to install packages in tempdir 

### DIFF
--- a/pkg-r/R/run-r.R
+++ b/pkg-r/R/run-r.R
@@ -53,11 +53,10 @@ tool_run_r <- function(private) {
       "\n- Do not use this tool to talk to the user; explanations belong in your reply.",
       "\n- Return results implicitly (`x`, not `print(x)`) and prefer brief",
       "summaries (head(), summary()) over large outputs.",
+      "\n- The session can only write to its own temporary directory.",
       if (identical(private$worker$network, "none")) {
         "\n- The session has no network access."
-      },
-      "\n- The session can only write to its own temporary directory.",
-      if (identical(private$worker$network, "full")) {
+      } else {
         paste(
           "\n- The temporary directory has been added to libPaths, so you",
           "can use install.packages() normally."

--- a/pkg-r/R/run-r.R
+++ b/pkg-r/R/run-r.R
@@ -55,13 +55,14 @@ tool_run_r <- function(private) {
       "summaries (head(), summary()) over large outputs.",
       if (identical(private$worker$network, "none")) {
         "\n- The session has no network access."
-      } else {
+      },
+      "\n- The session can only write to its own temporary directory.",
+      if (identical(private$worker$network, "full")) {
         paste(
           "\n- The temporary directory has been added to libPaths, so you",
           "can use install.packages() normally."
         )
-      },
-      "\n- The session can only write to its own temporary directory."
+      }
     ),
     arguments = list(
       code = ellmer::type_string("The R code to run.")

--- a/pkg-r/R/run-r.R
+++ b/pkg-r/R/run-r.R
@@ -56,7 +56,10 @@ tool_run_r <- function(private) {
       if (identical(private$worker$network, "none")) {
         "\n- The session has no network access."
       } else {
-        "\n- You can install R packages with install.packages()."
+        paste(
+          "\n- The temporary directory has been added to libPaths, so you",
+          "can use install.packages() normally."
+        )
       },
       "\n- The session can only write to its own temporary directory."
     ),

--- a/pkg-r/R/run-r.R
+++ b/pkg-r/R/run-r.R
@@ -55,6 +55,8 @@ tool_run_r <- function(private) {
       "summaries (head(), summary()) over large outputs.",
       if (identical(private$worker$network, "none")) {
         "\n- The session has no network access."
+      } else {
+        "\n- You can install R packages with install.packages()."
       },
       "\n- The session can only write to its own temporary directory."
     ),
@@ -856,6 +858,9 @@ worker_init <- function(
 ) {
   setwd(work_dir)
   options(width = 80, cli.num_colors = 1)
+  worker_lib <- file.path(work_dir, "library")
+  dir.create(worker_lib)
+  .libPaths(c(worker_lib, .libPaths()))
   if (!protection %in% c("sandbox", "guardrails")) {
     stop("unknown run_r protection mode: ", protection)
   }

--- a/pkg-r/tests/testthat/test-run-r.R
+++ b/pkg-r/tests/testthat/test-run-r.R
@@ -53,6 +53,19 @@ test_that("run_r session state persists across calls, and handles sync lazily", 
   expect_match(res@value, "48")
 })
 
+test_that("run_r prepends a worker-local package library", {
+  worker <- local_guardrail_worker()
+  worker_ensure(worker)
+
+  paths <- worker$rs$run(function() {
+    list(libraries = .libPaths(), bit64 = find.package("bit64"))
+  })
+
+  expect_equal(basename(paths$libraries[[1]]), "library")
+  expect_true(dir.exists(paths$libraries[[1]]))
+  expect_false(startsWith(paths$bit64, paths$libraries[[1]]))
+})
+
 test_that("run_r loads integer64 methods for stored handles", {
   skip_if_not_installed("bit64")
   worker <- local_worker()


### PR DESCRIPTION
Closes #182. Appends the tempdir to lib paths so that the sandbox policy doesn't have to change.

Appended regardless, but only relevant for the `network = "full"` case.