### PR TITLE
isolate the R worker runtime

### DIFF
--- a/pkg-r/R/run-r.R
+++ b/pkg-r/R/run-r.R
@@ -98,12 +98,17 @@ run_r_tool <- function(worker, handles, code, fn_sources = character()) {
         # callr rebinds a transferred function's environment to the worker's
         # global env, so the entry point must be namespace-qualified.
         worker$rs$call(
-          worker_run_code,
+          worker_call,
           args = list(
-            code = code,
-            new_handles = new_handles,
-            plot_width = dims$width,
-            plot_height = dims$height
+            name = "worker_run_code",
+            args = list(
+              code = code,
+              new_handles = new_handles,
+              plot_width = dims$width,
+              plot_height = dims$height,
+              evaluate = evaluate::evaluate,
+              new_output_handler = evaluate::new_output_handler
+            )
           )
         )
         worker$synced <- length(ids)
@@ -296,32 +301,42 @@ worker_ensure <- function(worker, fn_sources = character()) {
     ),
     wait = TRUE
   )
-  # callr rebinds a transferred function's environment to the worker's global
-  # env, and the worker starts with a scrubbed, minimal package set, so the
-  # worker entry points are self-contained (no commons internals by name). The
-  # sandbox is reached by loading commons's compiled library by path, which
-  # works whether commons is installed or loaded via load_all().
+  # Source the worker runtime before engaging the sandbox so load_all() paths
+  # outside the worker's read roots work. No user-provided code runs until the
+  # sandbox is active.
   rs$run(
-    worker_init,
+    worker_bootstrap,
     args = list(
-      parent_tmp = tempdir(),
-      work_dir = work_dir,
-      dll_path = commons_dll_path(),
-      network = worker$network,
-      protection = worker$protection
+      path = worker_script_path(),
+      args = list(
+        parent_tmp = tempdir(),
+        work_dir = work_dir,
+        dll_path = commons_dll_path(),
+        network = worker$network,
+        protection = worker$protection
+      )
     )
   )
   if (identical(worker$protection, "guardrails")) {
     # Build hooks in the worker so their captured functions stay worker-local.
     rs$run(
-      worker_guardrails,
-      args = list(work_dir = work_dir, network = worker$network)
+      worker_call,
+      args = list(
+        name = "worker_guardrails",
+        args = list(work_dir = work_dir, network = worker$network)
+      )
     )
   }
   # Defining sources at spawn (rather than syncing per call like handles)
   # means a respawned worker gets them again for free.
   if (length(fn_sources)) {
-    rs$run(worker_define_functions, args = list(fn_sources = fn_sources))
+    rs$run(
+      worker_call,
+      args = list(
+        name = "worker_define_functions",
+        args = list(fn_sources = fn_sources)
+      )
+    )
   }
   worker$rs <- rs
   worker$synced <- 0L
@@ -388,374 +403,17 @@ worker_scrubbed_env <- function(work_dir, single_thread = FALSE) {
   env
 }
 
-worker_guardrails <- function(work_dir, network = "none") {
-  normalize <- base::normalizePath
-  file_exists <- base::file.exists
-  dir_exists <- base::dir.exists
-  path_exists <- function(path) {
-    file_exists(path) || dir_exists(path)
-  }
-  canonical_path <- function(path) {
-    path <- path.expand(path)
-    if (!grepl("^([A-Za-z]:[/\\\\]|[/\\\\]{1,2})", path)) {
-      path <- file.path(getwd(), path)
-    }
-    suffix <- character()
-    # Resolving an existing ancestor exposes symlinks beneath nonexistent paths.
-    while (!path_exists(path) && !identical(dirname(path), path)) {
-      suffix <- c(basename(path), suffix)
-      path <- dirname(path)
-    }
-    path <- normalize(path, winslash = "/", mustWork = FALSE)
-    if (length(suffix)) {
-      path <- do.call(file.path, as.list(c(path, suffix)))
-    }
-    if (nchar(path) > 1L && !grepl("^[A-Za-z]:/$", path)) {
-      path <- sub("/+$", "", path)
-    }
-    path
-  }
-  canonical_paths <- function(paths) {
-    unique(vapply(paths, canonical_path, character(1), USE.NAMES = FALSE))
-  }
-  package_dirs <- unlist(
-    lapply(.libPaths(), base::list.dirs, recursive = FALSE, full.names = TRUE),
-    use.names = FALSE
-  )
-  read_roots <- canonical_paths(c(R.home(), .libPaths(), package_dirs, work_dir))
-  write_roots <- canonical_paths(work_dir)
-  windows <- identical(Sys.info()[["sysname"]], "Windows")
+worker_script_path <- function() {
+  system.file("worker", "worker.R", package = "commons", mustWork = TRUE)
+}
 
-  in_roots <- function(path, roots) {
-    if (windows) {
-      path <- tolower(path)
-      roots <- tolower(roots)
-    }
-    any(vapply(
-      roots,
-      function(root) {
-        identical(path, root) ||
-          identical(root, "/") ||
-          startsWith(path, paste0(root, "/"))
-      },
-      logical(1)
-    ))
-  }
-  deny <- function(kind, target = NULL) {
-    detail <- if (is.null(target)) "" else paste0(" to '", target, "'")
-    stop("commons run_r guardrails denied ", kind, detail, call. = FALSE)
-  }
-  check_path <- function(paths, access) {
-    if (is.null(paths)) {
-      return(invisible())
-    }
-    if (inherits(paths, "connection")) {
-      description <- tryCatch(
-        summary(paths)$description,
-        error = function(e) ""
-      )
-      if (
-        !nzchar(description) ||
-          description %in% c("stdin", "stdout", "stderr", "terminal") ||
-          startsWith(description, "textConnection") ||
-          startsWith(description, "rawConnection")
-      ) {
-        return(invisible())
-      }
-      paths <- description
-    }
-    paths <- as.character(paths)
-    paths <- paths[!is.na(paths) & nzchar(paths)]
-    for (path in paths) {
-      uri <- grepl("^[A-Za-z][A-Za-z0-9+.-]*:", path) &&
-        !grepl("^[A-Za-z]:[/\\\\]", path)
-      if (uri) {
-        if (startsWith(tolower(path), "file:")) {
-          deny(paste(access, "access"), path)
-        }
-        if (identical(network, "none")) {
-          deny("network access", path)
-        }
-        next
-      }
-      resolved <- canonical_path(path)
-      roots <- if (identical(access, "write")) write_roots else read_roots
-      if (!in_roots(resolved, roots)) {
-        deny(paste(access, "access"), path)
-      }
-    }
-    invisible()
-  }
-  namespace_function <- function(package, name) {
-    get(name, envir = asNamespace(package), inherits = FALSE)
-  }
-  matched_arguments <- function(original, args) {
-    call <- as.call(c(list(quote(.guarded_call)), args))
-    names(call) <- c("", names(args))
-    match.call(original, call, expand.dots = FALSE)
-  }
-  path_hook <- function(
-    package,
-    name,
-    access,
-    argument,
-    dots = FALSE,
-    exclude = character()
-  ) {
-    original <- namespace_function(package, name)
-    replacement <- function(...) {
-      args <- list(...)
-      if (identical(name, "load") && is.null(args$envir)) {
-        args$envir <- parent.frame()
-      }
-      matched <- matched_arguments(original, args)
-      paths <- if (dots) {
-        values <- as.list(matched$...)
-        value_names <- names(values)
-        if (is.null(value_names)) {
-          value_names <- rep("", length(values))
-        }
-        values <- values[!nzchar(value_names) | !value_names %in% exclude]
-        unlist(values, use.names = FALSE)
-      } else if (!is.null(matched[[argument]])) {
-        matched[[argument]]
-      } else {
-        NULL
-      }
-      check_path(paths, access)
-      do.call(original, args)
-    }
-    list(package = package, name = name, replacement = replacement)
-  }
-  named_path_hook <- function(package, name, access, argument, default = NULL) {
-    original <- namespace_function(package, name)
-    replacement <- function(...) {
-      args <- list(...)
-      path <- args[[argument]]
-      if (is.null(path)) {
-        path <- default
-      }
-      check_path(path, access)
-      do.call(original, args)
-    }
-    list(package = package, name = name, replacement = replacement)
-  }
-  pair_hook <- function(package, name, first_access, second_access) {
-    original <- namespace_function(package, name)
-    replacement <- function(...) {
-      args <- list(...)
-      matched <- matched_arguments(original, args)
-      formal_names <- names(formals(original))
-      check_path(matched[[formal_names[[1L]]]], first_access)
-      check_path(matched[[formal_names[[2L]]]], second_access)
-      do.call(original, args)
-    }
-    list(package = package, name = name, replacement = replacement)
-  }
-  arguments_hook <- function(package, name, accesses) {
-    original <- namespace_function(package, name)
-    replacement <- function(...) {
-      args <- list(...)
-      matched <- matched_arguments(original, args)
-      for (argument in names(accesses)) {
-        check_path(matched[[argument]], accesses[[argument]])
-      }
-      do.call(original, args)
-    }
-    list(package = package, name = name, replacement = replacement)
-  }
-  connection_hook <- function(name) {
-    original <- namespace_function("base", name)
-    replacement <- function(...) {
-      args <- list(...)
-      matched <- matched_arguments(original, args)
-      description <- matched$description
-      open <- matched$open
-      if (is.null(description)) description <- ""
-      if (is.null(open)) open <- ""
-      access <- if (grepl("[wa+]", open)) "write" else "read"
-      check_path(description, access)
-      do.call(original, args)
-    }
-    list(package = "base", name = name, replacement = replacement)
-  }
-  open_connection_hook <- function() {
-    original <- namespace_function("base", "open.connection")
-    replacement <- function(con, open = "r", blocking = TRUE, ...) {
-      access <- if (grepl("[wa+]", open)) "write" else "read"
-      check_path(con, access)
-      original(con, open = open, blocking = blocking, ...)
-    }
-    list(
-      package = "base",
-      name = "open.connection",
-      replacement = replacement
-    )
-  }
-  save_hook <- function() {
-    original <- namespace_function("base", "save")
-    replacement <- function(
-      ...,
-      list = character(),
-      file = stop("'file' must be specified"),
-      ascii = FALSE,
-      version = NULL,
-      envir = parent.frame(),
-      compress = isTRUE(!ascii),
-      compression_level,
-      eval.promises = TRUE,
-      precheck = TRUE
-    ) {
-      check_path(file, "write")
-      dots <- as.list(substitute(list(...)))[-1L]
-      dot_names <- vapply(dots, deparse1, character(1))
-      args <- list(
-        list = unique(c(dot_names, list)),
-        file = file,
-        ascii = ascii,
-        version = version,
-        envir = envir,
-        compress = compress,
-        eval.promises = eval.promises,
-        precheck = precheck
-      )
-      if (!missing(compression_level)) {
-        args$compression_level <- compression_level
-      }
-      do.call(original, args)
-    }
-    list(package = "base", name = "save", replacement = replacement)
-  }
-  denied_hook <- function(package, name, kind) {
-    original <- namespace_function(package, name)
-    replacement <- function(...) {
-      deny(kind)
-      do.call(original, list(...))
-    }
-    list(package = package, name = name, replacement = replacement)
-  }
+worker_bootstrap <- function(path, args) {
+  sys.source(path, envir = globalenv())
+  do.call("worker_init", args, envir = globalenv())
+}
 
-  read_arguments <- c(
-    file.access = "names", list.files = "path", list.dirs = "path",
-    dir = "path", normalizePath = "path", setwd = "dir",
-    readLines = "con", readChar = "con", readBin = "con", scan = "file",
-    dget = "file", load = "file", readRDS = "file", source = "file",
-    sys.source = "file", parse = "file",
-    read.dcf = "file", readRenviron = "path", dyn.load = "x"
-  )
-  write_arguments <- c(
-    dir.create = "path", unlink = "x", Sys.chmod = "paths",
-    Sys.setFileTime = "path", sink = "file"
-  )
-  pair_access <- list(
-    file.rename = c("write", "write"),
-    file.copy = c("read", "write"),
-    file.append = c("write", "read"),
-    file.symlink = c("read", "write"),
-    file.link = c("read", "write")
-  )
-  hooks <- c(
-    list(
-      path_hook("base", "file.exists", "read", "...", dots = TRUE),
-      path_hook("base", "dir.exists", "read", "paths"),
-      path_hook(
-        "base", "file.info", "read", "...", dots = TRUE,
-        exclude = "extra_cols"
-      ),
-      path_hook("base", "Sys.readlink", "read", "paths"),
-      path_hook("base", "Sys.glob", "read", "paths"),
-      path_hook("base", "file.show", "read", "...", dots = TRUE)
-    ),
-    Map(
-      function(name, argument) path_hook("base", name, "read", argument),
-      names(read_arguments),
-      unname(read_arguments)
-    ),
-    list(
-      path_hook(
-        "base", "file.create", "write", "...", dots = TRUE,
-        exclude = "showWarnings"
-      ),
-      path_hook("base", "file.remove", "write", "...", dots = TRUE)
-    ),
-    Map(
-      function(name, argument) path_hook("base", name, "write", argument),
-      names(write_arguments),
-      unname(write_arguments)
-    ),
-    list(
-      path_hook("base", "writeLines", "write", "con"),
-      path_hook("base", "writeChar", "write", "con"),
-      path_hook("base", "writeBin", "write", "con"),
-      path_hook("base", "dput", "write", "file"),
-      path_hook("base", "saveRDS", "write", "file"),
-      path_hook("base", "write.dcf", "write", "file"),
-      named_path_hook("base", "cat", "write", "file", ""),
-      save_hook()
-    ),
-    Map(
-      function(name, access) {
-        pair_hook("base", name, access[[1L]], access[[2L]])
-      },
-      names(pair_access),
-      unname(pair_access)
-    ),
-    lapply(c("file", "gzfile", "bzfile", "xzfile", "fifo"), connection_hook),
-    list(
-      path_hook("base", "unz", "read", "description"),
-      open_connection_hook()
-    ),
-    lapply(
-      c("system", "system2", "pipe"),
-      function(name) denied_hook("base", name, "subprocess creation")
-    ),
-    list(denied_hook("utils", "browseURL", "subprocess creation"))
-  )
-  if (exists("shell", envir = baseenv(), inherits = FALSE)) {
-    hooks <- c(hooks, list(denied_hook("base", "shell", "subprocess creation")))
-  }
-  for (package in c("base", "utils")) {
-    namespace <- asNamespace(package)
-    if (exists("shell.exec", envir = namespace, inherits = FALSE)) {
-      hooks <- c(
-        hooks,
-        list(denied_hook(package, "shell.exec", "subprocess creation"))
-      )
-    }
-  }
-  if (identical(network, "none")) {
-    hooks <- c(
-      hooks,
-      lapply(
-        c("url", "socketConnection", "serverSocket", "socketAccept"),
-        function(name) denied_hook("base", name, "network access")
-      ),
-      lapply(
-        c("download.file", "url.show"),
-        function(name) denied_hook("utils", name, "network access")
-      )
-    )
-  } else {
-    hooks <- c(
-      hooks,
-      list(
-        connection_hook("url"),
-        pair_hook("utils", "download.file", "read", "write"),
-        arguments_hook(
-          "utils",
-          "url.show",
-          c(url = "read", file = "write")
-        )
-      )
-    )
-  }
-  attach(NULL, name = "commons:guardrails")
-  assign(
-    ".commons_guardrails",
-    hooks,
-    envir = as.environment("commons:guardrails")
-  )
-  invisible(TRUE)
+worker_call <- function(name, args) {
+  do.call(name, args, envir = globalenv())
 }
 
 # Close the worker after a quiet stretch; it respawns lazily on the next
@@ -859,274 +517,4 @@ worker_await <- function(
     }
     poll()
   })
-}
-
-# --- worker side -------------------------------------------------------------
-# Everything below runs inside the callr worker process, whose closure
-# environment is reset to the global env, so these reference only base R,
-# `pkg::fn`, and their own arguments — no commons internals.
-
-worker_init <- function(
-  parent_tmp,
-  work_dir,
-  dll_path,
-  network = "none",
-  protection = "sandbox",
-  sandbox_mode = "auto"
-) {
-  setwd(work_dir)
-  options(width = 80, cli.num_colors = 1)
-  worker_lib <- file.path(work_dir, "library")
-  dir.create(worker_lib)
-  .libPaths(c(worker_lib, .libPaths()))
-  if (!protection %in% c("sandbox", "guardrails")) {
-    stop("unknown run_r protection mode: ", protection)
-  }
-  if (identical(protection, "guardrails")) {
-    requireNamespace("bit64", quietly = TRUE)
-    return(invisible(TRUE))
-  }
-  sysname <- Sys.info()[["sysname"]]
-  if (!sysname %in% c("Linux", "Darwin")) {
-    stop(
-      "commons cannot sandbox the run_r session on ",
-      sysname,
-      "; only Linux and macOS are supported."
-    )
-  }
-  if (is.na(dll_path)) {
-    stop(
-      "commons cannot sandbox the run_r session: its compiled library was ",
-      "not found. Install commons as a package, or bundle its src/ directory ",
-      "so load_all() can compile it."
-    )
-  }
-  if (!("commons" %in% names(getLoadedDLLs()))) {
-    dyn.load(dll_path)
-  }
-  resolve <- function(paths) {
-    vapply(
-      paths,
-      function(p) tryCatch(normalizePath(p), error = function(e) p),
-      character(1),
-      USE.NAMES = FALSE
-    )
-  }
-  # The sandboxes match symlink-free paths: Connect's packrat library is a
-  # farm of symlinks into a shared cache, and macOS's /tmp and /var live
-  # under /private, so grant resolved paths alongside the originals.
-  pkg_dirs <- list.dirs(.libPaths(), recursive = FALSE)
-  os_roots <- switch(
-    sysname,
-    Linux = c(
-      "/usr", "/bin", "/sbin", "/lib", "/lib64", "/etc", "/opt/R"
-    ),
-    Darwin = c(
-      "/usr", "/bin", "/sbin", "/System", "/Library",
-      "/private/etc", "/private/var/db", "/opt", "/dev"
-    )
-  )
-  read_roots <- unique(c(
-    R.home(),
-    .libPaths(),
-    resolve(pkg_dirs),
-    os_roots
-  ))
-  read_roots <- read_roots[dir.exists(read_roots)]
-  read_roots <- unique(c(read_roots, resolve(read_roots)))
-  # callr writes its per-call result files into the parent's tempdir, so the
-  # worker must be able to write there for results to make it back.
-  write_roots <- c(parent_tmp, work_dir)
-  write_roots <- unique(c(write_roots, resolve(write_roots)))
-  # callr reports status on fd 3 and saves stdout/stderr while a call runs.
-  callr_data <- as.environment("tools:callr")[["__callr_data__"]]
-  preserve_fds <- c(
-    3L,
-    callr_data[[".__stdout__"]],
-    callr_data[[".__stderr__"]]
-  )
-  sym <- getNativeSymbolInfo("c_sandbox_engage", PACKAGE = "commons")
-  .Call(
-    sym,
-    read_roots,
-    write_roots,
-    # 8 GiB leaves ample headroom for light R; a lower Connect limit still applies.
-    8 * 1024^3,
-    sandbox_mode,
-    preserve_fds,
-    network
-  )
-  # Register methods for integer64 columns transferred from ODBC results.
-  requireNamespace("bit64", quietly = TRUE)
-  invisible(TRUE)
-}
-
-# Define measure/helper sources in the worker's global env so the model can
-# read them. Parsing with keep.source here (the worker is non-interactive, so
-# it defaults off) keeps comments when a function is printed.
-worker_define_functions <- function(fn_sources) {
-  for (nm in names(fn_sources)) {
-    fn <- eval(
-      parse(text = fn_sources[[nm]], keep.source = TRUE),
-      envir = globalenv()
-    )
-    assign(nm, fn, envir = globalenv())
-  }
-  invisible(TRUE)
-}
-
-worker_run_code <- function(
-  code,
-  new_handles,
-  plot_width,
-  plot_height
-) {
-  for (id in names(new_handles)) {
-    assign(id, new_handles[[id]], envir = globalenv())
-  }
-
-  segments <- list()
-  add <- function(type, ...) {
-    segments[[length(segments) + 1L]] <<- list(type = type, ...)
-  }
-
-  # evaluate emits a recordedplot per plot-modifying step; only flush the
-  # prior state when the new one doesn't build on it (btw's run_r prior art).
-  is_prefix <- function(x, y) {
-    x <- x[[1]]
-    y <- y[[1]]
-    length(x) <= length(y) && identical(x[], y[seq_along(x)])
-  }
-
-  last_plot <- NULL
-  flush_plot <- function() {
-    if (is.null(last_plot)) {
-      return()
-    }
-    path <- tempfile("plot-", fileext = ".png")
-    if (requireNamespace("ragg", quietly = TRUE)) {
-      ragg::agg_png(path, width = plot_width, height = plot_height, scaling = 1.5)
-    } else {
-      grDevices::png(path, width = plot_width, height = plot_height)
-    }
-    tryCatch(
-      grDevices::replayPlot(last_plot),
-      finally = grDevices::dev.off()
-    )
-    add("plot", path = path)
-    last_plot <<- NULL
-  }
-
-  handler <- evaluate::new_output_handler(
-    source = function(src, expr) {
-      add("source", text = sub("\n$", "", src$src))
-    },
-    text = function(text) {
-      flush_plot()
-      add("text", text = text)
-      text
-    },
-    graphics = function(plot) {
-      if (!is.null(last_plot) && !is_prefix(last_plot, plot)) {
-        flush_plot()
-      }
-      last_plot <<- plot
-      plot
-    },
-    message = function(msg) {
-      flush_plot()
-      add("message", text = sub("\n$", "", conditionMessage(msg)))
-      msg
-    },
-    warning = function(warn) {
-      flush_plot()
-      add("warning", text = conditionMessage(warn))
-      warn
-    },
-    error = function(err) {
-      flush_plot()
-      add("error", text = conditionMessage(err))
-      err
-    },
-    value = function(value, visible) {
-      if (visible) {
-        flush_plot()
-        lines <- utils::capture.output(print(value))
-        if (length(lines) > 100) {
-          lines <- c(
-            lines[1:100],
-            sprintf("... (%d more lines not shown)", length(lines) - 100)
-          )
-        }
-        # Printing invisibly (e.g. a ggplot, which draws to the device and
-        # returns nothing) yields no lines; skip the otherwise-empty segment.
-        if (length(lines)) {
-          add("text", text = paste(lines, collapse = "\n"))
-        }
-      }
-    }
-  )
-
-  guardrails <- if ("commons:guardrails" %in% search()) {
-    get(
-      ".commons_guardrails",
-      envir = as.environment("commons:guardrails"),
-      inherits = FALSE
-    )
-  }
-  if (!is.null(guardrails)) {
-    restore <- list()
-    on.exit({
-      for (item in rev(restore)) {
-        if (bindingIsLocked(item$name, item$environment)) {
-          unlockBinding(item$name, item$environment)
-        }
-        assign(item$name, item$original, envir = item$environment)
-        if (item$locked) {
-          lockBinding(item$name, item$environment)
-        }
-      }
-    }, add = TRUE)
-    for (hook in guardrails) {
-      namespace <- asNamespace(hook$package)
-      environments <- list(namespace)
-      attached_name <- paste0("package:", hook$package)
-      # Attached exports are copied bindings rather than namespace lookups.
-      if (attached_name %in% search()) {
-        attached <- as.environment(attached_name)
-        if (!identical(attached, namespace) &&
-          exists(hook$name, envir = attached, inherits = FALSE)) {
-          environments <- c(environments, list(attached))
-        }
-      }
-      for (environment in environments) {
-        original <- get(hook$name, envir = environment, inherits = FALSE)
-        locked <- bindingIsLocked(hook$name, environment)
-        if (locked) {
-          unlockBinding(hook$name, environment)
-        }
-        assign(hook$name, hook$replacement, envir = environment)
-        if (locked) {
-          lockBinding(hook$name, environment)
-        }
-        restore[[length(restore) + 1L]] <- list(
-          name = hook$name,
-          environment = environment,
-          original = original,
-          locked = locked
-        )
-      }
-    }
-  }
-
-  evaluate::evaluate(
-    code,
-    envir = globalenv(),
-    stop_on_error = 1,
-    new_device = TRUE,
-    output_handler = handler
-  )
-  flush_plot()
-
-  list(segments = segments)
 }

--- a/pkg-r/R/run-r.R
+++ b/pkg-r/R/run-r.R
@@ -95,8 +95,7 @@ run_r_tool <- function(worker, handles, code, fn_sources = character()) {
           function(id) get_handle(handles, id)
         )
         dims <- plot_dimensions()
-        # callr rebinds a transferred function's environment to the worker's
-        # global env, so the entry point must be namespace-qualified.
+        # Dispatch by name to an entry point sourced into the child process.
         worker$rs$call(
           worker_call,
           args = list(
@@ -403,6 +402,7 @@ worker_scrubbed_env <- function(work_dir, single_thread = FALSE) {
   env
 }
 
+# The runtime lives outside R/ because it deliberately mutates only the child.
 worker_script_path <- function() {
   system.file("worker", "worker.R", package = "commons", mustWork = TRUE)
 }

--- a/pkg-r/R/run-r.R
+++ b/pkg-r/R/run-r.R
@@ -95,10 +95,12 @@ run_r_tool <- function(worker, handles, code, fn_sources = character()) {
           function(id) get_handle(handles, id)
         )
         dims <- plot_dimensions()
-        # Dispatch by name to an entry point sourced into the child process.
+        # Recreate entry points outside the model's global environment for
+        # each call.
         worker$rs$call(
           worker_call,
           args = list(
+            runtime = worker$runtime,
             name = "worker_run_code",
             args = list(
               code = code,
@@ -278,6 +280,7 @@ new_r_worker <- function(network = "none", protection = "sandbox") {
   worker$tail <- NULL
   worker$pending <- 0L
   worker$last_used <- Sys.time()
+  worker$runtime <- worker_runtime()
   # Close the child process when the agent is garbage-collected, so a session
   # that ends without idling out doesn't leak an R process.
   reg.finalizer(worker, worker_close, onexit = TRUE)
@@ -300,13 +303,13 @@ worker_ensure <- function(worker, fn_sources = character()) {
     ),
     wait = TRUE
   )
-  # Source the worker runtime before engaging the sandbox so load_all() paths
-  # outside the worker's read roots work. No user-provided code runs until the
-  # sandbox is active.
+  # Load the worker runtime before engaging the sandbox. No user-provided code
+  # runs until the sandbox is active.
   rs$run(
-    worker_bootstrap,
+    worker_call,
     args = list(
-      path = worker_script_path(),
+      runtime = worker$runtime,
+      name = "worker_init",
       args = list(
         parent_tmp = tempdir(),
         work_dir = work_dir,
@@ -321,6 +324,7 @@ worker_ensure <- function(worker, fn_sources = character()) {
     rs$run(
       worker_call,
       args = list(
+        runtime = worker$runtime,
         name = "worker_guardrails",
         args = list(work_dir = work_dir, network = worker$network)
       )
@@ -332,6 +336,7 @@ worker_ensure <- function(worker, fn_sources = character()) {
     rs$run(
       worker_call,
       args = list(
+        runtime = worker$runtime,
         name = "worker_define_functions",
         args = list(fn_sources = fn_sources)
       )
@@ -407,13 +412,15 @@ worker_script_path <- function() {
   system.file("worker", "worker.R", package = "commons", mustWork = TRUE)
 }
 
-worker_bootstrap <- function(path, args) {
-  sys.source(path, envir = globalenv())
-  do.call("worker_init", args, envir = globalenv())
+worker_runtime <- function() {
+  parse(worker_script_path(), keep.source = FALSE)
 }
 
-worker_call <- function(name, args) {
-  do.call(name, args, envir = globalenv())
+worker_call <- function(runtime, name, args) {
+  runtime_env <- base::new.env(parent = base::baseenv())
+  base::eval(runtime, envir = runtime_env)
+  entry_point <- base::get(name, envir = runtime_env, inherits = FALSE)
+  base::do.call(entry_point, args)
 }
 
 # Close the worker after a quiet stretch; it respawns lazily on the next

--- a/pkg-r/R/sandbox.R
+++ b/pkg-r/R/sandbox.R
@@ -1,5 +1,5 @@
 # R side of the worker sandbox (src/sandbox.c). The run_r worker engages the
-# sandbox itself in worker_init() (run-r.R), calling the C symbol directly;
+# sandbox itself in worker_init() (inst/worker/worker.R), calling C directly;
 # the parent process is never sandboxed.
 
 sandbox_capabilities <- function() {

--- a/pkg-r/inst/worker/worker.R
+++ b/pkg-r/inst/worker/worker.R
@@ -1,0 +1,639 @@
+# This file is sourced only inside the isolated callr worker. Its functions may
+# mutate that process's global environment and temporarily replace bindings.
+
+worker_guardrails <- function(work_dir, network = "none") {
+  normalize <- base::normalizePath
+  file_exists <- base::file.exists
+  dir_exists <- base::dir.exists
+  path_exists <- function(path) {
+    file_exists(path) || dir_exists(path)
+  }
+  canonical_path <- function(path) {
+    path <- path.expand(path)
+    if (!grepl("^([A-Za-z]:[/\\\\]|[/\\\\]{1,2})", path)) {
+      path <- file.path(getwd(), path)
+    }
+    suffix <- character()
+    # Resolving an existing ancestor exposes symlinks beneath nonexistent paths.
+    while (!path_exists(path) && !identical(dirname(path), path)) {
+      suffix <- c(basename(path), suffix)
+      path <- dirname(path)
+    }
+    path <- normalize(path, winslash = "/", mustWork = FALSE)
+    if (length(suffix)) {
+      path <- do.call(file.path, as.list(c(path, suffix)))
+    }
+    if (nchar(path) > 1L && !grepl("^[A-Za-z]:/$", path)) {
+      path <- sub("/+$", "", path)
+    }
+    path
+  }
+  canonical_paths <- function(paths) {
+    unique(vapply(paths, canonical_path, character(1), USE.NAMES = FALSE))
+  }
+  package_dirs <- unlist(
+    lapply(.libPaths(), base::list.dirs, recursive = FALSE, full.names = TRUE),
+    use.names = FALSE
+  )
+  read_roots <- canonical_paths(c(R.home(), .libPaths(), package_dirs, work_dir))
+  write_roots <- canonical_paths(work_dir)
+  windows <- identical(Sys.info()[["sysname"]], "Windows")
+
+  in_roots <- function(path, roots) {
+    if (windows) {
+      path <- tolower(path)
+      roots <- tolower(roots)
+    }
+    any(vapply(
+      roots,
+      function(root) {
+        identical(path, root) ||
+          identical(root, "/") ||
+          startsWith(path, paste0(root, "/"))
+      },
+      logical(1)
+    ))
+  }
+  deny <- function(kind, target = NULL) {
+    detail <- if (is.null(target)) "" else paste0(" to '", target, "'")
+    stop("commons run_r guardrails denied ", kind, detail, call. = FALSE)
+  }
+  check_path <- function(paths, access) {
+    if (is.null(paths)) {
+      return(invisible())
+    }
+    if (inherits(paths, "connection")) {
+      description <- tryCatch(
+        summary(paths)$description,
+        error = function(e) ""
+      )
+      if (
+        !nzchar(description) ||
+          description %in% c("stdin", "stdout", "stderr", "terminal") ||
+          startsWith(description, "textConnection") ||
+          startsWith(description, "rawConnection")
+      ) {
+        return(invisible())
+      }
+      paths <- description
+    }
+    paths <- as.character(paths)
+    paths <- paths[!is.na(paths) & nzchar(paths)]
+    for (path in paths) {
+      uri <- grepl("^[A-Za-z][A-Za-z0-9+.-]*:", path) &&
+        !grepl("^[A-Za-z]:[/\\\\]", path)
+      if (uri) {
+        if (startsWith(tolower(path), "file:")) {
+          deny(paste(access, "access"), path)
+        }
+        if (identical(network, "none")) {
+          deny("network access", path)
+        }
+        next
+      }
+      resolved <- canonical_path(path)
+      roots <- if (identical(access, "write")) write_roots else read_roots
+      if (!in_roots(resolved, roots)) {
+        deny(paste(access, "access"), path)
+      }
+    }
+    invisible()
+  }
+  namespace_function <- function(package, name) {
+    get(name, envir = asNamespace(package), inherits = FALSE)
+  }
+  matched_arguments <- function(original, args) {
+    call <- as.call(c(list(quote(.guarded_call)), args))
+    names(call) <- c("", names(args))
+    match.call(original, call, expand.dots = FALSE)
+  }
+  path_hook <- function(
+    package,
+    name,
+    access,
+    argument,
+    dots = FALSE,
+    exclude = character()
+  ) {
+    original <- namespace_function(package, name)
+    replacement <- function(...) {
+      args <- list(...)
+      if (identical(name, "load") && is.null(args$envir)) {
+        args$envir <- parent.frame()
+      }
+      matched <- matched_arguments(original, args)
+      paths <- if (dots) {
+        values <- as.list(matched$...)
+        value_names <- names(values)
+        if (is.null(value_names)) {
+          value_names <- rep("", length(values))
+        }
+        values <- values[!nzchar(value_names) | !value_names %in% exclude]
+        unlist(values, use.names = FALSE)
+      } else if (!is.null(matched[[argument]])) {
+        matched[[argument]]
+      } else {
+        NULL
+      }
+      check_path(paths, access)
+      do.call(original, args)
+    }
+    list(package = package, name = name, replacement = replacement)
+  }
+  named_path_hook <- function(package, name, access, argument, default = NULL) {
+    original <- namespace_function(package, name)
+    replacement <- function(...) {
+      args <- list(...)
+      path <- args[[argument]]
+      if (is.null(path)) {
+        path <- default
+      }
+      check_path(path, access)
+      do.call(original, args)
+    }
+    list(package = package, name = name, replacement = replacement)
+  }
+  pair_hook <- function(package, name, first_access, second_access) {
+    original <- namespace_function(package, name)
+    replacement <- function(...) {
+      args <- list(...)
+      matched <- matched_arguments(original, args)
+      formal_names <- names(formals(original))
+      check_path(matched[[formal_names[[1L]]]], first_access)
+      check_path(matched[[formal_names[[2L]]]], second_access)
+      do.call(original, args)
+    }
+    list(package = package, name = name, replacement = replacement)
+  }
+  arguments_hook <- function(package, name, accesses) {
+    original <- namespace_function(package, name)
+    replacement <- function(...) {
+      args <- list(...)
+      matched <- matched_arguments(original, args)
+      for (argument in names(accesses)) {
+        check_path(matched[[argument]], accesses[[argument]])
+      }
+      do.call(original, args)
+    }
+    list(package = package, name = name, replacement = replacement)
+  }
+  connection_hook <- function(name) {
+    original <- namespace_function("base", name)
+    replacement <- function(...) {
+      args <- list(...)
+      matched <- matched_arguments(original, args)
+      description <- matched$description
+      open <- matched$open
+      if (is.null(description)) description <- ""
+      if (is.null(open)) open <- ""
+      access <- if (grepl("[wa+]", open)) "write" else "read"
+      check_path(description, access)
+      do.call(original, args)
+    }
+    list(package = "base", name = name, replacement = replacement)
+  }
+  open_connection_hook <- function() {
+    original <- namespace_function("base", "open.connection")
+    replacement <- function(con, open = "r", blocking = TRUE, ...) {
+      access <- if (grepl("[wa+]", open)) "write" else "read"
+      check_path(con, access)
+      original(con, open = open, blocking = blocking, ...)
+    }
+    list(
+      package = "base",
+      name = "open.connection",
+      replacement = replacement
+    )
+  }
+  save_hook <- function() {
+    original <- namespace_function("base", "save")
+    replacement <- function(
+      ...,
+      list = character(),
+      file = stop("'file' must be specified"),
+      ascii = FALSE,
+      version = NULL,
+      envir = parent.frame(),
+      compress = isTRUE(!ascii),
+      compression_level,
+      eval.promises = TRUE,
+      precheck = TRUE
+    ) {
+      check_path(file, "write")
+      dots <- as.list(substitute(list(...)))[-1L]
+      dot_names <- vapply(dots, deparse1, character(1))
+      args <- list(
+        list = unique(c(dot_names, list)),
+        file = file,
+        ascii = ascii,
+        version = version,
+        envir = envir,
+        compress = compress,
+        eval.promises = eval.promises,
+        precheck = precheck
+      )
+      if (!missing(compression_level)) {
+        args$compression_level <- compression_level
+      }
+      do.call(original, args)
+    }
+    list(package = "base", name = "save", replacement = replacement)
+  }
+  denied_hook <- function(package, name, kind) {
+    original <- namespace_function(package, name)
+    replacement <- function(...) {
+      deny(kind)
+      do.call(original, list(...))
+    }
+    list(package = package, name = name, replacement = replacement)
+  }
+
+  read_arguments <- c(
+    file.access = "names", list.files = "path", list.dirs = "path",
+    dir = "path", normalizePath = "path", setwd = "dir",
+    readLines = "con", readChar = "con", readBin = "con", scan = "file",
+    dget = "file", load = "file", readRDS = "file", source = "file",
+    sys.source = "file", parse = "file",
+    read.dcf = "file", readRenviron = "path", dyn.load = "x"
+  )
+  write_arguments <- c(
+    dir.create = "path", unlink = "x", Sys.chmod = "paths",
+    Sys.setFileTime = "path", sink = "file"
+  )
+  pair_access <- list(
+    file.rename = c("write", "write"),
+    file.copy = c("read", "write"),
+    file.append = c("write", "read"),
+    file.symlink = c("read", "write"),
+    file.link = c("read", "write")
+  )
+  hooks <- c(
+    list(
+      path_hook("base", "file.exists", "read", "...", dots = TRUE),
+      path_hook("base", "dir.exists", "read", "paths"),
+      path_hook(
+        "base", "file.info", "read", "...", dots = TRUE,
+        exclude = "extra_cols"
+      ),
+      path_hook("base", "Sys.readlink", "read", "paths"),
+      path_hook("base", "Sys.glob", "read", "paths"),
+      path_hook("base", "file.show", "read", "...", dots = TRUE)
+    ),
+    Map(
+      function(name, argument) path_hook("base", name, "read", argument),
+      names(read_arguments),
+      unname(read_arguments)
+    ),
+    list(
+      path_hook(
+        "base", "file.create", "write", "...", dots = TRUE,
+        exclude = "showWarnings"
+      ),
+      path_hook("base", "file.remove", "write", "...", dots = TRUE)
+    ),
+    Map(
+      function(name, argument) path_hook("base", name, "write", argument),
+      names(write_arguments),
+      unname(write_arguments)
+    ),
+    list(
+      path_hook("base", "writeLines", "write", "con"),
+      path_hook("base", "writeChar", "write", "con"),
+      path_hook("base", "writeBin", "write", "con"),
+      path_hook("base", "dput", "write", "file"),
+      path_hook("base", "saveRDS", "write", "file"),
+      path_hook("base", "write.dcf", "write", "file"),
+      named_path_hook("base", "cat", "write", "file", ""),
+      save_hook()
+    ),
+    Map(
+      function(name, access) {
+        pair_hook("base", name, access[[1L]], access[[2L]])
+      },
+      names(pair_access),
+      unname(pair_access)
+    ),
+    lapply(c("file", "gzfile", "bzfile", "xzfile", "fifo"), connection_hook),
+    list(
+      path_hook("base", "unz", "read", "description"),
+      open_connection_hook()
+    ),
+    lapply(
+      c("system", "system2", "pipe"),
+      function(name) denied_hook("base", name, "subprocess creation")
+    ),
+    list(denied_hook("utils", "browseURL", "subprocess creation"))
+  )
+  if (exists("shell", envir = baseenv(), inherits = FALSE)) {
+    hooks <- c(hooks, list(denied_hook("base", "shell", "subprocess creation")))
+  }
+  for (package in c("base", "utils")) {
+    namespace <- asNamespace(package)
+    if (exists("shell.exec", envir = namespace, inherits = FALSE)) {
+      hooks <- c(
+        hooks,
+        list(denied_hook(package, "shell.exec", "subprocess creation"))
+      )
+    }
+  }
+  if (identical(network, "none")) {
+    hooks <- c(
+      hooks,
+      lapply(
+        c("url", "socketConnection", "serverSocket", "socketAccept"),
+        function(name) denied_hook("base", name, "network access")
+      ),
+      lapply(
+        c("download.file", "url.show"),
+        function(name) denied_hook("utils", name, "network access")
+      )
+    )
+  } else {
+    hooks <- c(
+      hooks,
+      list(
+        connection_hook("url"),
+        pair_hook("utils", "download.file", "read", "write"),
+        arguments_hook(
+          "utils",
+          "url.show",
+          c(url = "read", file = "write")
+        )
+      )
+    )
+  }
+  attach(NULL, name = "commons:guardrails")
+  assign(
+    ".commons_guardrails",
+    hooks,
+    envir = as.environment("commons:guardrails")
+  )
+  invisible(TRUE)
+}
+
+worker_init <- function(
+  parent_tmp,
+  work_dir,
+  dll_path,
+  network = "none",
+  protection = "sandbox",
+  sandbox_mode = "auto"
+) {
+  setwd(work_dir)
+  options(width = 80, cli.num_colors = 1)
+  worker_lib <- file.path(work_dir, "library")
+  dir.create(worker_lib)
+  .libPaths(c(worker_lib, .libPaths()))
+  if (!protection %in% c("sandbox", "guardrails")) {
+    stop("unknown run_r protection mode: ", protection)
+  }
+  if (identical(protection, "guardrails")) {
+    requireNamespace("bit64", quietly = TRUE)
+    return(invisible(TRUE))
+  }
+  sysname <- Sys.info()[["sysname"]]
+  if (!sysname %in% c("Linux", "Darwin")) {
+    stop(
+      "commons cannot sandbox the run_r session on ",
+      sysname,
+      "; only Linux and macOS are supported."
+    )
+  }
+  if (is.na(dll_path)) {
+    stop(
+      "commons cannot sandbox the run_r session: its compiled library was ",
+      "not found. Install commons as a package, or bundle its src/ directory ",
+      "so load_all() can compile it."
+    )
+  }
+  if (!("commons" %in% names(getLoadedDLLs()))) {
+    dyn.load(dll_path)
+  }
+  resolve <- function(paths) {
+    vapply(
+      paths,
+      function(p) tryCatch(normalizePath(p), error = function(e) p),
+      character(1),
+      USE.NAMES = FALSE
+    )
+  }
+  # The sandboxes match symlink-free paths: Connect's packrat library is a
+  # farm of symlinks into a shared cache, and macOS's /tmp and /var live
+  # under /private, so grant resolved paths alongside the originals.
+  pkg_dirs <- list.dirs(.libPaths(), recursive = FALSE)
+  os_roots <- switch(
+    sysname,
+    Linux = c(
+      "/usr", "/bin", "/sbin", "/lib", "/lib64", "/etc", "/opt/R"
+    ),
+    Darwin = c(
+      "/usr", "/bin", "/sbin", "/System", "/Library",
+      "/private/etc", "/private/var/db", "/opt", "/dev"
+    )
+  )
+  read_roots <- unique(c(
+    R.home(),
+    .libPaths(),
+    resolve(pkg_dirs),
+    os_roots
+  ))
+  read_roots <- read_roots[dir.exists(read_roots)]
+  read_roots <- unique(c(read_roots, resolve(read_roots)))
+  # callr writes its per-call result files into the parent's tempdir, so the
+  # worker must be able to write there for results to make it back.
+  write_roots <- c(parent_tmp, work_dir)
+  write_roots <- unique(c(write_roots, resolve(write_roots)))
+  # callr reports status on fd 3 and saves stdout/stderr while a call runs.
+  callr_data <- as.environment("tools:callr")[["__callr_data__"]]
+  preserve_fds <- c(
+    3L,
+    callr_data[[".__stdout__"]],
+    callr_data[[".__stderr__"]]
+  )
+  sym <- getNativeSymbolInfo("c_sandbox_engage", PACKAGE = "commons")
+  .Call(
+    sym,
+    read_roots,
+    write_roots,
+    # 8 GiB leaves ample headroom for light R; a lower Connect limit still applies.
+    8 * 1024^3,
+    sandbox_mode,
+    preserve_fds,
+    network
+  )
+  # Register methods for integer64 columns transferred from ODBC results.
+  requireNamespace("bit64", quietly = TRUE)
+  invisible(TRUE)
+}
+
+# Define measure/helper sources in the worker's global env so the model can
+# read them. Parsing with keep.source here (the worker is non-interactive, so
+# it defaults off) keeps comments when a function is printed.
+worker_define_functions <- function(fn_sources) {
+  for (nm in names(fn_sources)) {
+    fn <- eval(
+      parse(text = fn_sources[[nm]], keep.source = TRUE),
+      envir = globalenv()
+    )
+    assign(nm, fn, envir = globalenv())
+  }
+  invisible(TRUE)
+}
+
+worker_run_code <- function(
+  code,
+  new_handles,
+  plot_width,
+  plot_height,
+  evaluate,
+  new_output_handler
+) {
+  for (id in names(new_handles)) {
+    assign(id, new_handles[[id]], envir = globalenv())
+  }
+
+  segments <- list()
+  add <- function(type, ...) {
+    segments[[length(segments) + 1L]] <<- list(type = type, ...)
+  }
+
+  # evaluate emits a recordedplot per plot-modifying step; only flush the
+  # prior state when the new one doesn't build on it (btw's run_r prior art).
+  is_prefix <- function(x, y) {
+    x <- x[[1]]
+    y <- y[[1]]
+    length(x) <= length(y) && identical(x[], y[seq_along(x)])
+  }
+
+  last_plot <- NULL
+  flush_plot <- function() {
+    if (is.null(last_plot)) {
+      return()
+    }
+    path <- tempfile("plot-", fileext = ".png")
+    if (requireNamespace("ragg", quietly = TRUE)) {
+      ragg::agg_png(path, width = plot_width, height = plot_height, scaling = 1.5)
+    } else {
+      grDevices::png(path, width = plot_width, height = plot_height)
+    }
+    tryCatch(
+      grDevices::replayPlot(last_plot),
+      finally = grDevices::dev.off()
+    )
+    add("plot", path = path)
+    last_plot <<- NULL
+  }
+
+  handler <- new_output_handler(
+    source = function(src, expr) {
+      add("source", text = sub("\n$", "", src$src))
+    },
+    text = function(text) {
+      flush_plot()
+      add("text", text = text)
+      text
+    },
+    graphics = function(plot) {
+      if (!is.null(last_plot) && !is_prefix(last_plot, plot)) {
+        flush_plot()
+      }
+      last_plot <<- plot
+      plot
+    },
+    message = function(msg) {
+      flush_plot()
+      add("message", text = sub("\n$", "", conditionMessage(msg)))
+      msg
+    },
+    warning = function(warn) {
+      flush_plot()
+      add("warning", text = conditionMessage(warn))
+      warn
+    },
+    error = function(err) {
+      flush_plot()
+      add("error", text = conditionMessage(err))
+      err
+    },
+    value = function(value, visible) {
+      if (visible) {
+        flush_plot()
+        lines <- utils::capture.output(print(value))
+        if (length(lines) > 100) {
+          lines <- c(
+            lines[1:100],
+            sprintf("... (%d more lines not shown)", length(lines) - 100)
+          )
+        }
+        # Printing invisibly (e.g. a ggplot, which draws to the device and
+        # returns nothing) yields no lines; skip the otherwise-empty segment.
+        if (length(lines)) {
+          add("text", text = paste(lines, collapse = "\n"))
+        }
+      }
+    }
+  )
+
+  guardrails <- if ("commons:guardrails" %in% search()) {
+    get(
+      ".commons_guardrails",
+      envir = as.environment("commons:guardrails"),
+      inherits = FALSE
+    )
+  }
+  if (!is.null(guardrails)) {
+    restore <- list()
+    on.exit({
+      for (item in rev(restore)) {
+        if (bindingIsLocked(item$name, item$environment)) {
+          unlockBinding(item$name, item$environment)
+        }
+        assign(item$name, item$original, envir = item$environment)
+        if (item$locked) {
+          lockBinding(item$name, item$environment)
+        }
+      }
+    }, add = TRUE)
+    for (hook in guardrails) {
+      namespace <- asNamespace(hook$package)
+      environments <- list(namespace)
+      attached_name <- paste0("package:", hook$package)
+      # Attached exports are copied bindings rather than namespace lookups.
+      if (attached_name %in% search()) {
+        attached <- as.environment(attached_name)
+        if (!identical(attached, namespace) &&
+          exists(hook$name, envir = attached, inherits = FALSE)) {
+          environments <- c(environments, list(attached))
+        }
+      }
+      for (environment in environments) {
+        original <- get(hook$name, envir = environment, inherits = FALSE)
+        locked <- bindingIsLocked(hook$name, environment)
+        if (locked) {
+          unlockBinding(hook$name, environment)
+        }
+        assign(hook$name, hook$replacement, envir = environment)
+        if (locked) {
+          lockBinding(hook$name, environment)
+        }
+        restore[[length(restore) + 1L]] <- list(
+          name = hook$name,
+          environment = environment,
+          original = original,
+          locked = locked
+        )
+      }
+    }
+  }
+
+  evaluate(
+    code,
+    envir = globalenv(),
+    stop_on_error = 1,
+    new_device = TRUE,
+    output_handler = handler
+  )
+  flush_plot()
+
+  list(segments = segments)
+}

--- a/pkg-r/inst/worker/worker.R
+++ b/pkg-r/inst/worker/worker.R
@@ -1,4 +1,4 @@
-# This file is sourced only inside the isolated callr worker. Its functions may
+# This file is loaded only inside the isolated callr worker. Its functions may
 # mutate that process's global environment and temporarily replace bindings.
 
 worker_guardrails <- function(work_dir, network = "none") {

--- a/pkg-r/tests/testthat/test-run-r.R
+++ b/pkg-r/tests/testthat/test-run-r.R
@@ -63,6 +63,26 @@ test_that("run_r session state persists across calls, and handles sync lazily", 
   expect_match(res@value, "48")
 })
 
+test_that("worker entry points stay outside the model environment", {
+  worker <- local_guardrail_worker()
+  store <- new_handle_store()
+  outside <- withr::local_tempfile(tmpdir = dirname(tempdir()))
+  writeLines("secret", outside)
+  replacement <- sprintf(
+    paste0(
+      "worker_run_code <- function(...) ",
+      "list(segments = list(list(type = 'text', text = readLines(%s))))"
+    ),
+    encodeString(outside, quote = "\"")
+  )
+
+  sync_promise(run_r_tool(worker, store, replacement))
+  res <- sync_promise(run_r_tool(worker, store, "1 + 1"))
+
+  expect_match(res@value, "[1] 2", fixed = TRUE)
+  expect_no_match(res@value, "secret", fixed = TRUE)
+})
+
 test_that("run_r prepends a worker-local package library", {
   worker <- local_guardrail_worker()
   worker_ensure(worker)

--- a/pkg-r/tests/testthat/test-sandbox.R
+++ b/pkg-r/tests/testthat/test-sandbox.R
@@ -69,9 +69,10 @@ test_that("worker_init refuses to run unsandboxed off Linux and macOS", {
   skip_on_os(c("linux", "mac"))
   expect_error(
     callr::r(
-      worker_bootstrap,
+      worker_call,
       args = list(
-        path = worker_script_path(),
+        runtime = worker_runtime(),
+        name = "worker_init",
         args = list(
           parent_tmp = tempdir(),
           work_dir = tempdir(),
@@ -87,9 +88,10 @@ test_that("worker_init errors without the compiled library", {
   skip_on_os(c("windows", "solaris"))
   expect_error(
     callr::r(
-      worker_bootstrap,
+      worker_call,
       args = list(
-        path = worker_script_path(),
+        runtime = worker_runtime(),
+        name = "worker_init",
         args = list(
           parent_tmp = tempdir(),
           work_dir = tempdir(),
@@ -103,9 +105,10 @@ test_that("worker_init errors without the compiled library", {
 
 test_that("worker_init permits the explicit guardrail mode", {
   expect_true(callr::r(
-    worker_bootstrap,
+    worker_call,
     args = list(
-      path = worker_script_path(),
+      runtime = worker_runtime(),
+      name = "worker_init",
       args = list(
         parent_tmp = tempdir(),
         work_dir = tempdir(),
@@ -153,9 +156,10 @@ sandboxed_worker_probes <- function(
     args = list(outside = outside)
   )
   rs$run(
-    worker_bootstrap,
+    worker_call,
     args = list(
-      path = worker_script_path(),
+      runtime = worker_runtime(),
+      name = "worker_init",
       args = list(
         parent_tmp = tempdir(),
         work_dir = work_dir,

--- a/pkg-r/tests/testthat/test-sandbox.R
+++ b/pkg-r/tests/testthat/test-sandbox.R
@@ -69,11 +69,14 @@ test_that("worker_init refuses to run unsandboxed off Linux and macOS", {
   skip_on_os(c("linux", "mac"))
   expect_error(
     callr::r(
-      worker_init,
+      worker_bootstrap,
       args = list(
-        parent_tmp = tempdir(),
-        work_dir = tempdir(),
-        dll_path = NA_character_
+        path = worker_script_path(),
+        args = list(
+          parent_tmp = tempdir(),
+          work_dir = tempdir(),
+          dll_path = NA_character_
+        )
       )
     ),
     "only Linux and macOS are supported"
@@ -84,11 +87,14 @@ test_that("worker_init errors without the compiled library", {
   skip_on_os(c("windows", "solaris"))
   expect_error(
     callr::r(
-      worker_init,
+      worker_bootstrap,
       args = list(
-        parent_tmp = tempdir(),
-        work_dir = tempdir(),
-        dll_path = NA_character_
+        path = worker_script_path(),
+        args = list(
+          parent_tmp = tempdir(),
+          work_dir = tempdir(),
+          dll_path = NA_character_
+        )
       )
     ),
     "compiled library"
@@ -97,12 +103,15 @@ test_that("worker_init errors without the compiled library", {
 
 test_that("worker_init permits the explicit guardrail mode", {
   expect_true(callr::r(
-    worker_init,
+    worker_bootstrap,
     args = list(
-      parent_tmp = tempdir(),
-      work_dir = tempdir(),
-      dll_path = NA_character_,
-      protection = "guardrails"
+      path = worker_script_path(),
+      args = list(
+        parent_tmp = tempdir(),
+        work_dir = tempdir(),
+        dll_path = NA_character_,
+        protection = "guardrails"
+      )
     )
   ))
 })
@@ -144,13 +153,16 @@ sandboxed_worker_probes <- function(
     args = list(outside = outside)
   )
   rs$run(
-    worker_init,
+    worker_bootstrap,
     args = list(
-      parent_tmp = tempdir(),
-      work_dir = work_dir,
-      dll_path = commons_dll_path(),
-      network = network,
-      sandbox_mode = sandbox_mode
+      path = worker_script_path(),
+      args = list(
+        parent_tmp = tempdir(),
+        work_dir = work_dir,
+        dll_path = commons_dll_path(),
+        network = network,
+        sandbox_mode = sandbox_mode
+      )
     )
   )
 


### PR DESCRIPTION
Worker-only code now lives in an installed script that is sourced inside the fresh `callr` subprocess before the sandbox is engaged. Package code only bootstraps and dispatches to that runtime, so global assignments and binding changes cannot affect the user’s R session and are no longer mistaken for package-level side effects by `R CMD check`.

Related to #210 but does not close.