### PR TITLE
Syntax-highlight run_r code

### DIFF
--- a/pkg-r/DESCRIPTION
+++ b/pkg-r/DESCRIPTION
@@ -26,6 +26,7 @@ Imports:
     ellmer (>= 0.4.1),
     evaluate,
     glue,
+    highr,
     htmltools,
     httr2 (>= 1.1.0),
     jsonlite,

--- a/pkg-r/R/run-r.R
+++ b/pkg-r/R/run-r.R
@@ -236,7 +236,7 @@ run_r_html <- function(code, segments) {
   }
   code_html <- sprintf(
     "<pre class=\"commons-run-r-code\"><code class=\"language-r\">%s</code></pre>",
-    html_escape(paste(c(code, output), collapse = "\n"))
+    highlight_r_html(paste(c(code, output), collapse = "\n"))
   )
   if (length(plot_html)) {
     code_html <- paste0(
@@ -249,6 +249,17 @@ run_r_html <- function(code, segments) {
     "<div class=\"commons-run-r-display\">%s</div>",
     paste(c(code_html, plot_html), collapse = "\n")
   )
+}
+
+highlight_r_html <- function(code) {
+  fallback <- tryCatch(
+    {
+      parse(text = code)
+      FALSE
+    },
+    error = function(...) TRUE
+  )
+  paste(highr::hi_html(code, fallback = fallback), collapse = "\n")
 }
 
 # --- worker lifecycle --------------------------------------------------------

--- a/pkg-r/inst/www/commons-chat/commons-chat.css
+++ b/pkg-r/inst/www/commons-chat/commons-chat.css
@@ -379,6 +379,49 @@ shiny-chat-container
   white-space: pre;
 }
 
+.commons-run-r-code .hl.com {
+  color: #a0a1a7;
+  font-style: italic;
+}
+
+.commons-run-r-code .hl.kwa {
+  color: #a626a4;
+}
+
+.commons-run-r-code .hl.kwc,
+.commons-run-r-code .hl.num {
+  color: #986801;
+}
+
+.commons-run-r-code .hl.kwd {
+  color: #4078f2;
+}
+
+.commons-run-r-code .hl.sng {
+  color: #50a14f;
+}
+
+[data-bs-theme="dark"] .commons-run-r-code .hl.com {
+  color: #5c6370;
+}
+
+[data-bs-theme="dark"] .commons-run-r-code .hl.kwa {
+  color: #c678dd;
+}
+
+[data-bs-theme="dark"] .commons-run-r-code .hl.kwc,
+[data-bs-theme="dark"] .commons-run-r-code .hl.num {
+  color: #d19a66;
+}
+
+[data-bs-theme="dark"] .commons-run-r-code .hl.kwd {
+  color: #61aeee;
+}
+
+[data-bs-theme="dark"] .commons-run-r-code .hl.sng {
+  color: #98c379;
+}
+
 .commons-run-r-details > .commons-run-r-code {
   margin-top: 0.4rem;
 }

--- a/pkg-r/inst/www/commons-chat/commons-chat.css
+++ b/pkg-r/inst/www/commons-chat/commons-chat.css
@@ -373,7 +373,7 @@ shiny-chat-container
   text-transform: uppercase;
 }
 
-.commons-run-r-code {
+.commons-run-r-display .commons-run-r-code {
   margin: 0;
   overflow-x: auto;
   white-space: pre;

--- a/pkg-r/tests/testthat/test-run-r.R
+++ b/pkg-r/tests/testthat/test-run-r.R
@@ -33,6 +33,16 @@ test_that("run_r executes code against stored handles", {
     '<pre class="commons-run-r-code"><code class="language-r">',
     fixed = TRUE
   )
+  expect_match(
+    res@extra$display$html,
+    '<span class="hl kwd">sum</span>',
+    fixed = TRUE
+  )
+  expect_match(
+    res@extra$display$html,
+    '<span class="hl com">#&gt; [1] 5650</span>',
+    fixed = TRUE
+  )
   expect_match(res@extra$display$html, "#&gt; [1] 5650", fixed = TRUE)
   expect_no_match(res@extra$display$html, "<details", fixed = TRUE)
   expect_no_match(
@@ -181,10 +191,28 @@ test_that("run_r displays code directly when it produces no output", {
 
   expect_match(res@value, "produced no output", fixed = TRUE)
   expect_false(res@extra$display$open)
-  expect_match(res@extra$display$html, "x &lt;- 1", fixed = TRUE)
+  expect_match(
+    res@extra$display$html,
+    '<span class="hl def">x</span>',
+    fixed = TRUE
+  )
+  expect_match(
+    res@extra$display$html,
+    '<span class="hl num">1</span>',
+    fixed = TRUE
+  )
   expect_match(res@extra$display$html, "commons-run-r-code", fixed = TRUE)
   expect_no_match(res@extra$display$html, "#&gt;", fixed = TRUE)
   expect_no_match(res@extra$display$html, "<details", fixed = TRUE)
+})
+
+test_that("run_r highlights malformed code without exposing HTML", {
+  expect_no_warning(
+    html <- run_r_html("x <- '<unsafe>' +", list())
+  )
+
+  expect_match(html, "'&lt;unsafe&gt;'", fixed = TRUE)
+  expect_no_match(html, "<unsafe>", fixed = TRUE)
 })
 
 test_that("run_r displays worker failures directly and escapes their HTML", {
@@ -193,7 +221,7 @@ test_that("run_r displays worker failures directly and escapes their HTML", {
   expect_match(res@value, "Error: worker <broke>", fixed = TRUE)
   expect_equal(res@extra$display$title, "Analyzed data")
   expect_false(res@extra$display$open)
-  expect_match(res@extra$display$html, "&#39;&lt;unsafe&gt;&#39;", fixed = TRUE)
+  expect_match(res@extra$display$html, "'&lt;unsafe&gt;'", fixed = TRUE)
   expect_match(res@extra$display$html, "#&gt; worker &lt;broke&gt;", fixed = TRUE)
   expect_match(res@extra$display$html, "commons-run-r-code", fixed = TRUE)
   expect_no_match(res@extra$display$html, "<details", fixed = TRUE)


### PR DESCRIPTION
Closes #185. Kinda looks fire:

With a plot:

> <img height="296" alt="Screenshot 2026-08-27 at 4 03 25 PM" src="https://github.com/user-attachments/assets/1f250e2d-654f-4ebe-9954-3f80a0e412c2" />

A table:

> <img height="139" alt="Screenshot 2026-08-27 at 4 03 55 PM" src="https://github.com/user-attachments/assets/a561b88b-a342-497c-b668-436fc95df552" />

We now scroll horizontally rather than wrapping when there's not enough space:

> <img height="139" alt="Screenshot 2026-08-27 at 4 04 00 PM" src="https://github.com/user-attachments/assets/79d95f4b-e8d6-4cf4-9d27-39d5cfe9ccd3" />
