### PR TITLE
Python streaming citation scanner + shared projection fixtures

### DIFF
--- a/pkg-py/src/commons/_citation_scan.py
+++ b/pkg-py/src/commons/_citation_scan.py
@@ -75,6 +75,7 @@ class _Event:
 
 
 def _find(literal: str, buffer: str) -> re.Match[str] | None:
+    """Locate the first occurrence of a reserved literal in the buffer."""
     return _LITERALS[literal].search(buffer)
 
 
@@ -161,6 +162,7 @@ class CitationScanner:
         return self._step_discard()
 
     def _step_text(self) -> bool:
+        """Emit plain text up to the next reserved literal, or up to the holdback."""
         event = self._find_text_event()
         if event is not None:
             prefix = self._buffer[: event.pos]
@@ -185,6 +187,7 @@ class CitationScanner:
         return False
 
     def _step_citation(self) -> bool:
+        """Close, abandon, or keep buffering the citation body being collected."""
         event = self._find_reserved_event()
         if event is not None and event.action == "close" and event.pos <= self._cap:
             body = self._buffer[: event.pos]
@@ -204,6 +207,7 @@ class CitationScanner:
         return False
 
     def _step_discard(self) -> bool:
+        """Drop buffered text through the close tag of the element being discarded."""
         assert self._discard_close is not None
         match = _find(self._discard_close, self._buffer)
         if match is not None:
@@ -220,6 +224,7 @@ class CitationScanner:
         return False
 
     def _find_text_event(self) -> _Event | None:
+        """Find the earliest reserved literal that matters while in text mode."""
         pattern = (
             _CITATION_OPEN_AT_LINE_START
             if self._at_line_start
@@ -241,6 +246,7 @@ class CitationScanner:
         return min(events, key=lambda event: event.pos, default=None)
 
     def _find_reserved_event(self) -> _Event | None:
+        """Find the earliest reserved literal inside a citation body."""
         found: list[tuple[re.Match[str] | None, int, _Action]] = [
             (_find(CITATION_OPEN, self._buffer), len(CITATION_OPEN), "drop"),
             (_find(CITATION_CLOSE, self._buffer), len(CITATION_CLOSE), "close"),
@@ -263,6 +269,7 @@ class CitationScanner:
         return len(self._buffer) - _held_back(self._buffer, CITATION_CLOSE)
 
     def _holdback_length(self) -> int:
+        """Longest buffer tail that could still grow into any reserved literal."""
         return max(
             _held_back(self._buffer, CITATION_OPEN, self._at_line_start),
             _held_back(self._buffer, ASIDE_OPEN),
@@ -271,6 +278,7 @@ class CitationScanner:
         )
 
     def _close_citation(self, body: str) -> None:
+        """Parse a completed citation body, record its verdict, and emit if verified."""
         parsed = parse_commons_citation(body)
         if parsed is None:
             self._candidates.append(CitationDecision(quote=None, status="malformed"))
@@ -296,14 +304,17 @@ class CitationScanner:
         )
 
     def _begin_discard(self, close_literal: str) -> None:
+        """Enter discard mode, dropping everything through ``close_literal``."""
         self._mode = "discard"
         self._discard_close = close_literal
 
     def _emit(self, text: str) -> None:
+        """Queue text for the current chunk's output."""
         if text:
             self._out.append(text)
 
     def _note_line_start(self, original: str) -> None:
+        """Update whether the next text sits at a line start, per the model's text."""
         # Tag anchoring follows the model's own text, not the projected output.
         if original:
             self._at_line_start = original.endswith("\n")

--- a/pkg-py/src/commons/_citation_scan.py
+++ b/pkg-py/src/commons/_citation_scan.py
@@ -56,10 +56,10 @@ _PREFIXES = {
 }
 # The opening tag only counts at the start of a line, so prose that mentions it
 # mid-sentence survives.
-_CITATION_OPEN_ANCHORED = re.compile(
+_CITATION_OPEN_AFTER_NEWLINE = re.compile(
     r"(?<=\n)" + re.escape(CITATION_OPEN), re.IGNORECASE
 )
-_CITATION_OPEN_AT_START = re.compile(
+_CITATION_OPEN_AT_LINE_START = re.compile(
     r"(?:^|(?<=\n))" + re.escape(CITATION_OPEN), re.IGNORECASE
 )
 
@@ -216,7 +216,9 @@ class CitationScanner:
 
     def _find_text_event(self) -> _Event | None:
         pattern = (
-            _CITATION_OPEN_AT_START if self._at_line_start else _CITATION_OPEN_ANCHORED
+            _CITATION_OPEN_AT_LINE_START
+            if self._at_line_start
+            else _CITATION_OPEN_AFTER_NEWLINE
         )
         found: list[tuple[re.Match[str] | None, int, _Action]] = [
             (pattern.search(self._buffer), len(CITATION_OPEN), "citation"),

--- a/pkg-py/src/commons/_citation_scan.py
+++ b/pkg-py/src/commons/_citation_scan.py
@@ -41,9 +41,9 @@ ELEMENT_BODY_CAP = 16384
 _Mode = Literal["text", "citation", "discard"]
 _Action = Literal["citation", "aside", "drop", "close"]
 
-# Matched as patterns rather than by lowercasing the buffer (like in R), because
-# casefolding unicode can change a string's length and would shift every position
-# that follows.
+# Matched as patterns rather than by lowercasing the buffer, as R does: Python's
+# str.lower() can change a string's length, which would shift every position that
+# follows, while R's tolower() preserves it.
 _LITERALS = {
     literal: re.compile(re.escape(literal), re.IGNORECASE)
     for literal in (CITATION_OPEN, CITATION_CLOSE, ASIDE_OPEN, ASIDE_CLOSE)

--- a/pkg-py/src/commons/_citation_scan.py
+++ b/pkg-py/src/commons/_citation_scan.py
@@ -1,0 +1,302 @@
+"""Project a model's streamed text for display, holding reserved markup back.
+
+The projection is a cross-language contract pinned by the ``citation_scan``
+cases in ``tests/shared/citations.json``; change that fixture, not just this
+file. ``pkg-r/R/citation-scan.R`` implements the same contract for R.
+
+Reserved markup is anything the display layer treats as trusted: a
+``<commons-citation>`` block, which becomes an aside only once its quote
+verifies, and a ``<shiny-aside>``, which the model must never be able to author.
+Output cannot depend on where a chunk boundary falls, so text that could still
+grow into a reserved tag is held back until the next chunk decides it.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+from ._citations import (
+    CitationDecision,
+    CorpusEntry,
+    citation_aside_html,
+    match_citation,
+    parse_commons_citation,
+)
+
+__all__ = ["CitationScanner"]
+
+CITATION_OPEN = "<commons-citation>"
+CITATION_CLOSE = "</commons-citation>"
+# Attributes may follow, so the opening aside tag is matched without its bracket.
+ASIDE_OPEN = "<shiny-aside"
+ASIDE_CLOSE = "</shiny-aside>"
+
+# A body this large is a runaway rather than a citation. Past it the element is
+# abandoned, which is what keeps an unclosed tag from buffering without limit.
+ELEMENT_BODY_CAP = 16384
+
+_Mode = Literal["text", "citation", "discard"]
+_Action = Literal["citation", "aside", "drop", "close"]
+
+# Matched as patterns rather than by lowercasing the buffer, because casefolding
+# can change a string's length and would shift every position that follows.
+_LITERALS = {
+    literal: re.compile(re.escape(literal), re.IGNORECASE)
+    for literal in (CITATION_OPEN, CITATION_CLOSE, ASIDE_OPEN, ASIDE_CLOSE)
+}
+_PREFIXES = {
+    literal: [
+        re.compile(re.escape(literal[:length]) + r"\Z", re.IGNORECASE)
+        for length in range(len(literal))
+    ]
+    for literal in _LITERALS
+}
+# The opening tag only counts at the start of a line, so prose that mentions it
+# mid-sentence survives.
+_CITATION_OPEN_ANCHORED = re.compile(
+    r"(?<=\n)" + re.escape(CITATION_OPEN), re.IGNORECASE
+)
+_CITATION_OPEN_AT_START = re.compile(
+    r"(?:^|(?<=\n))" + re.escape(CITATION_OPEN), re.IGNORECASE
+)
+
+
+@dataclass(frozen=True)
+class _Event:
+    """A reserved literal found in the buffer, and what to do with it."""
+
+    pos: int
+    length: int
+    action: _Action
+
+
+def _find(literal: str, buffer: str) -> re.Match[str] | None:
+    return _LITERALS[literal].search(buffer)
+
+
+def _held_back(buffer: str, literal: str, at_line_start: bool | None = None) -> int:
+    """Length of the longest buffer suffix that could still grow into ``literal``.
+
+    Pass ``at_line_start`` for a literal that only counts at the start of a
+    line, so a tail that could never open an element is emitted rather than
+    held; leave it None for the literals that count at any position.
+    """
+    for length in range(min(len(buffer), len(literal) - 1), 0, -1):
+        start = len(buffer) - length
+        if at_line_start is not None:
+            anchored = at_line_start if start == 0 else buffer[start - 1] == "\n"
+            if not anchored:
+                continue
+        if _PREFIXES[literal][length].match(buffer, start):
+            return length
+    return 0
+
+
+class CitationScanner:
+    """Rewrite verified citations and drop every other reserved element.
+
+    Feed the model's chunks in and emit what is safe to display now. The
+    scanner projects text for display and never rewrites what the caller
+    stores, so the turn keeps the model's own words.
+    """
+
+    def __init__(
+        self,
+        corpus: Sequence[CorpusEntry] = (),
+        *,
+        max_element_bytes: int = ELEMENT_BODY_CAP,
+    ) -> None:
+        self._corpus = list(corpus)
+        self._cap = max_element_bytes
+        self._buffer = ""
+        self._mode: _Mode = "text"
+        self._at_line_start = True
+        self._discard_close: str | None = None
+        self._candidates: list[CitationDecision] = []
+        self._out: list[str] = []
+
+    def feed(self, chunk: str) -> str:
+        """Consume a stream chunk and return the text safe to emit now."""
+        self._buffer += chunk
+        self._out = []
+        while self._step():
+            pass
+        return "".join(self._out)
+
+    def finish(self) -> str:
+        """Flush held-back text at end of stream."""
+        if self._mode == "text":
+            flushed, self._buffer = self._buffer, ""
+            return flushed
+        # Incomplete model-authored markup must never reach the display.
+        self._buffer = ""
+        self._mode = "text"
+        self._discard_close = None
+        return ""
+
+    @property
+    def candidates(self) -> list[CitationDecision]:
+        """Every candidate citation and its verdict, in the order they arrived."""
+        return list(self._candidates)
+
+    @property
+    def any_verified(self) -> bool:
+        """Whether any candidate's quote was found in the corpus."""
+        return any(candidate.status == "accepted" for candidate in self._candidates)
+
+    def _step(self) -> bool:
+        """Advance once. True when the buffer moved and another step may apply."""
+        if self._mode == "text":
+            return self._step_text()
+        if self._mode == "citation":
+            return self._step_citation()
+        return self._step_discard()
+
+    def _step_text(self) -> bool:
+        event = self._find_text_event()
+        if event is not None:
+            prefix = self._buffer[: event.pos]
+            literal = self._buffer[event.pos : event.pos + event.length]
+            self._emit(prefix)
+            self._note_line_start(prefix)
+            self._buffer = self._buffer[event.pos + event.length :]
+            if event.action == "citation":
+                self._mode = "citation"
+            elif event.action == "aside":
+                self._begin_discard(ASIDE_CLOSE)
+            else:
+                self._note_line_start(literal)
+            return True
+
+        flush_to = len(self._buffer) - self._holdback_length()
+        if flush_to > 0:
+            flushed = self._buffer[:flush_to]
+            self._emit(flushed)
+            self._note_line_start(flushed)
+            self._buffer = self._buffer[flush_to:]
+        return False
+
+    def _step_citation(self) -> bool:
+        event = self._find_reserved_event()
+        if event is not None and event.action == "close" and event.pos <= self._cap:
+            body = self._buffer[: event.pos]
+            self._buffer = self._buffer[event.pos + event.length :]
+            self._close_citation(body)
+            self._mode = "text"
+            self._at_line_start = False
+            return True
+        # Any other reserved literal inside the body means the element is not a
+        # citation at all, so it is abandoned rather than parsed.
+        if event is not None:
+            self._begin_discard(CITATION_CLOSE)
+            return True
+        if self._confirmed_body_length() > self._cap:
+            self._begin_discard(CITATION_CLOSE)
+            return True
+        return False
+
+    def _step_discard(self) -> bool:
+        assert self._discard_close is not None
+        match = _find(self._discard_close, self._buffer)
+        if match is not None:
+            self._note_line_start(self._buffer[: match.end()])
+            self._buffer = self._buffer[match.end() :]
+            self._mode = "text"
+            self._discard_close = None
+            return True
+
+        drop_to = len(self._buffer) - _held_back(self._buffer, self._discard_close)
+        if drop_to > 0:
+            self._note_line_start(self._buffer[:drop_to])
+            self._buffer = self._buffer[drop_to:]
+        return False
+
+    def _find_text_event(self) -> _Event | None:
+        pattern = (
+            _CITATION_OPEN_AT_START if self._at_line_start else _CITATION_OPEN_ANCHORED
+        )
+        found: list[tuple[re.Match[str] | None, int, _Action]] = [
+            (pattern.search(self._buffer), len(CITATION_OPEN), "citation"),
+            (_find(ASIDE_OPEN, self._buffer), len(ASIDE_OPEN), "aside"),
+            # A close tag with no open one is stray markup and is dropped, but
+            # it leaves the text around it alone.
+            (_find(CITATION_CLOSE, self._buffer), len(CITATION_CLOSE), "drop"),
+            (_find(ASIDE_CLOSE, self._buffer), len(ASIDE_CLOSE), "drop"),
+        ]
+        events = [
+            _Event(match.start(), length, action)
+            for match, length, action in found
+            if match is not None
+        ]
+        return min(events, key=lambda event: event.pos, default=None)
+
+    def _find_reserved_event(self) -> _Event | None:
+        found: list[tuple[re.Match[str] | None, int, _Action]] = [
+            (_find(CITATION_OPEN, self._buffer), len(CITATION_OPEN), "drop"),
+            (_find(CITATION_CLOSE, self._buffer), len(CITATION_CLOSE), "close"),
+            (_find(ASIDE_OPEN, self._buffer), len(ASIDE_OPEN), "drop"),
+            (_find(ASIDE_CLOSE, self._buffer), len(ASIDE_CLOSE), "drop"),
+        ]
+        events = [
+            _Event(match.start(), length, action)
+            for match, length, action in found
+            if match is not None
+        ]
+        return min(events, key=lambda event: event.pos, default=None)
+
+    def _confirmed_body_length(self) -> int:
+        """Body length so far, less a partial close tag that may still complete.
+
+        Counting the partial tag would let a chunk boundary push an in-range
+        body over the cap.
+        """
+        return len(self._buffer) - _held_back(self._buffer, CITATION_CLOSE)
+
+    def _holdback_length(self) -> int:
+        return max(
+            _held_back(self._buffer, CITATION_OPEN, self._at_line_start),
+            _held_back(self._buffer, ASIDE_OPEN),
+            _held_back(self._buffer, CITATION_CLOSE),
+            _held_back(self._buffer, ASIDE_CLOSE),
+        )
+
+    def _close_citation(self, body: str) -> None:
+        parsed = parse_commons_citation(body)
+        if parsed is None:
+            self._candidates.append(CitationDecision(quote=None, status="malformed"))
+            return
+        entry = match_citation(parsed.quote, self._corpus)
+        if entry is None:
+            self._candidates.append(
+                CitationDecision(quote=parsed.quote, status="rejected")
+            )
+            return
+        self._emit(
+            citation_aside_html(
+                parsed.quote, parsed.explanation, entry.label, entry.kind
+            )
+        )
+        self._candidates.append(
+            CitationDecision(
+                quote=parsed.quote,
+                status="accepted",
+                label=entry.label,
+                kind=entry.kind,
+            )
+        )
+
+    def _begin_discard(self, close_literal: str) -> None:
+        self._mode = "discard"
+        self._discard_close = close_literal
+
+    def _emit(self, text: str) -> None:
+        if text:
+            self._out.append(text)
+
+    def _note_line_start(self, original: str) -> None:
+        # Tag anchoring follows the model's own text, not the projected output.
+        if original:
+            self._at_line_start = original.endswith("\n")

--- a/pkg-py/src/commons/_citation_scan.py
+++ b/pkg-py/src/commons/_citation_scan.py
@@ -1,6 +1,6 @@
 """Project a model's streamed text for display, holding reserved markup back.
 
-The projection is a cross-language contract pinned by the ``citation_scan``
+The projection is shared cross-language and enforced by the ``citation_scan``
 cases in ``tests/shared/citations.json``; change that fixture, not just this
 file. ``pkg-r/R/citation-scan.R`` implements the same contract for R.
 
@@ -41,8 +41,9 @@ ELEMENT_BODY_CAP = 16384
 _Mode = Literal["text", "citation", "discard"]
 _Action = Literal["citation", "aside", "drop", "close"]
 
-# Matched as patterns rather than by lowercasing the buffer, because casefolding
-# can change a string's length and would shift every position that follows.
+# Matched as patterns rather than by lowercasing the buffer (like in R), because
+# casefolding unicode can change a string's length and would shift every position
+# that follows.
 _LITERALS = {
     literal: re.compile(re.escape(literal), re.IGNORECASE)
     for literal in (CITATION_OPEN, CITATION_CLOSE, ASIDE_OPEN, ASIDE_CLOSE)
@@ -101,6 +102,10 @@ class CitationScanner:
     Feed the model's chunks in and emit what is safe to display now. The
     scanner projects text for display and never rewrites what the caller
     stores, so the turn keeps the model's own words.
+
+    ``citation_scanner()`` in ``pkg-r/R/citation-scan.R`` is the R side of the
+    same contract, and the ``citation_scan`` and ``citation_holdback`` cases in
+    ``tests/shared/citations.json`` hold the two to the same output.
     """
 
     def __init__(

--- a/pkg-py/src/commons/_citations.py
+++ b/pkg-py/src/commons/_citations.py
@@ -181,8 +181,7 @@ def citation_aside_html(quote: str, explanation: str, label: str, kind: str) -> 
 
     ``kind`` selects the icon the UI layer draws beside the label. No icon is
     emitted yet: the URL comes from the served asset bundle, which arrives with
-    the Python UI (see decision D10 in the port plan), and a URL nothing serves
-    would be worse than none.
+    the Python UI (see decision D10 in the port plan).
     """
     reason = f"{explanation}\n\n" if explanation else ""
     blockquote = "> " + quote.strip().replace("\n", "\n> ")

--- a/pkg-py/src/commons/_citations.py
+++ b/pkg-py/src/commons/_citations.py
@@ -7,6 +7,7 @@ file. ``pkg-r/R/citations.R`` implements the same contract for R.
 
 from __future__ import annotations
 
+import html
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -16,6 +17,7 @@ __all__ = [
     "CitationDecision",
     "CorpusEntry",
     "ParsedCitation",
+    "citation_aside_html",
     "match_citation",
     "normalize_citation",
     "parse_commons_citation",
@@ -172,3 +174,31 @@ def match_citation(quote: str, corpus: Sequence[CorpusEntry]) -> CorpusEntry | N
         (entry for entry in corpus if needle in normalize_citation(entry.text)),
         None,
     )
+
+
+def citation_aside_html(quote: str, explanation: str, label: str, kind: str) -> str:
+    """Render a verified citation as the aside shinychat displays.
+
+    ``kind`` selects the icon the UI layer draws beside the label. No icon is
+    emitted yet: the URL comes from the served asset bundle, which arrives with
+    the Python UI (see decision D10 in the port plan), and a URL nothing serves
+    would be worse than none.
+    """
+    reason = f"{explanation}\n\n" if explanation else ""
+    blockquote = "> " + quote.strip().replace("\n", "\n> ")
+    # shinychat only renders the popover's title row for grouped asides, so the
+    # body carries its own title to keep the source named for a lone citation.
+    title = (
+        '<span class="commons-citation-title">'
+        '<span class="commons-citation-title-label">'
+        f"{html.escape(label, quote=False)}</span></span>\n\n"
+    )
+    return (
+        f'<shiny-aside label="{_escape_attr(label)}">'
+        f"{title}{reason}{blockquote}</shiny-aside>"
+    )
+
+
+# Ampersands first, so the entities this generates are not escaped again.
+def _escape_attr(text: str) -> str:
+    return text.replace("&", "&amp;").replace('"', "&quot;")

--- a/pkg-py/tests/test_citation_scan.py
+++ b/pkg-py/tests/test_citation_scan.py
@@ -1,0 +1,157 @@
+"""The streaming scanner that projects model text for display.
+
+The projection is a cross-language contract, so the cases live in
+``tests/shared/citations.json`` under ``citation_scan`` and the R suite runs
+the same ones. Do not restate a case here; add it to the fixture.
+"""
+
+from collections.abc import Iterator, Sequence
+from typing import Any
+
+import pytest
+
+from commons._citation_scan import CITATION_CLOSE, ELEMENT_BODY_CAP, CitationScanner
+from commons._citations import CorpusEntry, citation_aside_html, match_citation
+
+from ._shared import load_shared_fixture
+
+SPEC: dict[str, Any] = load_shared_fixture("citations")["citation_scan"]
+CASES: list[dict[str, Any]] = SPEC["cases"]
+HOLDBACK_CASES: list[dict[str, Any]] = load_shared_fixture("citations")[
+    "citation_holdback"
+]["cases"]
+CORPORA: dict[str, list[dict[str, Any]]] = SPEC["corpora"]
+EXHAUSTIVE_MAX: int = SPEC["exhaustive_split_max_chars"]
+
+PAD_TOKEN = "{{pad}}"
+SPLIT_TOKEN = "{{split}}"
+CITATION_OPEN = "<commons-citation>"
+
+# One sample passage for the tests below that need a quote but do not pin the
+# projection. Anything that pins the projection belongs in the fixture.
+SAMPLE_QUOTE = "Canopy cover is always acre-weighted for reporting."
+SAMPLE_CORPUS = [CorpusEntry(label="documentation", kind="prose", text=SAMPLE_QUOTE)]
+
+
+def scan(chunks: Sequence[str], corpus: Sequence[CorpusEntry]) -> tuple[str, list[Any]]:
+    scanner = CitationScanner(corpus)
+    text = "".join(scanner.feed(chunk) for chunk in chunks) + scanner.finish()
+    return text, [decision.as_record() for decision in scanner.candidates]
+
+
+def _padding(case: dict[str, Any], text: str) -> str:
+    """Expand ``{{pad}}`` so the first citation body reaches its stated length."""
+    pad = case.get("pad")
+    if pad is None:
+        return ""
+    body = text.split(CITATION_OPEN, 1)[1].split(CITATION_CLOSE, 1)[0]
+    return pad["char"] * (pad["citation_body_length"] - len(body) + len(PAD_TOKEN))
+
+
+def _render(
+    case: dict[str, Any],
+    expected: str,
+    corpus: Sequence[CorpusEntry],
+    padding: str,
+) -> str:
+    """Substitute each ``{{aside:N}}`` with the aside this package renders."""
+    for index, aside in enumerate(case.get("asides", [])):
+        quote = aside["quote"]
+        entry = match_citation(quote, corpus)
+        assert entry is not None, f"aside {index} of {case['name']} does not verify"
+        explanation = aside["explanation"].replace(PAD_TOKEN, padding)
+        html = citation_aside_html(quote, explanation, entry.label, entry.kind)
+        expected = expected.replace(f"{{{{aside:{index}}}}}", html)
+    return expected
+
+
+def _chunkings(text: str, explicit: list[str]) -> Iterator[tuple[str, list[str]]]:
+    yield "the whole text", [text]
+    if len(explicit) > 1:
+        yield "the fixture's feed boundaries", explicit
+    if len(text) <= EXHAUSTIVE_MAX:
+        yield "one character at a time", list(text)
+        for at in range(1, len(text)):
+            yield f"a split at {at}", [text[:at], text[at:]]
+
+
+def test_shared_fixture_is_populated() -> None:
+    # Parametrizing over an empty list collects nothing and the suite still
+    # passes, so pin what the fixture has to cover.
+    assert len(CASES) >= 20
+    statuses = {decision["status"] for case in CASES for decision in case["decisions"]}
+    assert statuses == {"accepted", "rejected", "malformed"}
+
+
+def test_the_cap_matches_the_shared_fixture() -> None:
+    assert ELEMENT_BODY_CAP == SPEC["element_body_cap"]
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda case: case["name"])
+def test_projection_matches_the_shared_cases(case: dict[str, Any]) -> None:
+    corpus = [CorpusEntry(**entry) for entry in CORPORA[case["corpus"]]]
+    text = case["text"].replace(SPLIT_TOKEN, "")
+    padding = _padding(case, text)
+    text = text.replace(PAD_TOKEN, padding)
+    chunks = case["text"].replace(PAD_TOKEN, padding).split(SPLIT_TOKEN)
+    expected = _render(
+        case, case["expected_text"].replace(PAD_TOKEN, padding), corpus, padding
+    )
+
+    for description, fed in _chunkings(text, chunks):
+        got_text, got_decisions = scan(fed, corpus)
+        assert got_text == expected, f"fed {description}"
+        assert got_decisions == case["decisions"], f"fed {description}"
+
+
+@pytest.mark.parametrize("case", HOLDBACK_CASES, ids=lambda case: case["name"])
+def test_each_feed_emits_the_shared_cases(case: dict[str, Any]) -> None:
+    scanner = CitationScanner(SAMPLE_CORPUS)
+
+    emitted = [scanner.feed(chunk) for chunk in case["chunks"]]
+
+    assert emitted == case["emitted"]
+    assert scanner.finish() == case["flushed"]
+
+
+def test_any_verified_reports_whether_a_quote_was_accepted() -> None:
+    scanner = CitationScanner(SAMPLE_CORPUS)
+    assert not scanner.any_verified
+
+    scanner.feed("<commons-citation>\n\nwhy\n\n> nothing supports this\n\n")
+    scanner.feed("</commons-citation>")
+    assert not scanner.any_verified
+
+    scanner.feed(f"\n<commons-citation>\n\nwhy\n\n> {SAMPLE_QUOTE}\n\n")
+    scanner.feed("</commons-citation>")
+    assert scanner.any_verified
+
+
+def test_an_oversized_unclosed_citation_does_not_grow_the_buffer() -> None:
+    # Memory, not projection: the fixture pins that nothing is emitted, and
+    # this pins that nothing is retained while waiting for a close tag.
+    scanner = CitationScanner(SAMPLE_CORPUS)
+
+    assert scanner.feed("<commons-citation>" + "x" * (ELEMENT_BODY_CAP + 1)) == ""
+    assert len(scanner._buffer) < len(CITATION_CLOSE)
+    assert scanner.feed("y" * (ELEMENT_BODY_CAP * 2)) == ""
+    assert len(scanner._buffer) < len(CITATION_CLOSE)
+    assert scanner.finish() == ""
+
+
+def test_the_aside_escapes_its_label_and_reflows_the_quote() -> None:
+    html = citation_aside_html(
+        "first line\nsecond line", "why", 'a "quoted" & label', "prose"
+    )
+
+    # The attribute and the title text sit in different contexts, so they are
+    # escaped differently: quotes in the attribute, angle brackets in the text.
+    assert html.startswith('<shiny-aside label="a &quot;quoted&quot; &amp; label">')
+    assert '>a "quoted" &amp; label</span>' in html
+    assert html.endswith("why\n\n> first line\n> second line</shiny-aside>")
+
+
+def test_the_aside_omits_the_explanation_when_the_model_gave_none() -> None:
+    html = citation_aside_html(SAMPLE_QUOTE, "", "documentation", "prose")
+
+    assert html.endswith(f"</span>\n\n> {SAMPLE_QUOTE}</shiny-aside>")

--- a/pkg-r/tests/testthat/fixtures/shared/citations.json
+++ b/pkg-r/tests/testthat/fixtures/shared/citations.json
@@ -649,9 +649,9 @@
       },
       {
         "name": "a body one character over the cap is removed",
-        "why": "Past the cap the element is abandoned without a verdict, so an unbounded body cannot be buffered while waiting for a close tag.",
+        "why": "Past the cap the element is abandoned without a verdict, so an unbounded body cannot be buffered while waiting for a close tag. The boundary before the close tag is where the body crosses the cap with no part of a close tag buffered to discount.",
         "corpus": "documentation",
-        "text": "Before.\n<commons-cit{{split}}ation>{{pad}}\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-cita{{split}}tion>\nAfter.",
+        "text": "Before.\n<commons-cit{{split}}ation>{{pad}}\n\n> Canopy cover is always acre-weighted for reporting.\n\n{{split}}</commons-cita{{split}}tion>\nAfter.",
         "pad": {
           "char": "x",
           "citation_body_length": 16385

--- a/pkg-r/tests/testthat/fixtures/shared/citations.json
+++ b/pkg-r/tests/testthat/fixtures/shared/citations.json
@@ -626,7 +626,7 @@
         "name": "a body exactly at the cap verifies",
         "why": "The cap is inclusive, so the largest allowed body is still scanned.",
         "corpus": "documentation",
-        "text": "<commons-citation>{{pad}}{{split}}\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>",
+        "text": "<commons-cita{{split}}tion>{{pad}}{{split}}\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-cit{{split}}ation>",
         "pad": {
           "char": "x",
           "citation_body_length": 16384
@@ -651,7 +651,7 @@
         "name": "a body one character over the cap is removed",
         "why": "Past the cap the element is abandoned without a verdict, so an unbounded body cannot be buffered while waiting for a close tag.",
         "corpus": "documentation",
-        "text": "Before.\n<commons-citation>{{pad}}\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\nAfter.",
+        "text": "Before.\n<commons-cit{{split}}ation>{{pad}}\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-cita{{split}}tion>\nAfter.",
         "pad": {
           "char": "x",
           "citation_body_length": 16385
@@ -688,7 +688,7 @@
         "name": "scanning resumes after an oversized element",
         "why": "An element dropped for size must not swallow the elements after it.",
         "corpus": "documentation",
-        "text": "Before.\n<commons-citation>{{pad}}</commons-citation>\nBetween.\n<commons-citation>\n\nno blockquote\n\n</commons-citation>\nAfter malformed.\n<commons-citation>\n\nFollows the weighting rule.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\nAfter valid.",
+        "text": "Before.\n<commo{{split}}ns-citation>{{pad}}{{split}}</commons-cit{{split}}ation>\nBetween.\n<commons-cit{{split}}ation>\n\nno blockquote\n\n</commons-citation>\nAfter malformed.\n<commons-citation>\n\nFollows the weighting rule.\n\n> Canopy cover is always acre-weighted for reporting.{{split}}\n\n</commons-c{{split}}itation>\nAfter valid.",
         "pad": {
           "char": "x",
           "citation_body_length": 16385

--- a/pkg-r/tests/testthat/fixtures/shared/citations.json
+++ b/pkg-r/tests/testthat/fixtures/shared/citations.json
@@ -326,5 +326,461 @@
         }
       }
     ]
+  },
+  "citation_scan": {
+    "description": "The streaming scanner that projects a model's text for display. It rewrites a verified <commons-citation> into a <shiny-aside>, drops every other reserved element, and passes the rest through unchanged. Output must not depend on where chunk boundaries fall.\nEach case gives a corpus, an input text, the expected output, and the expected candidate verdicts. Three tokens appear in the strings. '{{pad}}' expands to 'pad.char' repeated so that the body of the first <commons-citation> element is exactly 'pad.citation_body_length' characters, which is how the cap cases stay small on disk. '{{split}}' marks a feed boundary and is removed from the input text. '{{aside:N}}' stands for the Nth entry of 'asides' rendered by the reading package, because the two packages differ in the icon URLs they can resolve; every other character of the expected output is pinned exactly.",
+    "element_body_cap": 16384,
+    "exhaustive_split_max_chars": 1000,
+    "corpora": {
+      "empty": [],
+      "documentation": [
+        {
+          "label": "documentation",
+          "kind": "prose",
+          "text": "Canopy cover is always acre-weighted for reporting."
+        }
+      ]
+    },
+    "cases": [
+      {
+        "name": "plain text passes through unchanged",
+        "why": "A bare '<' is not the start of a reserved tag, so nothing is held back past it.",
+        "corpus": "empty",
+        "text": "Hello.\n\nA < b, honest.",
+        "expected_text": "Hello.\n\nA < b, honest.",
+        "decisions": []
+      },
+      {
+        "name": "a verified citation replaces only its own element",
+        "why": "The surrounding prose keeps its exact separators; only the element is rewritten.",
+        "corpus": "documentation",
+        "text": "Answer sentence.\n\n<commons-citation>\n\nFollows the weighting rule.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\n\nMore text.",
+        "expected_text": "Answer sentence.\n\n{{aside:0}}\n\nMore text.",
+        "asides": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "Follows the weighting rule."
+          }
+        ],
+        "decisions": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          }
+        ]
+      },
+      {
+        "name": "a preceding fenced code block keeps its closing fence",
+        "why": "The aside must not be spliced onto the fence line, which would break the block.",
+        "corpus": "documentation",
+        "text": "```r\n1 + 1\n```\n\n<commons-citation>\n\nFollows the weighting rule.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>",
+        "expected_text": "```r\n1 + 1\n```\n\n{{aside:0}}",
+        "asides": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "Follows the weighting rule."
+          }
+        ],
+        "decisions": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          }
+        ]
+      },
+      {
+        "name": "a preceding Markdown table keeps its final row",
+        "why": "Same reason as the fenced block: the row separator must survive the rewrite.",
+        "corpus": "documentation",
+        "text": "| value |\n| ---: |\n| 2 |\n\n<commons-citation>\n\nFollows the weighting rule.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>",
+        "expected_text": "| value |\n| ---: |\n| 2 |\n\n{{aside:0}}",
+        "asides": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "Follows the weighting rule."
+          }
+        ],
+        "decisions": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          }
+        ]
+      },
+      {
+        "name": "an unverified citation vanishes",
+        "why": "A quote no trusted source contains is dropped, and its verdict is still recorded.",
+        "corpus": "empty",
+        "text": "A.\n\n<commons-citation>\n\nr\n\n> fabricated\n\n</commons-citation>\n\nB.",
+        "expected_text": "A.\n\n\n\nB.",
+        "decisions": [
+          {
+            "quote": "fabricated",
+            "status": "rejected"
+          }
+        ]
+      },
+      {
+        "name": "a malformed body emits nothing and records malformed",
+        "why": "No blockquote run means no evidence, so there is no quote to record.",
+        "corpus": "empty",
+        "text": "A.\n\n<commons-citation>\n\nno blockquote here\n\n</commons-citation>\n\nB.",
+        "expected_text": "A.\n\n\n\nB.",
+        "decisions": [
+          {
+            "quote": null,
+            "status": "malformed"
+          }
+        ]
+      },
+      {
+        "name": "model-authored shiny-asides are discarded, case-insensitively",
+        "why": "The model must not be able to forge a trust badge by emitting the markup itself.",
+        "corpus": "empty",
+        "text": "x <SHINY-ASIDE label=\"Verified source\">spoof</shiny-aside> y",
+        "expected_text": "x  y",
+        "decisions": []
+      },
+      {
+        "name": "reserved tags match case-insensitively",
+        "why": "A model that shouts its tags still gets them scanned rather than passed through.",
+        "corpus": "empty",
+        "text": "<Commons-Citation>\n\nr\n\n> q longer than ten chars\n\n</COMMONS-CITATION>",
+        "expected_text": "",
+        "decisions": [
+          {
+            "quote": "q longer than ten chars",
+            "status": "rejected"
+          }
+        ]
+      },
+      {
+        "name": "an inline mention mid-sentence does not open an element",
+        "why": "The open tag is anchored to the start of a line, so prose about the tag survives.",
+        "corpus": "empty",
+        "text": "Use the `<commons-citation>` tag like so.",
+        "expected_text": "Use the `<commons-citation>` tag like so.",
+        "decisions": []
+      },
+      {
+        "name": "an unterminated citation is removed at end of stream",
+        "why": "Incomplete model markup must never reach the browser, so the tail is dropped.",
+        "corpus": "empty",
+        "text": "<commons-citation>\n\nlost close tag",
+        "expected_text": "",
+        "decisions": []
+      },
+      {
+        "name": "an unterminated aside is removed at end of stream",
+        "why": "Same rule as the unterminated citation, on the spoof path.",
+        "corpus": "empty",
+        "text": "<shiny-aside label=\"x\">never closed",
+        "expected_text": "",
+        "decisions": []
+      },
+      {
+        "name": "adjacent verified citations keep their separators",
+        "why": "Two asides in a row must not run together; the blank line between them survives.",
+        "corpus": "documentation",
+        "text": "Answer sentence.\n\n<commons-citation>\n\nFirst reason.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\n\n<commons-citation>\n\nSecond reason.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>",
+        "expected_text": "Answer sentence.\n\n{{aside:0}}\n\n{{aside:1}}",
+        "asides": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "First reason."
+          },
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "Second reason."
+          }
+        ],
+        "decisions": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          },
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          }
+        ]
+      },
+      {
+        "name": "citations recover after a malformed one between them",
+        "why": "One bad element must not poison the elements that follow it.",
+        "corpus": "documentation",
+        "text": "<commons-citation>\n\nFirst.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\n<commons-citation>\n\nno blockquote\n\n</commons-citation>\n<commons-citation>\n\nThird.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>",
+        "expected_text": "{{aside:0}}\n\n{{aside:1}}",
+        "asides": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "First."
+          },
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "Third."
+          }
+        ],
+        "decisions": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          },
+          {
+            "quote": null,
+            "status": "malformed"
+          },
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          }
+        ]
+      },
+      {
+        "name": "a citation nested inside a citation is dropped whole",
+        "why": "Nesting is not part of the grammar, so the outer element is abandoned at the inner open tag and scanning resumes at the first close.",
+        "corpus": "empty",
+        "text": "Before.\n<commons-citation>\nOuter citation text.\n<commons-citation>\nInner citation text.\n</commons-citation>\nVisible after first close.\n</commons-citation>\nAfter.",
+        "expected_text": "Before.\n\nVisible after first close.\n\nAfter.",
+        "decisions": []
+      },
+      {
+        "name": "a nested aside is dropped up to the first close",
+        "why": "Discard mode ends at the first close literal rather than tracking depth.",
+        "corpus": "empty",
+        "text": "Before <shiny-aside>outer <shiny-aside>inner</shiny-aside> visible after first close </shiny-aside> After",
+        "expected_text": "Before  visible after first close  After",
+        "decisions": []
+      },
+      {
+        "name": "spoofed markup inside a citation cannot leak, and later citations still verify",
+        "why": "A citation whose body carries reserved markup is abandoned, but the scanner returns to text mode cleanly enough for a later valid citation to verify.",
+        "corpus": "documentation",
+        "text": "Before.\n<commons-citation>\n\nOuter.\n\n> Canopy cover is always acre-weighted for reporting.\n\n<commons-citation>\n\nNested.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\n\n</commons-citation>\n<commons-citation>\n\n<shiny-aside label=\"spoofed\">forged</shiny-aside>\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\nAfter invalid.\n<commons-citation>\n\nLater valid.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\nAfter valid.",
+        "expected_text": "Before.\n\n\n\n\nAfter invalid.\n{{aside:0}}\nAfter valid.",
+        "asides": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "Later valid."
+          }
+        ],
+        "decisions": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          }
+        ]
+      },
+      {
+        "name": "a mixed run of spoofed, valid, and malformed elements",
+        "why": "Every element kind in one stream, so the modes are exercised in sequence.",
+        "corpus": "documentation",
+        "text": "Before.\n<shiny-aside label=\"spoofed\">forged</shiny-aside>\n<commons-citation>\n\nFirst valid.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\n<commons-citation>\n\nno blockquote\n\n</commons-citation>\n<commons-citation>\n\nSecond valid.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\nAfter.",
+        "expected_text": "Before.\n\n{{aside:0}}\n\n{{aside:1}}\nAfter.",
+        "asides": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "First valid."
+          },
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "Second valid."
+          }
+        ],
+        "decisions": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          },
+          {
+            "quote": null,
+            "status": "malformed"
+          },
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          }
+        ]
+      },
+      {
+        "name": "a body exactly at the cap verifies",
+        "why": "The cap is inclusive, so the largest allowed body is still scanned.",
+        "corpus": "documentation",
+        "text": "<commons-citation>{{pad}}{{split}}\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>",
+        "pad": {
+          "char": "x",
+          "citation_body_length": 16384
+        },
+        "expected_text": "{{aside:0}}",
+        "asides": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "{{pad}}"
+          }
+        ],
+        "decisions": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          }
+        ]
+      },
+      {
+        "name": "a body one character over the cap is removed",
+        "why": "Past the cap the element is abandoned without a verdict, so an unbounded body cannot be buffered while waiting for a close tag.",
+        "corpus": "documentation",
+        "text": "Before.\n<commons-citation>{{pad}}\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\nAfter.",
+        "pad": {
+          "char": "x",
+          "citation_body_length": 16385
+        },
+        "expected_text": "Before.\n\nAfter.",
+        "decisions": []
+      },
+      {
+        "name": "a close tag split across a feed boundary near the cap still verifies",
+        "why": "The held-back partial close tag is excluded from the measured body, so a chunk boundary cannot push an in-range body over the cap.",
+        "corpus": "documentation",
+        "text": "A.\n<commons-citation>{{pad}}\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commo{{split}}ns-citation>\nB.",
+        "pad": {
+          "char": "x",
+          "citation_body_length": 16379
+        },
+        "expected_text": "A.\n{{aside:0}}\nB.",
+        "asides": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "{{pad}}"
+          }
+        ],
+        "decisions": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          }
+        ]
+      },
+      {
+        "name": "scanning resumes after an oversized element",
+        "why": "An element dropped for size must not swallow the elements after it.",
+        "corpus": "documentation",
+        "text": "Before.\n<commons-citation>{{pad}}</commons-citation>\nBetween.\n<commons-citation>\n\nno blockquote\n\n</commons-citation>\nAfter malformed.\n<commons-citation>\n\nFollows the weighting rule.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\nAfter valid.",
+        "pad": {
+          "char": "x",
+          "citation_body_length": 16385
+        },
+        "expected_text": "Before.\n\nBetween.\n\nAfter malformed.\n{{aside:0}}\nAfter valid.",
+        "asides": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "Follows the weighting rule."
+          }
+        ],
+        "decisions": [
+          {
+            "quote": null,
+            "status": "malformed"
+          },
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          }
+        ]
+      }
+    ]
+  },
+  "citation_holdback": {
+    "description": "What each feed() may emit, rather than what the whole stream projects to. Text is emitted as soon as it is known to be safe, and held back only while the buffer's tail could still grow into a reserved literal on the next chunk. Holding back more than that delays a model's words on screen for no reason; holding back less lets a tag split across two chunks reach the display. 'emitted' pins the return of each feed() in turn, and 'flushed' the return of finish().",
+    "cases": [
+      {
+        "name": "a tail that cannot start a reserved literal is emitted at once",
+        "why": "Only a suffix that is a prefix of a reserved literal is worth holding.",
+        "chunks": [
+          "Answer sentence.",
+          " More text."
+        ],
+        "emitted": [
+          "Answer sentence.",
+          " More text."
+        ],
+        "flushed": ""
+      },
+      {
+        "name": "a partial open tag mid-line is emitted rather than held",
+        "why": "The opening tag only counts at the start of a line, so mid-line this text cannot become one however the next chunk continues it.",
+        "chunks": [
+          "Answer.",
+          "<commons"
+        ],
+        "emitted": [
+          "Answer.",
+          "<commons"
+        ],
+        "flushed": ""
+      },
+      {
+        "name": "a partial open tag at a line start is held until it resolves",
+        "why": "Here the next chunk could complete it, so emitting now would leak a tag.",
+        "chunks": [
+          "Answer.\n",
+          "<commons",
+          " not a tag"
+        ],
+        "emitted": [
+          "Answer.\n",
+          "",
+          "<commons not a tag"
+        ],
+        "flushed": ""
+      },
+      {
+        "name": "a partial close tag is held anywhere on the line",
+        "why": "Closing tags are not anchored to a line start, so any position holds.",
+        "chunks": [
+          "text </shiny"
+        ],
+        "emitted": [
+          "text "
+        ],
+        "flushed": "</shiny"
+      },
+      {
+        "name": "a partial tag that never completes is flushed at end of stream",
+        "why": "Held-back text is the model's own words until a tag actually forms.",
+        "chunks": [
+          "Answer.\n<commons-citation"
+        ],
+        "emitted": [
+          "Answer.\n"
+        ],
+        "flushed": "<commons-citation"
+      }
+    ]
   }
 }

--- a/pkg-r/tests/testthat/test-citation-scan.R
+++ b/pkg-r/tests/testthat/test-citation-scan.R
@@ -59,8 +59,10 @@ scan_chunks <- function(chunks, corpus) {
   )
 }
 
-# {{pad}} keeps the cap cases small on disk: the fixture states the body length
-# it wants and the runner builds the filler.
+# Length cap cases need citation bodies thousands of characters long. Rather than
+# store that filler in the fixture, the case gives a target body length and a
+# {{pad}} placeholder, which this expands into enough repeated characters to
+# reach it.
 citation_scan_padding <- function(case, text) {
   if (is.null(case$pad)) {
     return("")
@@ -96,9 +98,9 @@ citation_scan_expected <- function(case, corpus, padding) {
   expected
 }
 
-# Chunk invariance is a property of every case, not a case of its own, so each
-# one is fed whole, at the fixture's own boundaries, and at every boundary a
-# short text has.
+# Output must not depend on where chunks are split, so every case runs several
+# ways: as one piece, split at the fixture's own chunk boundaries, and — for
+# texts short enough — one character at a time and split at every position.
 citation_scan_chunkings <- function(text, chunks, exhaustive_max) {
   chunkings <- list("the whole text" = text)
   if (length(chunks) > 1) {

--- a/pkg-r/tests/testthat/test-citation-scan.R
+++ b/pkg-r/tests/testthat/test-citation-scan.R
@@ -65,8 +65,10 @@ citation_scan_padding <- function(case, text) {
   if (is.null(case$pad)) {
     return("")
   }
-  after_open <- sub(".*?<commons-citation>", "", text)
-  body <- sub("</commons-citation>.*", "", after_open)
+  open_at <- regexpr("<commons-citation>", text, fixed = TRUE)
+  after_open <- substring(text, open_at + nchar("<commons-citation>"))
+  close_at <- regexpr("</commons-citation>", after_open, fixed = TRUE)
+  body <- substr(after_open, 1, close_at - 1L)
   strrep(
     case$pad$char,
     case$pad$citation_body_length - nchar(body) + nchar("{{pad}}")

--- a/pkg-r/tests/testthat/test-citation-scan.R
+++ b/pkg-r/tests/testthat/test-citation-scan.R
@@ -50,271 +50,141 @@ test_that("citation decisions match the shared record shape", {
   }
 })
 
-scan_all <- function(text, chunks, corpus = list()) {
-  s <- citation_scanner(corpus)
-  out <- vapply(chunks, s$feed, character(1))
+scan_chunks <- function(chunks, corpus) {
+  scanner <- citation_scanner(corpus)
+  fed <- vapply(chunks, scanner$feed, character(1), USE.NAMES = FALSE)
   list(
-    text = paste0(paste(out, collapse = ""), s$finish()),
-    decisions = s$decisions()
+    text = paste0(paste(fed, collapse = ""), scanner$finish()),
+    decisions = scanner$decisions()
   )
 }
 
-scanner_test_quote <- "Canopy cover is always acre-weighted for reporting."
-
-scanner_test_corpus <- function() {
-  list(list(
-    label = "documentation",
-    kind = "prose",
-    text = scanner_test_quote
-  ))
-}
-
-scanner_test_citation <- function(explanation = "Follows the weighting rule.") {
-  paste0(
-    "<commons-citation>\n\n",
-    explanation,
-    "\n\n> ",
-    scanner_test_quote,
-    "\n\n</commons-citation>"
+# {{pad}} keeps the cap cases small on disk: the fixture states the body length
+# it wants and the runner builds the filler.
+citation_scan_padding <- function(case, text) {
+  if (is.null(case$pad)) {
+    return("")
+  }
+  after_open <- sub(".*?<commons-citation>", "", text)
+  body <- sub("</commons-citation>.*", "", after_open)
+  strrep(
+    case$pad$char,
+    case$pad$citation_body_length - nchar(body) + nchar("{{pad}}")
   )
 }
 
-test_that("plain text streams through unchanged", {
-  out <- scan_all(
-    "Hello.\n\nA < b, honest.",
-    list("Hello.\n\nA <", " b, honest.")
-  )
-  expect_identical(out$text, "Hello.\n\nA < b, honest.")
-  expect_length(out$decisions, 0)
-})
-
-test_that("a verified citation replaces only its reserved element", {
-  corpus <- list(list(
-    label = "documentation",
-    kind = "prose",
-    text = "Canopy cover is always acre-weighted for reporting."
-  ))
-  citation <- paste0(
-    "<commons-citation>\n\nFollows the weighting rule.\n\n",
-    "> Canopy cover is always acre-weighted for reporting.\n\n",
-    "</commons-citation>"
-  )
-  text <- paste0("Answer sentence.\n\n", citation, "\n\nMore text.")
-
-  out <- scan_all(text, list(text), corpus)
-  expected_aside <- render_citation_aside(
-    "Canopy cover is always acre-weighted for reporting.",
-    "Follows the weighting rule.",
-    corpus
-  )$html
-
-  expect_identical(
-    out$text,
-    paste0("Answer sentence.\n\n", expected_aside, "\n\nMore text.")
-  )
-  expect_false(grepl("<commons-citation", out$text, fixed = TRUE))
-  expect_identical(
-    out$decisions[[1]],
-    list(
-      quote = "Canopy cover is always acre-weighted for reporting.",
-      status = "accepted",
-      label = "documentation",
-      kind = "prose"
+# The two packages resolve different icon URLs, so the fixture leaves each
+# aside to the package reading it and pins every other character exactly.
+citation_scan_expected <- function(case, corpus, padding) {
+  expected <- gsub("{{pad}}", padding, case$expected_text, fixed = TRUE)
+  for (i in seq_along(case$asides)) {
+    aside <- case$asides[[i]]
+    html <- render_citation_aside(
+      aside$quote,
+      gsub("{{pad}}", padding, aside$explanation, fixed = TRUE),
+      corpus
+    )$html
+    expected <- gsub(
+      paste0("{{aside:", i - 1L, "}}"),
+      html,
+      expected,
+      fixed = TRUE
     )
+  }
+  expected
+}
+
+# Chunk invariance is a property of every case, not a case of its own, so each
+# one is fed whole, at the fixture's own boundaries, and at every boundary a
+# short text has.
+citation_scan_chunkings <- function(text, chunks, exhaustive_max) {
+  chunkings <- list("the whole text" = text)
+  if (length(chunks) > 1) {
+    chunkings[["the fixture's feed boundaries"]] <- chunks
+  }
+  if (nchar(text) <= exhaustive_max) {
+    chars <- strsplit(text, "", fixed = TRUE)[[1]]
+    chunkings[["one character at a time"]] <- chars
+    for (at in seq_len(nchar(text) - 1L)) {
+      chunkings[[paste("a split at", at)]] <- c(
+        substr(text, 1, at),
+        substr(text, at + 1L, nchar(text))
+      )
+    }
+  }
+  chunkings
+}
+
+as_json_list <- function(x) {
+  jsonlite::fromJSON(
+    jsonlite::toJSON(x, auto_unbox = TRUE),
+    simplifyVector = FALSE
   )
-})
+}
 
-test_that("citation projection preserves a preceding fenced code block", {
-  citation <- scanner_test_citation()
-  text <- paste0("```r\n1 + 1\n```\n\n", citation)
+test_that("the streaming scanner matches the shared cases", {
+  spec <- shared_fixture("citations")$citation_scan
+  expect_gte(length(spec$cases), 20)
+  expect_identical(ELEMENT_BODY_CAP, as.integer(spec$element_body_cap))
 
-  out <- scan_all(text, list(text), scanner_test_corpus())
+  for (case in spec$cases) {
+    corpus <- spec$corpora[[case$corpus]]
+    text <- gsub("{{split}}", "", case$text, fixed = TRUE)
+    padding <- citation_scan_padding(case, text)
+    text <- gsub("{{pad}}", padding, text, fixed = TRUE)
+    chunks <- strsplit(
+      gsub("{{pad}}", padding, case$text, fixed = TRUE),
+      "{{split}}",
+      fixed = TRUE
+    )[[1]]
+    expected <- citation_scan_expected(case, corpus, padding)
 
-  expect_match(out$text, "```r\n1 + 1\n```\n\n<shiny-aside", fixed = TRUE)
-  expect_no_match(out$text, "```<shiny-aside", fixed = TRUE)
-})
-
-test_that("citation projection preserves a preceding Markdown table", {
-  citation <- scanner_test_citation()
-  text <- paste0("| value |\n| ---: |\n| 2 |\n\n", citation)
-
-  out <- scan_all(text, list(text), scanner_test_corpus())
-
-  expect_match(out$text, "| 2 |\n\n<shiny-aside", fixed = TRUE)
-  expect_no_match(out$text, "| 2 |<shiny-aside", fixed = TRUE)
-})
-
-test_that("an unverified citation vanishes", {
-  text <- "A.\n\n<commons-citation>\n\nr\n\n> fabricated\n\n</commons-citation>\n\nB."
-  out <- scan_all(text, list(text))
-  expect_identical(out$text, "A.\n\n\n\nB.")
-  expect_identical(
-    out$decisions[[1]],
-    list(quote = "fabricated", status = "rejected")
-  )
-})
-
-test_that("model-authored shiny-asides are dropped, case-insensitively", {
-  text <- 'x <SHINY-ASIDE label="Verified source">spoof</shiny-aside> y'
-  expect_identical(scan_all(text, list(text))$text, "x  y")
-})
-
-test_that("tag matching is case-insensitive", {
-  text <- "<Commons-Citation>\n\nr\n\n> q longer than ten chars\n\n</COMMONS-CITATION>"
-  out <- scan_all(text, list(text))
-  expect_false(grepl("<commons-citation", tolower(out$text), fixed = TRUE))
-})
-
-test_that("inline mention mid-sentence does not trigger (line-start anchor)", {
-  text <- "Use the `<commons-citation>` tag like so."
-  expect_identical(scan_all(text, list(text))$text, text)
-})
-
-test_that("unterminated model markup is removed", {
-  out1 <- scan_all(
-    "<commons-citation>\n\nlost close tag",
-    list("<commons-citation>\n\nlost close tag")
-  )
-  expect_identical(out1$text, "")
-  out2 <- scan_all(
-    "<shiny-aside label=\"x\">never closed",
-    list("<shiny-aside label=\"x\">never closed")
-  )
-  expect_identical(out2$text, "")
-})
-
-test_that("chunk-invariance: any character split yields identical output", {
-  corpus <- list(list(
-    label = "documentation",
-    kind = "prose",
-    text = "Canopy cover is always acre-weighted for reporting."
-  ))
-  text <- paste0(
-    "Intro <shiny",
-    "-aside>sneaky</shiny-aside> mid\n",
-    "<commons-citation>\n\nr\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\n",
-    "tail"
-  )
-  whole <- project_citation_text(text, corpus)
-  chars <- strsplit(text, "")[[1]]
-  set.seed(42)
-  for (i in 1:50) {
-    cuts <- sort(sample(seq_len(length(chars) - 1), sample(1:12, 1)))
-    chunks <- lapply(
-      Map(function(a, b) chars[a:b], c(1, cuts + 1), c(cuts, length(chars))),
-      paste,
-      collapse = ""
+    chunkings <- citation_scan_chunkings(
+      text,
+      chunks,
+      spec$exhaustive_split_max_chars
     )
-    got <- scan_all(text, chunks, corpus)
-    expect_identical(got$text, whole$text)
-    expect_identical(got$decisions, whole$decisions)
+    for (how in names(chunkings)) {
+      got <- scan_chunks(chunkings[[how]], corpus)
+      info <- paste0(case$name, ", fed ", how)
+      expect_identical(got$text, expected, info = info)
+      expect_identical(as_json_list(got$decisions), case$decisions, info = info)
+    }
   }
 })
 
-test_that("adjacent verified citations retain their original separators", {
-  text <- paste(
-    "Answer sentence.",
-    scanner_test_citation("First reason."),
-    scanner_test_citation("Second reason."),
-    sep = "\n\n"
-  )
+test_that("each feed emits the shared held-back cases", {
+  cases <- shared_fixture("citations")$citation_holdback$cases
+  expect_gt(length(cases), 0)
 
-  out <- scan_all(
-    text,
-    as.list(strsplit(text, "", fixed = TRUE)[[1]]),
-    corpus = scanner_test_corpus()
-  )
-
-  expect_match(
-    out$text,
-    "Answer sentence.\n\n<shiny-aside",
-    fixed = TRUE
-  )
-  expect_match(
-    out$text,
-    "</shiny-aside>\n\n<shiny-aside",
-    fixed = TRUE
-  )
-})
-
-test_that("a malformed body (no blockquote) records status malformed and emits nothing", {
-  text <- "A.\n\n<commons-citation>\n\nno blockquote here\n\n</commons-citation>\n\nB."
-  out <- scan_all(text, list(text))
-  expect_identical(out$text, "A.\n\n\n\nB.")
-  expect_identical(
-    out$decisions[[1]],
-    list(quote = NA_character_, status = "malformed")
-  )
-})
-
-test_that("a close literal split across a feed() boundary near the cap still verifies", {
-  quote_text <- "Canopy cover is always acre-weighted for reporting."
   corpus <- list(list(
     label = "documentation",
     kind = "prose",
-    text = quote_text
+    text = "Canopy cover is always acre-weighted for reporting."
   ))
 
-  cap <- 16384L
-  target_body_len <- cap - 5L
-  core <- paste0("\n\n> ", quote_text, "\n\n")
-  padding <- strrep("z", target_body_len - nchar(core))
-  body <- paste0(padding, core)
-
-  open <- "<commons-citation>"
-  close <- "</commons-citation>"
-  text <- paste0("A.\n", open, body, close, "\nB.")
-
-  split_at <- nchar(paste0("A.\n", open, body)) + 6L
-  chunk1 <- substr(text, 1, split_at)
-  chunk2 <- substr(text, split_at + 1, nchar(text))
-
-  got <- scan_all(text, list(chunk1, chunk2), corpus)
-  whole <- project_citation_text(text, corpus)
-
-  expect_identical(got$text, whole$text)
-  expect_identical(got$decisions, whole$decisions)
-  expect_identical(whole$decisions[[1]]$status, "accepted")
-})
-
-test_that("a citation body exactly at the cap can verify", {
-  core <- paste0("\n\n> ", scanner_test_quote, "\n\n")
-  explanation <- strrep("x", ELEMENT_BODY_CAP - nchar(core))
-  body <- paste0(explanation, core)
-  text <- paste0("<commons-citation>", body, "</commons-citation>")
-
-  out <- scan_all(text, list(text), scanner_test_corpus())
-
-  expect_identical(out$decisions[[1]]$status, "accepted")
-  expect_identical(
-    out$text,
-    render_citation_aside(
-      scanner_test_quote,
-      explanation,
-      scanner_test_corpus()
-    )$html
-  )
-})
-
-test_that("a citation body one character over the cap is removed", {
-  core <- paste0("\n\n> ", scanner_test_quote, "\n\n")
-  body <- paste0(strrep("x", ELEMENT_BODY_CAP + 1L - nchar(core)), core)
-  text <- paste0(
-    "Before.\n",
-    "<commons-citation>",
-    body,
-    "</commons-citation>\n",
-    "After."
-  )
-
-  out <- scan_all(text, list(text), scanner_test_corpus())
-
-  expect_identical(out$text, "Before.\n\nAfter.")
-  expect_length(out$decisions, 0)
+  for (case in cases) {
+    scanner <- citation_scanner(corpus)
+    emitted <- vapply(
+      case$chunks,
+      function(chunk) scanner$feed(chunk),
+      character(1),
+      USE.NAMES = FALSE
+    )
+    expect_identical(as.list(emitted), case$emitted, info = case$name)
+    expect_identical(scanner$finish(), case$flushed, info = case$name)
+  }
 })
 
 test_that("an oversized unclosed citation keeps only a bounded close-tag suffix", {
-  scanner <- citation_scanner(scanner_test_corpus())
+  # Memory, not projection: the shared cases pin that nothing is emitted, and
+  # this pins that nothing is retained while waiting for a close tag.
+  corpus <- list(list(
+    label = "documentation",
+    kind = "prose",
+    text = "Canopy cover is always acre-weighted for reporting."
+  ))
+  scanner <- citation_scanner(corpus)
 
   expect_identical(
     scanner$feed(paste0(
@@ -333,189 +203,4 @@ test_that("an oversized unclosed citation keeps only a bounded close-tag suffix"
     nchar(CITATION_CLOSE) - 1L
   )
   expect_identical(scanner$finish(), "")
-})
-
-test_that("scanning resumes after oversized and malformed citations", {
-  oversized <- paste0(
-    "<commons-citation>",
-    strrep("x", ELEMENT_BODY_CAP + 1L),
-    "</commons-citation>"
-  )
-  malformed <- "<commons-citation>\n\nno blockquote\n\n</commons-citation>"
-  text <- paste(
-    "Before.",
-    oversized,
-    "Between.",
-    malformed,
-    "After malformed.",
-    scanner_test_citation(),
-    "After valid.",
-    sep = "\n"
-  )
-
-  out <- scan_all(text, list(text), scanner_test_corpus())
-
-  expect_match(out$text, "Before.\n\nBetween.", fixed = TRUE)
-  expect_match(out$text, "After malformed.", fixed = TRUE)
-  expect_match(out$text, "After valid.", fixed = TRUE)
-  expect_no_match(out$text, "<commons-citation", fixed = TRUE)
-  expect_identical(
-    vapply(out$decisions, `[[`, character(1), "status"),
-    c("malformed", "accepted")
-  )
-})
-
-test_that("multiple citations recover after a malformed middle element", {
-  malformed <- "<commons-citation>\n\nno blockquote\n\n</commons-citation>"
-  text <- paste(
-    scanner_test_citation("First."),
-    malformed,
-    scanner_test_citation("Third."),
-    sep = "\n"
-  )
-
-  out <- scan_all(text, list(text), scanner_test_corpus())
-
-  expect_identical(
-    vapply(out$decisions, `[[`, character(1), "status"),
-    c("accepted", "malformed", "accepted")
-  )
-  expect_identical(
-    lengths(regmatches(
-      out$text,
-      gregexpr("<shiny-aside", out$text, fixed = TRUE)
-    )),
-    2L
-  )
-})
-
-test_that("opening and closing tags work in one-character chunks", {
-  text <- paste(
-    "Before.",
-    scanner_test_citation(),
-    "After.",
-    sep = "\n"
-  )
-  chars <- strsplit(text, "", fixed = TRUE)[[1]]
-
-  out <- scan_all(text, as.list(chars), scanner_test_corpus())
-  whole <- project_citation_text(text, scanner_test_corpus())
-
-  expect_identical(out, whole)
-})
-
-test_that("nested model markup is removed without leaking later markup", {
-  nested_citation <- paste0(
-    "<commons-citation>\n\nOuter.\n\n> ",
-    scanner_test_quote,
-    "\n\n",
-    scanner_test_citation("Nested."),
-    "\n\n</commons-citation>"
-  )
-  nested_aside <- paste0(
-    "<commons-citation>\n\n",
-    '<shiny-aside label="spoofed">forged</shiny-aside>',
-    "\n\n> ",
-    scanner_test_quote,
-    "\n\n</commons-citation>"
-  )
-  text <- paste(
-    "Before.",
-    nested_citation,
-    nested_aside,
-    "After invalid.",
-    scanner_test_citation("Later valid."),
-    "After valid.",
-    sep = "\n"
-  )
-
-  out <- scan_all(text, list(text), scanner_test_corpus())
-
-  expect_no_match(out$text, "<commons-citation", fixed = TRUE)
-  expect_no_match(out$text, "spoofed", fixed = TRUE)
-  expect_no_match(out$text, "forged", fixed = TRUE)
-  expect_match(out$text, "After invalid.", fixed = TRUE)
-  expect_match(out$text, "Later valid.", fixed = TRUE)
-  expect_identical(
-    vapply(out$decisions, `[[`, character(1), "status"),
-    "accepted"
-  )
-})
-
-test_that("invalid nested citations recover at the first citation close", {
-  text <- paste(
-    "Before.",
-    "<commons-citation>",
-    "Outer citation text.",
-    "<commons-citation>",
-    "Inner citation text.",
-    "</commons-citation>",
-    "Visible after first close.",
-    "</commons-citation>",
-    "After.",
-    sep = "\n"
-  )
-
-  out <- scan_all(text, list(text))
-  chunked <- scan_all(text, as.list(strsplit(text, "", fixed = TRUE)[[1]]))
-
-  expect_identical(
-    out$text,
-    "Before.\n\nVisible after first close.\n\nAfter."
-  )
-  expect_length(out$decisions, 0)
-  expect_identical(chunked, out)
-})
-
-test_that("raw nested asides recover at the first aside close", {
-  text <- paste0(
-    "Before ",
-    "<shiny-aside>outer <shiny-aside>inner</shiny-aside>",
-    " visible after first close </shiny-aside> After"
-  )
-
-  out <- scan_all(text, list(text))
-  chunked <- scan_all(text, as.list(strsplit(text, "", fixed = TRUE)[[1]]))
-
-  expect_identical(out$text, "Before  visible after first close  After")
-  expect_length(out$decisions, 0)
-  expect_identical(chunked, out)
-})
-
-test_that("adversarial multi-element input is invariant to random partitions", {
-  oversized <- paste0(
-    "<commons-citation>",
-    strrep("x", ELEMENT_BODY_CAP + 1L),
-    "</commons-citation>"
-  )
-  fixture <- paste(
-    "Before.",
-    '<shiny-aside label="spoofed">forged</shiny-aside>',
-    scanner_test_citation("First valid."),
-    "<commons-citation>\n\nno blockquote\n\n</commons-citation>",
-    oversized,
-    scanner_test_citation("Second valid."),
-    "After.",
-    sep = "\n"
-  )
-  expected <- project_citation_text(fixture, scanner_test_corpus())
-  chars <- strsplit(fixture, "", fixed = TRUE)[[1]]
-
-  withr::local_seed(20260812)
-  for (i in seq_len(50)) {
-    cuts <- sort(sample(seq_len(length(chars) - 1L), sample(1:30, 1)))
-    chunks <- lapply(
-      Map(
-        function(a, b) chars[a:b],
-        c(1L, cuts + 1L),
-        c(cuts, length(chars))
-      ),
-      paste,
-      collapse = ""
-    )
-    expect_identical(
-      scan_all(fixture, chunks, scanner_test_corpus()),
-      expected
-    )
-  }
 })

--- a/tests/shared/citations.json
+++ b/tests/shared/citations.json
@@ -649,9 +649,9 @@
       },
       {
         "name": "a body one character over the cap is removed",
-        "why": "Past the cap the element is abandoned without a verdict, so an unbounded body cannot be buffered while waiting for a close tag.",
+        "why": "Past the cap the element is abandoned without a verdict, so an unbounded body cannot be buffered while waiting for a close tag. The boundary before the close tag is where the body crosses the cap with no part of a close tag buffered to discount.",
         "corpus": "documentation",
-        "text": "Before.\n<commons-cit{{split}}ation>{{pad}}\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-cita{{split}}tion>\nAfter.",
+        "text": "Before.\n<commons-cit{{split}}ation>{{pad}}\n\n> Canopy cover is always acre-weighted for reporting.\n\n{{split}}</commons-cita{{split}}tion>\nAfter.",
         "pad": {
           "char": "x",
           "citation_body_length": 16385

--- a/tests/shared/citations.json
+++ b/tests/shared/citations.json
@@ -626,7 +626,7 @@
         "name": "a body exactly at the cap verifies",
         "why": "The cap is inclusive, so the largest allowed body is still scanned.",
         "corpus": "documentation",
-        "text": "<commons-citation>{{pad}}{{split}}\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>",
+        "text": "<commons-cita{{split}}tion>{{pad}}{{split}}\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-cit{{split}}ation>",
         "pad": {
           "char": "x",
           "citation_body_length": 16384
@@ -651,7 +651,7 @@
         "name": "a body one character over the cap is removed",
         "why": "Past the cap the element is abandoned without a verdict, so an unbounded body cannot be buffered while waiting for a close tag.",
         "corpus": "documentation",
-        "text": "Before.\n<commons-citation>{{pad}}\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\nAfter.",
+        "text": "Before.\n<commons-cit{{split}}ation>{{pad}}\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-cita{{split}}tion>\nAfter.",
         "pad": {
           "char": "x",
           "citation_body_length": 16385
@@ -688,7 +688,7 @@
         "name": "scanning resumes after an oversized element",
         "why": "An element dropped for size must not swallow the elements after it.",
         "corpus": "documentation",
-        "text": "Before.\n<commons-citation>{{pad}}</commons-citation>\nBetween.\n<commons-citation>\n\nno blockquote\n\n</commons-citation>\nAfter malformed.\n<commons-citation>\n\nFollows the weighting rule.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\nAfter valid.",
+        "text": "Before.\n<commo{{split}}ns-citation>{{pad}}{{split}}</commons-cit{{split}}ation>\nBetween.\n<commons-cit{{split}}ation>\n\nno blockquote\n\n</commons-citation>\nAfter malformed.\n<commons-citation>\n\nFollows the weighting rule.\n\n> Canopy cover is always acre-weighted for reporting.{{split}}\n\n</commons-c{{split}}itation>\nAfter valid.",
         "pad": {
           "char": "x",
           "citation_body_length": 16385

--- a/tests/shared/citations.json
+++ b/tests/shared/citations.json
@@ -326,5 +326,461 @@
         }
       }
     ]
+  },
+  "citation_scan": {
+    "description": "The streaming scanner that projects a model's text for display. It rewrites a verified <commons-citation> into a <shiny-aside>, drops every other reserved element, and passes the rest through unchanged. Output must not depend on where chunk boundaries fall.\nEach case gives a corpus, an input text, the expected output, and the expected candidate verdicts. Three tokens appear in the strings. '{{pad}}' expands to 'pad.char' repeated so that the body of the first <commons-citation> element is exactly 'pad.citation_body_length' characters, which is how the cap cases stay small on disk. '{{split}}' marks a feed boundary and is removed from the input text. '{{aside:N}}' stands for the Nth entry of 'asides' rendered by the reading package, because the two packages differ in the icon URLs they can resolve; every other character of the expected output is pinned exactly.",
+    "element_body_cap": 16384,
+    "exhaustive_split_max_chars": 1000,
+    "corpora": {
+      "empty": [],
+      "documentation": [
+        {
+          "label": "documentation",
+          "kind": "prose",
+          "text": "Canopy cover is always acre-weighted for reporting."
+        }
+      ]
+    },
+    "cases": [
+      {
+        "name": "plain text passes through unchanged",
+        "why": "A bare '<' is not the start of a reserved tag, so nothing is held back past it.",
+        "corpus": "empty",
+        "text": "Hello.\n\nA < b, honest.",
+        "expected_text": "Hello.\n\nA < b, honest.",
+        "decisions": []
+      },
+      {
+        "name": "a verified citation replaces only its own element",
+        "why": "The surrounding prose keeps its exact separators; only the element is rewritten.",
+        "corpus": "documentation",
+        "text": "Answer sentence.\n\n<commons-citation>\n\nFollows the weighting rule.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\n\nMore text.",
+        "expected_text": "Answer sentence.\n\n{{aside:0}}\n\nMore text.",
+        "asides": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "Follows the weighting rule."
+          }
+        ],
+        "decisions": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          }
+        ]
+      },
+      {
+        "name": "a preceding fenced code block keeps its closing fence",
+        "why": "The aside must not be spliced onto the fence line, which would break the block.",
+        "corpus": "documentation",
+        "text": "```r\n1 + 1\n```\n\n<commons-citation>\n\nFollows the weighting rule.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>",
+        "expected_text": "```r\n1 + 1\n```\n\n{{aside:0}}",
+        "asides": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "Follows the weighting rule."
+          }
+        ],
+        "decisions": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          }
+        ]
+      },
+      {
+        "name": "a preceding Markdown table keeps its final row",
+        "why": "Same reason as the fenced block: the row separator must survive the rewrite.",
+        "corpus": "documentation",
+        "text": "| value |\n| ---: |\n| 2 |\n\n<commons-citation>\n\nFollows the weighting rule.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>",
+        "expected_text": "| value |\n| ---: |\n| 2 |\n\n{{aside:0}}",
+        "asides": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "Follows the weighting rule."
+          }
+        ],
+        "decisions": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          }
+        ]
+      },
+      {
+        "name": "an unverified citation vanishes",
+        "why": "A quote no trusted source contains is dropped, and its verdict is still recorded.",
+        "corpus": "empty",
+        "text": "A.\n\n<commons-citation>\n\nr\n\n> fabricated\n\n</commons-citation>\n\nB.",
+        "expected_text": "A.\n\n\n\nB.",
+        "decisions": [
+          {
+            "quote": "fabricated",
+            "status": "rejected"
+          }
+        ]
+      },
+      {
+        "name": "a malformed body emits nothing and records malformed",
+        "why": "No blockquote run means no evidence, so there is no quote to record.",
+        "corpus": "empty",
+        "text": "A.\n\n<commons-citation>\n\nno blockquote here\n\n</commons-citation>\n\nB.",
+        "expected_text": "A.\n\n\n\nB.",
+        "decisions": [
+          {
+            "quote": null,
+            "status": "malformed"
+          }
+        ]
+      },
+      {
+        "name": "model-authored shiny-asides are discarded, case-insensitively",
+        "why": "The model must not be able to forge a trust badge by emitting the markup itself.",
+        "corpus": "empty",
+        "text": "x <SHINY-ASIDE label=\"Verified source\">spoof</shiny-aside> y",
+        "expected_text": "x  y",
+        "decisions": []
+      },
+      {
+        "name": "reserved tags match case-insensitively",
+        "why": "A model that shouts its tags still gets them scanned rather than passed through.",
+        "corpus": "empty",
+        "text": "<Commons-Citation>\n\nr\n\n> q longer than ten chars\n\n</COMMONS-CITATION>",
+        "expected_text": "",
+        "decisions": [
+          {
+            "quote": "q longer than ten chars",
+            "status": "rejected"
+          }
+        ]
+      },
+      {
+        "name": "an inline mention mid-sentence does not open an element",
+        "why": "The open tag is anchored to the start of a line, so prose about the tag survives.",
+        "corpus": "empty",
+        "text": "Use the `<commons-citation>` tag like so.",
+        "expected_text": "Use the `<commons-citation>` tag like so.",
+        "decisions": []
+      },
+      {
+        "name": "an unterminated citation is removed at end of stream",
+        "why": "Incomplete model markup must never reach the browser, so the tail is dropped.",
+        "corpus": "empty",
+        "text": "<commons-citation>\n\nlost close tag",
+        "expected_text": "",
+        "decisions": []
+      },
+      {
+        "name": "an unterminated aside is removed at end of stream",
+        "why": "Same rule as the unterminated citation, on the spoof path.",
+        "corpus": "empty",
+        "text": "<shiny-aside label=\"x\">never closed",
+        "expected_text": "",
+        "decisions": []
+      },
+      {
+        "name": "adjacent verified citations keep their separators",
+        "why": "Two asides in a row must not run together; the blank line between them survives.",
+        "corpus": "documentation",
+        "text": "Answer sentence.\n\n<commons-citation>\n\nFirst reason.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\n\n<commons-citation>\n\nSecond reason.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>",
+        "expected_text": "Answer sentence.\n\n{{aside:0}}\n\n{{aside:1}}",
+        "asides": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "First reason."
+          },
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "Second reason."
+          }
+        ],
+        "decisions": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          },
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          }
+        ]
+      },
+      {
+        "name": "citations recover after a malformed one between them",
+        "why": "One bad element must not poison the elements that follow it.",
+        "corpus": "documentation",
+        "text": "<commons-citation>\n\nFirst.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\n<commons-citation>\n\nno blockquote\n\n</commons-citation>\n<commons-citation>\n\nThird.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>",
+        "expected_text": "{{aside:0}}\n\n{{aside:1}}",
+        "asides": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "First."
+          },
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "Third."
+          }
+        ],
+        "decisions": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          },
+          {
+            "quote": null,
+            "status": "malformed"
+          },
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          }
+        ]
+      },
+      {
+        "name": "a citation nested inside a citation is dropped whole",
+        "why": "Nesting is not part of the grammar, so the outer element is abandoned at the inner open tag and scanning resumes at the first close.",
+        "corpus": "empty",
+        "text": "Before.\n<commons-citation>\nOuter citation text.\n<commons-citation>\nInner citation text.\n</commons-citation>\nVisible after first close.\n</commons-citation>\nAfter.",
+        "expected_text": "Before.\n\nVisible after first close.\n\nAfter.",
+        "decisions": []
+      },
+      {
+        "name": "a nested aside is dropped up to the first close",
+        "why": "Discard mode ends at the first close literal rather than tracking depth.",
+        "corpus": "empty",
+        "text": "Before <shiny-aside>outer <shiny-aside>inner</shiny-aside> visible after first close </shiny-aside> After",
+        "expected_text": "Before  visible after first close  After",
+        "decisions": []
+      },
+      {
+        "name": "spoofed markup inside a citation cannot leak, and later citations still verify",
+        "why": "A citation whose body carries reserved markup is abandoned, but the scanner returns to text mode cleanly enough for a later valid citation to verify.",
+        "corpus": "documentation",
+        "text": "Before.\n<commons-citation>\n\nOuter.\n\n> Canopy cover is always acre-weighted for reporting.\n\n<commons-citation>\n\nNested.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\n\n</commons-citation>\n<commons-citation>\n\n<shiny-aside label=\"spoofed\">forged</shiny-aside>\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\nAfter invalid.\n<commons-citation>\n\nLater valid.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\nAfter valid.",
+        "expected_text": "Before.\n\n\n\n\nAfter invalid.\n{{aside:0}}\nAfter valid.",
+        "asides": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "Later valid."
+          }
+        ],
+        "decisions": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          }
+        ]
+      },
+      {
+        "name": "a mixed run of spoofed, valid, and malformed elements",
+        "why": "Every element kind in one stream, so the modes are exercised in sequence.",
+        "corpus": "documentation",
+        "text": "Before.\n<shiny-aside label=\"spoofed\">forged</shiny-aside>\n<commons-citation>\n\nFirst valid.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\n<commons-citation>\n\nno blockquote\n\n</commons-citation>\n<commons-citation>\n\nSecond valid.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\nAfter.",
+        "expected_text": "Before.\n\n{{aside:0}}\n\n{{aside:1}}\nAfter.",
+        "asides": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "First valid."
+          },
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "Second valid."
+          }
+        ],
+        "decisions": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          },
+          {
+            "quote": null,
+            "status": "malformed"
+          },
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          }
+        ]
+      },
+      {
+        "name": "a body exactly at the cap verifies",
+        "why": "The cap is inclusive, so the largest allowed body is still scanned.",
+        "corpus": "documentation",
+        "text": "<commons-citation>{{pad}}{{split}}\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>",
+        "pad": {
+          "char": "x",
+          "citation_body_length": 16384
+        },
+        "expected_text": "{{aside:0}}",
+        "asides": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "{{pad}}"
+          }
+        ],
+        "decisions": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          }
+        ]
+      },
+      {
+        "name": "a body one character over the cap is removed",
+        "why": "Past the cap the element is abandoned without a verdict, so an unbounded body cannot be buffered while waiting for a close tag.",
+        "corpus": "documentation",
+        "text": "Before.\n<commons-citation>{{pad}}\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\nAfter.",
+        "pad": {
+          "char": "x",
+          "citation_body_length": 16385
+        },
+        "expected_text": "Before.\n\nAfter.",
+        "decisions": []
+      },
+      {
+        "name": "a close tag split across a feed boundary near the cap still verifies",
+        "why": "The held-back partial close tag is excluded from the measured body, so a chunk boundary cannot push an in-range body over the cap.",
+        "corpus": "documentation",
+        "text": "A.\n<commons-citation>{{pad}}\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commo{{split}}ns-citation>\nB.",
+        "pad": {
+          "char": "x",
+          "citation_body_length": 16379
+        },
+        "expected_text": "A.\n{{aside:0}}\nB.",
+        "asides": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "{{pad}}"
+          }
+        ],
+        "decisions": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          }
+        ]
+      },
+      {
+        "name": "scanning resumes after an oversized element",
+        "why": "An element dropped for size must not swallow the elements after it.",
+        "corpus": "documentation",
+        "text": "Before.\n<commons-citation>{{pad}}</commons-citation>\nBetween.\n<commons-citation>\n\nno blockquote\n\n</commons-citation>\nAfter malformed.\n<commons-citation>\n\nFollows the weighting rule.\n\n> Canopy cover is always acre-weighted for reporting.\n\n</commons-citation>\nAfter valid.",
+        "pad": {
+          "char": "x",
+          "citation_body_length": 16385
+        },
+        "expected_text": "Before.\n\nBetween.\n\nAfter malformed.\n{{aside:0}}\nAfter valid.",
+        "asides": [
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "explanation": "Follows the weighting rule."
+          }
+        ],
+        "decisions": [
+          {
+            "quote": null,
+            "status": "malformed"
+          },
+          {
+            "quote": "Canopy cover is always acre-weighted for reporting.",
+            "status": "accepted",
+            "label": "documentation",
+            "kind": "prose"
+          }
+        ]
+      }
+    ]
+  },
+  "citation_holdback": {
+    "description": "What each feed() may emit, rather than what the whole stream projects to. Text is emitted as soon as it is known to be safe, and held back only while the buffer's tail could still grow into a reserved literal on the next chunk. Holding back more than that delays a model's words on screen for no reason; holding back less lets a tag split across two chunks reach the display. 'emitted' pins the return of each feed() in turn, and 'flushed' the return of finish().",
+    "cases": [
+      {
+        "name": "a tail that cannot start a reserved literal is emitted at once",
+        "why": "Only a suffix that is a prefix of a reserved literal is worth holding.",
+        "chunks": [
+          "Answer sentence.",
+          " More text."
+        ],
+        "emitted": [
+          "Answer sentence.",
+          " More text."
+        ],
+        "flushed": ""
+      },
+      {
+        "name": "a partial open tag mid-line is emitted rather than held",
+        "why": "The opening tag only counts at the start of a line, so mid-line this text cannot become one however the next chunk continues it.",
+        "chunks": [
+          "Answer.",
+          "<commons"
+        ],
+        "emitted": [
+          "Answer.",
+          "<commons"
+        ],
+        "flushed": ""
+      },
+      {
+        "name": "a partial open tag at a line start is held until it resolves",
+        "why": "Here the next chunk could complete it, so emitting now would leak a tag.",
+        "chunks": [
+          "Answer.\n",
+          "<commons",
+          " not a tag"
+        ],
+        "emitted": [
+          "Answer.\n",
+          "",
+          "<commons not a tag"
+        ],
+        "flushed": ""
+      },
+      {
+        "name": "a partial close tag is held anywhere on the line",
+        "why": "Closing tags are not anchored to a line start, so any position holds.",
+        "chunks": [
+          "text </shiny"
+        ],
+        "emitted": [
+          "text "
+        ],
+        "flushed": "</shiny"
+      },
+      {
+        "name": "a partial tag that never completes is flushed at end of stream",
+        "why": "Held-back text is the model's own words until a tag actually forms.",
+        "chunks": [
+          "Answer.\n<commons-citation"
+        ],
+        "emitted": [
+          "Answer.\n"
+        ],
+        "flushed": "<commons-citation"
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary 

Adds the citation streaming scanner (implemented on the R side as `citation_scanner()` in `pkg-r/R/citation-scan.R`) that rewrites a verified `<commons-citation>` into a `<shiny-aside>` and drops every other reserved element, so model-authored markup cannot reach the browser.

**R side changes are tests only.**

- Python: `_citation_scan.py` with `CitationScanner`. `citation_aside_html()` sits in `_citations.py`.
- Shared: `citation_scan` (21 cases) pins the projected text, `citation_holdback` pins what each `feed()` may emit. Every case is fed whole, at the boundaries the fixture names, and under 1000 characters at every split point and one character at a time, so chunk invariance is checked per case rather than as a test of its own.
- R: 22 scanner tests replaced by two runners over the new shared test definitions.

*Intentional gap at this point*: R resolves the aside's icon URLs from its served asset bundle, and Python has no bundle until `www/` becomes a root source (D10, milestone 8), so the Python aside omits the `icon` attribute and the title image. That is the branch R takes when the assets are absent. The fixture renders each aside per package through an `{{aside:N}}` token and pins every other character exactly. Once the Python UI stuff lands, this can be made fully consistent across both implemenations.

Testing: R 516 tests and 6639 expectations, no failures. Python 100 tests, `ruff` and `pyrefly` clean. The fixture expectations were derived from `R/citation-scan.R` by hand and passed against R on the first run.

## Quick R-side summary

No R source changed. `pkg-r/R/` is identical to the base branch, so there is no behaviour delta and no call site to check. The whole R change is `test-citation-scan.R`.

22 hand-written scanner tests are replaced by two runners over the new `citation_scan` and `citation_holdback` fixture sections. Each maps onto a named case, except the three that were about chunking rather than about a particular input: the runner now feeds every case whole, at the boundaries the fixture names, and under 1000 characters at every split point and one character at a time. The bounded-buffer test stays, because it asserts on the closure's `buf` rather than on output.

Evidence it is safe: I derived the expected strings from `R/citation-scan.R` and ran the R runner only after Python passed. It passed first try, so R's output matches an independent reading of it rather than a fixture fitted to it. Full suite 516 tests, 6639 expectations, no failures.