### PR TITLE
validate the sandbox native call

### DIFF
--- a/pkg-r/R/run-r.R
+++ b/pkg-r/R/run-r.R
@@ -945,9 +945,8 @@ worker_init <- function(
     callr_data[[".__stdout__"]],
     callr_data[[".__stderr__"]]
   )
-  sym <- getNativeSymbolInfo("c_sandbox_engage", PACKAGE = "commons")
   .Call(
-    sym,
+    getNativeSymbolInfo("c_sandbox_engage", PACKAGE = "commons"),
     read_roots,
     write_roots,
     # 8 GiB leaves ample headroom for light R; a lower Connect limit still applies.


### PR DESCRIPTION
Related to #210 but does not close.

Addresses:

```
❯ checking foreign function calls ... NOTE
  Registration problem:
    symbol ‘sym’ in the local frame:
     .Call(sym, read_roots, write_roots, 8 * 1024^3, sandbox_mode, 
         preserve_fds, network)
  See chapter ‘System and foreign language interfaces’ in the ‘Writing R
  Extensions’ manual.
```