### PR TITLE
Publish the Python package as `commons` on PyPI

### DIFF
--- a/.github/workflows/py-release.yaml
+++ b/.github/workflows/py-release.yaml
@@ -1,7 +1,7 @@
 name: py-release
 
 # Publishes pkg-py to PyPI via trusted publishing (OIDC); no API token is stored.
-# PyPI's publisher config for posit-commons names this file, so renaming it
+# PyPI's publisher config for commons names this file, so renaming it
 # breaks releases with an OIDC error until PyPI is updated to match.
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -32,10 +32,13 @@ pak::pak("posit-dev/commons/pkg-r")
 
 To learn more, see `vignette("commons", package = "commons")`.
 
-To install the Python package from PyPI, run:
+To install the [Python package from PyPI](https://pypi.org/project/commons/), run:
 
 ``` sh
 pip install commons
+
+# or, using uv (https://docs.astral.sh/uv/):
+uv pip install commons
 ```
 
 Then, import with:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To learn more, see `vignette("commons", package = "commons")`.
 To install the Python package from PyPI, run:
 
 ``` sh
-pip install posit-commons
+pip install commons
 ```
 
 Then, import with:

--- a/pkg-py/README.md
+++ b/pkg-py/README.md
@@ -1,8 +1,6 @@
-# posit-commons
+# commons
 
 `commons` is a constructor for trustworthy data agents. Once implemented, this package will give an LLM data, semantic, and context layers to work with, tools for querying them, and A/B/C provenance tags so every answer carries a classification as to its trustworthiness.
-
-The distribution name on PyPI is `posit-commons`, but the package is imported as `commons`.
 
 **Status: pre-alpha.** The package installs, imports, lints, type-checks, and tests, but exports nothing yet: `commons.__all__` is empty and there is no public API. Python 3.11 or later is required.
 

--- a/pkg-py/pyproject.toml
+++ b/pkg-py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "commons"
-version = "0.1.0.dev0"
+version = "0.1.0.dev1"
 description = "AI Agents for Data Analysis"
 readme = "README.md"
 # Upper bound tracks raghilda, which caps at <3.14 (posit-dev/raghilda#93).

--- a/pkg-py/pyproject.toml
+++ b/pkg-py/pyproject.toml
@@ -1,10 +1,8 @@
 [project]
-name = "posit-commons"
+name = "commons"
 version = "0.1.0.dev0"
 description = "AI Agents for Data Analysis"
 readme = "README.md"
-# The PyPI name `commons` is taken, so the distribution is `posit-commons` and
-# the import name is `commons`.
 # Upper bound tracks raghilda, which caps at <3.14 (posit-dev/raghilda#93).
 requires-python = ">=3.11,<3.14"
 license = "MIT"
@@ -38,12 +36,6 @@ dev = ["pytest>=8", "pytest-asyncio", "ruff", "pyrefly"]
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-# Hatchling derives the package directory from the *distribution* name, so
-# this packages line is required to have a package import name that differs
-# from the PyPI distribution name
-[tool.hatch.build.targets.wheel]
-packages = ["src/commons"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pkg-py/src/commons/__init__.py
+++ b/pkg-py/src/commons/__init__.py
@@ -3,8 +3,6 @@
 Give an LLM data, semantic, and context layers to work with, tools for
 querying them, and A/B/C provenance semantics so every answer carries a
 classification as to how much it can be trusted.
-
-The distribution is ``posit-commons`` on PyPI; the import name is ``commons``.
 """
 
 __all__: list[str] = []

--- a/pkg-py/tests/test_packaging.py
+++ b/pkg-py/tests/test_packaging.py
@@ -1,21 +1,13 @@
-"""Pin the distribution/import name split.
+"""Pin what the built distribution promises its consumers: the distribution
+name, the import name, and the type marker.
 
-The distribution is ``posit-commons`` (the PyPI name ``commons`` is taken).
-Hatchling infers the package directory from the distribution name, so
-the split works because ``[tool.hatch.build.targets.wheel]``
-names ``src/commons`` explicitly.
-
-Without that setting the wheel build fails outright, which is loud but invites
-the wrong fix: renaming ``src/commons/`` to ``src/posit_commons/`` also makes
-the error go away and silently changes what consumers import. These tests fail
-on that rename, so the decision cannot be reversed by accident.
+Both names are ``commons``, so hatchling infers ``src/commons`` without an
+explicit packages setting. These run against the installed package, so they
+check the built artifact rather than the source tree.
 """
 
-import importlib
 import importlib.resources
 from importlib.metadata import metadata, version
-
-import pytest
 
 import commons
 
@@ -24,14 +16,9 @@ def test_import_name_is_commons() -> None:
     assert commons.__name__ == "commons"
 
 
-def test_distribution_name_is_posit_commons() -> None:
-    assert metadata("posit-commons")["Name"] == "posit-commons"
-    assert version("posit-commons")
-
-
-def test_posit_commons_is_not_an_import_name() -> None:
-    with pytest.raises(ModuleNotFoundError):
-        importlib.import_module("posit_commons")
+def test_distribution_name_is_commons() -> None:
+    assert metadata("commons")["Name"] == "commons"
+    assert version("commons")
 
 
 def test_package_ships_type_information() -> None:

--- a/pkg-py/uv.lock
+++ b/pkg-py/uv.lock
@@ -199,6 +199,60 @@ wheels = [
 ]
 
 [[package]]
+name = "commons"
+version = "0.1.0.dev0"
+source = { editable = "." }
+dependencies = [
+    { name = "chatlas" },
+    { name = "duckdb" },
+    { name = "jinja2" },
+    { name = "pyarrow" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "raghilda" },
+    { name = "sqlalchemy" },
+]
+
+[package.optional-dependencies]
+tracing = [
+    { name = "httpx" },
+    { name = "opentelemetry-exporter-otlp-json-file" },
+    { name = "opentelemetry-sdk" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pyrefly" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "chatlas", specifier = ">=0.21.2" },
+    { name = "duckdb", specifier = ">=1.0" },
+    { name = "httpx", marker = "extra == 'tracing'", specifier = ">=0.27" },
+    { name = "jinja2", specifier = ">=3" },
+    { name = "opentelemetry-exporter-otlp-json-file", marker = "extra == 'tracing'" },
+    { name = "opentelemetry-sdk", marker = "extra == 'tracing'", specifier = ">=1.39" },
+    { name = "pyarrow", specifier = ">=17" },
+    { name = "pydantic", specifier = ">=2" },
+    { name = "pyyaml", specifier = ">=6" },
+    { name = "raghilda", specifier = ">=0.2" },
+    { name = "sqlalchemy", specifier = ">=2.0" },
+]
+provides-extras = ["tracing"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pyrefly" },
+    { name = "pytest", specifier = ">=8" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[[package]]
 name = "defusedxml"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -899,60 +953,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "posit-commons"
-version = "0.1.0.dev0"
-source = { editable = "." }
-dependencies = [
-    { name = "chatlas" },
-    { name = "duckdb" },
-    { name = "jinja2" },
-    { name = "pyarrow" },
-    { name = "pydantic" },
-    { name = "pyyaml" },
-    { name = "raghilda" },
-    { name = "sqlalchemy" },
-]
-
-[package.optional-dependencies]
-tracing = [
-    { name = "httpx" },
-    { name = "opentelemetry-exporter-otlp-json-file" },
-    { name = "opentelemetry-sdk" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pyrefly" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "chatlas", specifier = ">=0.21.2" },
-    { name = "duckdb", specifier = ">=1.0" },
-    { name = "httpx", marker = "extra == 'tracing'", specifier = ">=0.27" },
-    { name = "jinja2", specifier = ">=3" },
-    { name = "opentelemetry-exporter-otlp-json-file", marker = "extra == 'tracing'" },
-    { name = "opentelemetry-sdk", marker = "extra == 'tracing'", specifier = ">=1.39" },
-    { name = "pyarrow", specifier = ">=17" },
-    { name = "pydantic", specifier = ">=2" },
-    { name = "pyyaml", specifier = ">=6" },
-    { name = "raghilda", specifier = ">=0.2" },
-    { name = "sqlalchemy", specifier = ">=2.0" },
-]
-provides-extras = ["tracing"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pyrefly" },
-    { name = "pytest", specifier = ">=8" },
-    { name = "pytest-asyncio" },
-    { name = "ruff" },
 ]
 
 [[package]]

--- a/pkg-py/uv.lock
+++ b/pkg-py/uv.lock
@@ -200,7 +200,7 @@ wheels = [
 
 [[package]]
 name = "commons"
-version = "0.1.0.dev0"
+version = "0.1.0.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "chatlas" },


### PR DESCRIPTION
We own the `commons` name on PyPI now, so the Python package is published under it instead of `posit-commons`. The import name was already `commons` and does not change.

## Summary

The distribution name in `pkg-py/pyproject.toml` becomes `commons`, and the lockfile, both READMEs, the package docstring, and the comment in `py-release.yaml` follow.

Because the distribution and import names are now the same, two things that existed only to support the mismatch are removed rather than updated. Hatchling derives the package directory from the distribution name, so `[tool.hatch.build.targets.wheel] packages` was needed to point it at `src/commons`; it now infers the same directory unaided. And `pkg-py/tests/test_packaging.py` was written to make the split hard to reverse by accident, including a test asserting that `posit_commons` is not importable, which no longer pins anything. What remains pins the distribution name, the import name, and the `py.typed` marker.

## Review notes

The trusted publisher on the `commons` PyPI project is already configured against this same workflow file, so releases keep working over OIDC with no repository change beyond that comment.

This breaks `pip install posit-commons`, deliberately and with no deprecation path. `posit-commons` only ever held one placeholder release (0.1.0.dev0), nothing depends on it, and the repository's own guidance is that neither package has been publicly released. The intent is to delete that project from PyPI rather than yank it or keep it as a redirect.

Two consequences worth weighing, neither visible in the diff:

- Deleting a PyPI project frees its name for anyone to re-register, because PyPI only blocks reuse of deleted versions within a surviving project, not deleted project names. Someone could publish a hostile `posit-commons` that stale links would install.
- The `commons` project currently lists no files at all, which is consistent with its earlier releases having been deleted. PyPI permanently blocks reuse of deleted version numbers, so the version here is 0.1.0.dev1 rather than 0.1.0.dev0. That number has never been published under either name, so tagging this after merge exercises the release workflow end to end instead of failing on a duplicate.

## Testing

`uv sync --locked --all-extras`, `uv run ruff check`, `uv run ruff format --check`, `uv run pyrefly check`, and `uv run pytest` all pass, which is what `py-check.yaml` runs. The `--locked` run is the one that matters most here, since it confirms the regenerated lockfile matches the renamed project.

Beyond the standard checks, both the wheel and the sdist were built and inspected, confirming that dropping the hatch packages setting still yields `commons/` with `py.typed` at the root. The release workflow's tag check was also simulated against the new wheel filename, confirming it accepts `py-v0.1.0.dev1` and rejects a mismatched tag. That check parses the version out of the filename, which the distribution name is part of, so the rename could have broken it.

No tests were added. `test_packaging.py` shrank because the behaviour it guarded no longer exists.
