### PR TITLE
Python data sources over data frames, with a read-only SQL guard

### DIFF
--- a/.github/workflows/py-check.yaml
+++ b/.github/workflows/py-check.yaml
@@ -34,6 +34,9 @@ jobs:
       - name: Lint
         run: uv run ruff check
       - name: Type check
-        run: uv run pyrefly check
+        # Explicit paths: with none, pyrefly consults the repo's git ignore
+        # files, and a worktree checked out under an ignored directory
+        # silently type-checks nothing.
+        run: uv run pyrefly check src tests
       - name: Test
         run: uv run pytest

--- a/pkg-py/pyproject.toml
+++ b/pkg-py/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pyyaml>=6",
     "jinja2>=3",
     "pyarrow>=17",
+    "sqlglot>=25",
 ]
 
 [project.urls]
@@ -31,7 +32,7 @@ tracing = [
 ]
 
 [dependency-groups]
-dev = ["pytest>=8", "pytest-asyncio", "ruff", "pyrefly"]
+dev = ["pytest>=8", "pytest-asyncio", "ruff", "pyrefly", "pandas>=2", "polars>=1"]
 
 [build-system]
 requires = ["hatchling"]

--- a/pkg-py/src/commons/__init__.py
+++ b/pkg-py/src/commons/__init__.py
@@ -5,4 +5,6 @@ querying them, and A/B/C provenance semantics so every answer carries a
 classification as to how much it can be trusted.
 """
 
-__all__: list[str] = []
+from ._data_source import DataSource, data_source, list_tables
+
+__all__: list[str] = ["DataSource", "data_source", "list_tables"]

--- a/pkg-py/src/commons/_backends.py
+++ b/pkg-py/src/commons/_backends.py
@@ -1,0 +1,61 @@
+"""What a data source needs from whatever holds its tables.
+
+The protocol exists so the in-process DuckDB commons builds from frames can
+hold a raw connection while a caller-supplied connection stays a SQLAlchemy
+engine (D2 makes the engine the connection currency). The raw path is not
+routed through SQLAlchemy because the lockdown and the deferred pin writes are
+DuckDB-specific and gain nothing from it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol
+
+import duckdb
+
+from ._duckdb import quote_identifier
+
+if TYPE_CHECKING:
+    from ._data_source import TableId
+
+__all__ = ["Backend", "DuckDBBackend"]
+
+
+class Backend(Protocol):
+    def query(self, sql: str) -> list[dict[str, Any]]: ...
+
+    def list_tables(self) -> list[str]: ...
+
+    def quote(self, table_id: TableId) -> str: ...
+
+    def dialect(self) -> str: ...
+
+
+class DuckDBBackend:
+    def __init__(self, con: duckdb.DuckDBPyConnection) -> None:
+        self._con = con
+
+    @property
+    def connection(self) -> duckdb.DuckDBPyConnection:
+        return self._con
+
+    def query(self, sql: str) -> list[dict[str, Any]]:
+        cursor = self._con.execute(sql)
+        if cursor.description is None:
+            return []
+        columns = [column[0] for column in cursor.description]
+        return [dict(zip(columns, row)) for row in cursor.fetchall()]
+
+    def list_tables(self) -> list[str]:
+        rows = self._con.execute(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_schema = 'main' ORDER BY table_name"
+        ).fetchall()
+        return [row[0] for row in rows]
+
+    def quote(self, table_id: TableId) -> str:
+        parts = [table_id.schema, table_id.table] if table_id.schema else [table_id.table]
+        return ".".join(quote_identifier(part) for part in parts)
+
+    def dialect(self) -> str:
+        return "duckdb"

--- a/pkg-py/src/commons/_data_source.py
+++ b/pkg-py/src/commons/_data_source.py
@@ -1,0 +1,114 @@
+"""The set of tables available to a commons agent.
+
+``DataSource`` is a dataclass rather than a pydantic model (D8): its checks run
+against live external state, which pydantic cannot express. Validation lives in
+the constructor functions, which is where a bad argument can still be named.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from . import _duckdb
+from ._backends import Backend, DuckDBBackend
+from ._sql_guard import check_query
+
+__all__ = ["DataSource", "TableId", "data_source", "list_tables"]
+
+
+@dataclass(frozen=True)
+class TableId:
+    """A table's identity, schema-qualified where the backend has schemas."""
+
+    table: str
+    schema: str | None = None
+
+    @property
+    def label(self) -> str:
+        """The name the agent uses for this table."""
+        return f"{self.schema}.{self.table}" if self.schema else self.table
+
+
+@dataclass
+class DataSource:
+    """Tables an agent can query, and the dictionary that describes them."""
+
+    backend: Backend
+    tables: list[str]
+    table_ids: dict[str, TableId] = field(default_factory=dict)
+
+    @classmethod
+    def from_frames(cls, **frames: Any) -> DataSource:
+        """Load named data frames into a locked-down in-process DuckDB."""
+        _check_named_frames(frames)
+        con = _duckdb.connect()
+        for position, (name, frame) in enumerate(frames.items()):
+            # The registered relation gets a generated name rather than one
+            # derived from the caller's, so nothing user-supplied is ever
+            # spliced into SQL unquoted.
+            staging = f"_commons_input_{position}"
+            con.register(staging, frame)
+            con.execute(
+                f"CREATE TABLE {_duckdb.quote_identifier(name)} AS SELECT * FROM {staging}"
+            )
+            con.unregister(staging)
+        _duckdb.lock_down(con)
+
+        tables = list(frames)
+        return cls(
+            backend=DuckDBBackend(con),
+            tables=tables,
+            table_ids={name: TableId(table=name) for name in tables},
+        )
+
+    def query(self, sql: str) -> list[dict[str, Any]]:
+        """Run one read-only statement, rejecting anything else first."""
+        check_query(sql, dialect=self.backend.dialect())
+        return self.backend.query(sql)
+
+    def dialect(self) -> str:
+        """A hint for the system prompt, not a contract."""
+        return self.backend.dialect()
+
+
+def data_source(*args: Any, **frames: Any) -> DataSource:
+    """Create a data source from named data frames.
+
+    A thin dispatcher over the constructors, which are the documented way in.
+    Engine and pins-board sources land alongside `DataSource.from_engine` and
+    `DataSource.from_board`.
+    """
+    if args:
+        raise TypeError(
+            "data_source() takes named data frames. Got a positional "
+            f"{type(args[0]).__name__}."
+        )
+    return DataSource.from_frames(**frames)
+
+
+def list_tables(source: DataSource) -> list[str]:
+    """The table names an agent can query on `source`."""
+    if not isinstance(source, DataSource):
+        raise TypeError(f"Expected a DataSource, got {type(source).__name__}.")
+    return list(source.tables)
+
+
+def _check_named_frames(frames: dict[str, Any]) -> None:
+    if not frames:
+        raise TypeError(
+            "data_source() needs at least one named data frame, a connection, "
+            "or a pins board."
+        )
+    for name, frame in frames.items():
+        if not _is_frame(frame):
+            raise TypeError(
+                f"{name} must be a pandas or polars data frame, got "
+                f"{type(frame).__name__}."
+            )
+
+
+def _is_frame(value: Any) -> bool:
+    # Duck-typed rather than imported: pandas and polars are both optional at
+    # this boundary, and DuckDB accepts either through the same registration.
+    return hasattr(value, "__dataframe__") or hasattr(value, "columns")

--- a/pkg-py/src/commons/_duckdb.py
+++ b/pkg-py/src/commons/_duckdb.py
@@ -1,0 +1,62 @@
+"""The in-process DuckDB that backs frame and pin data sources.
+
+``lock_down`` is a security control, not a nicety: a data source built from
+frames must not be able to reach the host filesystem. ``pkg-r/R/data-source.R``
+applies the same settings.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import duckdb
+
+__all__ = ["connect", "lock_down", "quote_identifier"]
+
+_LOCKDOWN_SQL = """
+SET allow_community_extensions = false;
+SET allow_unsigned_extensions = false;
+SET autoinstall_known_extensions = false;
+SET autoload_known_extensions = false;
+SET enable_external_access = false;
+SET disabled_filesystems = 'LocalFileSystem';
+SET lock_configuration = true;
+"""
+
+
+def connect() -> duckdb.DuckDBPyConnection:
+    """Open an in-memory DuckDB with its scratch directories under temp.
+
+    DuckDB defaults its extension and home directories to the install location,
+    which is read-only in deployed environments such as Posit Connect.
+    `extension_directory` has to be set at startup, because the first query
+    initializes the extension subsystem against it. `home_directory` is a
+    process-global option, so passing it in `config` re-sets a global on every
+    connection and DuckDB rejects that once any instance exists in the process;
+    set it with a session-scoped SET instead.
+    """
+    directory = Path(tempfile.gettempdir()) / "duckdb"
+    directory.mkdir(parents=True, exist_ok=True)
+    con = duckdb.connect(config={"extension_directory": str(directory)})
+    con.execute("SET home_directory = ?", [str(directory)])
+    return con
+
+
+def lock_down(con: duckdb.DuckDBPyConnection) -> None:
+    """Disable extension loading and filesystem access, then freeze the config.
+
+    `lock_configuration` only freezes SET statements, so tables can still be
+    written afterwards. The board path relies on that.
+    """
+    con.execute(_LOCKDOWN_SQL)
+
+
+def quote_identifier(name: str) -> str:
+    """Quote `name` as a DuckDB identifier, doubling any embedded quote.
+
+    Table names come from caller-supplied keyword arguments and go into SQL
+    that runs before `lock_down`, so an unescaped one would be an injection
+    point the lockdown never gets a chance to close.
+    """
+    return '"' + name.replace('"', '""') + '"'

--- a/pkg-py/src/commons/_sql_guard.py
+++ b/pkg-py/src/commons/_sql_guard.py
@@ -1,0 +1,137 @@
+"""Reject anything that is not a single read-only statement.
+
+The guard parses the statement and checks what it is, rather than matching its
+text. A text check is not sound here: a first-word test lets `WITH t AS
+(SELECT 1) DELETE FROM sales` through, and every fix for that opens the next
+question about what a comment or a quote hides. sqlglot already knows the
+grammar, including nested block comments and dollar quoting, so the guard asks
+it instead of re-deriving it.
+
+The check is an allowlist. Statements that read are named; everything else is
+refused, so a statement form nobody thought of fails closed rather than
+falling through a denylist. This pairs with the DuckDB lockdown, and with the
+recommendation that a caller-supplied connection be opened read-only, because
+commons cannot open someone else's connection for them.
+"""
+
+from __future__ import annotations
+
+import sqlglot
+from sqlglot import expressions as exp
+
+__all__ = ["check_query"]
+
+# Statement forms that only read. A set operation carries its branches, and
+# sqlglot parses a leading CTE list onto the statement it belongs to, so
+# `WITH ... DELETE` arrives here as a Delete rather than as a Select.
+_READ_ONLY: tuple[type[sqlglot.Expr], ...] = (
+    exp.Select,
+    exp.Union,
+    exp.Intersect,
+    exp.Except,
+    exp.Subquery,
+    exp.Values,
+    exp.Pivot,
+)
+
+# Nodes that write, wherever they appear in the tree. `DML` and `DDL` cover
+# most of them, but sqlglot's hierarchy is not uniform: `Drop` and `Alter`
+# descend straight from `Expression`, so they are named here too. None of the
+# read-only types above descend from any of these, which a test pins.
+_WRITE_NODES: tuple[type[sqlglot.Expr], ...] = (
+    exp.DML,
+    exp.DDL,
+    exp.Drop,
+    exp.Alter,
+    exp.Attach,
+    exp.Detach,
+    exp.Install,
+    exp.LoadData,
+    exp.Grant,
+    exp.TruncateTable,
+    exp.Set,
+    exp.Use,
+    exp.Pragma,
+    exp.Command,
+)
+
+# SQLAlchemy and sqlglot spell some dialects differently.
+_DIALECTS = {
+    "postgresql": "postgres",
+    "mssql": "tsql",
+}
+
+
+def check_query(sql: str, dialect: str | None = None) -> None:
+    """Raise `ValueError` unless `sql` is one read-only statement."""
+    try:
+        parsed = sqlglot.parse(sql, dialect=_sqlglot_dialect(dialect))
+    except sqlglot.ParseError as error:
+        raise ValueError(
+            f"The query could not be parsed as {dialect or 'SQL'}: {error}. "
+            "Only read-only SELECT queries are allowed."
+        ) from error
+
+    statements = [statement for statement in parsed if statement is not None]
+    if not statements:
+        raise ValueError("The query is empty. Only read-only SELECT queries are allowed.")
+    if len(statements) > 1:
+        raise ValueError(
+            "The query contains a disallowed semicolon. "
+            "Only a single trailing semicolon is allowed."
+        )
+
+    statement = statements[0]
+    if isinstance(statement, _READ_ONLY):
+        # A statement that reads at the root can still carry a write beneath
+        # it. PostgreSQL runs data-modifying CTEs, so
+        # `WITH d AS (DELETE ... RETURNING *) SELECT * FROM d` is a Select
+        # whose CTE deletes rows, and `SELECT ... INTO t` creates a table.
+        nested = statement.find(*_WRITE_NODES)
+        if nested is not None:
+            raise ValueError(
+                f"The query contains a disallowed operation: "
+                f"{_operation_name(nested)}. "
+                "Only read-only SELECT queries are allowed."
+            )
+        if statement.args.get("into") is not None or statement.find(exp.Into):
+            raise ValueError(
+                "The query contains a disallowed operation: SELECT INTO. "
+                "Only read-only SELECT queries are allowed."
+            )
+        # A locking read changes no rows but takes locks that block writers,
+        # so it is not read-only in the sense the guard promises.
+        if statement.args.get("locks") or statement.find(exp.Lock):
+            raise ValueError(
+                "The query uses a locking read, such as FOR UPDATE. "
+                "Only read-only SELECT queries are allowed."
+            )
+        return
+
+    operation = _operation_name(statement)
+    if operation:
+        raise ValueError(
+            f"The query contains a disallowed operation: {operation}. "
+            "Only read-only SELECT queries are allowed."
+        )
+    raise ValueError(
+        "The query must begin with SELECT or WITH. "
+        "Only read-only SELECT queries are allowed."
+    )
+
+
+def _sqlglot_dialect(dialect: str | None) -> str | None:
+    if dialect is None:
+        return None
+    name = _DIALECTS.get(dialect.lower(), dialect.lower())
+    return name if name in sqlglot.Dialects.__members__.values() else None
+
+
+def _operation_name(statement: sqlglot.Expr) -> str | None:
+    """The keyword to name back to the model, when there is a useful one."""
+    if isinstance(statement, exp.Command):
+        # sqlglot's fallback for a statement it does not model; the keyword is
+        # the payload, e.g. VACUUM.
+        this = statement.this
+        return str(this).upper() if this else None
+    return statement.key.upper()

--- a/pkg-py/src/commons/_sql_guard.py
+++ b/pkg-py/src/commons/_sql_guard.py
@@ -17,6 +17,7 @@ commons cannot open someone else's connection for them.
 from __future__ import annotations
 
 import sqlglot
+import sqlglot.errors
 from sqlglot import expressions as exp
 
 __all__ = ["check_query"]
@@ -66,7 +67,7 @@ def check_query(sql: str, dialect: str | None = None) -> None:
     """Raise `ValueError` unless `sql` is one read-only statement."""
     try:
         parsed = sqlglot.parse(sql, dialect=_sqlglot_dialect(dialect))
-    except sqlglot.ParseError as error:
+    except sqlglot.errors.SqlglotError as error:
         raise ValueError(
             f"The query could not be parsed as {dialect or 'SQL'}: {error}. "
             "Only read-only SELECT queries are allowed."

--- a/pkg-py/tests/test_data_source.py
+++ b/pkg-py/tests/test_data_source.py
@@ -1,0 +1,105 @@
+"""``data_source()`` and the frames path."""
+
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+import pytest
+
+from commons import data_source, list_tables
+
+
+def sales_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "order_id": ["o01", "o02", "o03"],
+            "revenue": [100.0, 250.0, 700.0],
+            "region": ["EMEA", "APAC", "EMEA"],
+        }
+    )
+
+
+def test_frames_become_queryable_tables() -> None:
+    source = data_source(sales=sales_frame())
+
+    assert list_tables(source) == ["sales"]
+    assert source.query("SELECT count(*) AS n FROM sales") == [{"n": 3}]
+
+
+def test_several_frames_all_register() -> None:
+    source = data_source(sales=sales_frame(), regions=pd.DataFrame({"region": ["EMEA"]}))
+
+    assert sorted(list_tables(source)) == ["regions", "sales"]
+
+
+def test_a_frames_source_cannot_read_the_host_filesystem(tmp_path: Path) -> None:
+    # M2's acceptance criterion, written as the attempt rather than as an
+    # assertion about configuration.
+    secret = tmp_path / "secret.csv"
+    secret.write_text("a\n1\n", encoding="utf-8")
+    source = data_source(sales=sales_frame())
+
+    with pytest.raises(duckdb.Error):
+        source.query(f"SELECT * FROM read_csv_auto('{secret}')")
+
+
+def test_the_guard_runs_before_the_database_sees_the_query() -> None:
+    source = data_source(sales=sales_frame())
+
+    with pytest.raises(ValueError, match="disallowed operation"):
+        source.query("DROP TABLE sales")
+    assert source.query("SELECT count(*) AS n FROM sales") == [{"n": 3}]
+
+
+def test_unnamed_input_is_rejected() -> None:
+    with pytest.raises(TypeError, match="named"):
+        data_source(sales_frame())
+
+
+def test_a_non_frame_value_is_rejected() -> None:
+    with pytest.raises(TypeError, match="sales"):
+        data_source(sales=1)
+
+
+def test_a_polars_frame_registers_too() -> None:
+    polars = pytest.importorskip("polars")
+    source = data_source(sales=polars.DataFrame({"revenue": [1.0, 2.0]}))
+
+    assert source.query("SELECT count(*) AS n FROM sales") == [{"n": 2}]
+
+
+def test_the_dialect_of_a_frames_source_is_duckdb() -> None:
+    assert data_source(sales=sales_frame()).dialect() == "duckdb"
+
+
+@pytest.mark.parametrize("name", ["my sales", 'we"ird', "order-lines", "2024"])
+def test_a_table_name_that_is_not_a_bare_identifier_still_registers(name: str) -> None:
+    source = data_source(**{name: sales_frame()})
+
+    assert list_tables(source) == [name]
+    quoted = '"' + name.replace('"', '""') + '"'
+    assert source.query(f"SELECT count(*) AS n FROM {quoted}") == [{"n": 3}]
+
+
+def test_a_frame_name_cannot_inject_sql_before_the_lockdown(tmp_path: Path) -> None:
+    # Names reach DuckDB as identifiers, and the tables are written before
+    # lock_down() runs, so an unescaped name would be an injection point that
+    # the lockdown never gets to close.
+    secret = tmp_path / "secret.csv"
+    secret.write_text("a\n42\n", encoding="utf-8")
+    hostile = f"""x" AS SELECT * FROM read_csv_auto('{secret}'); --"""
+
+    source = data_source(**{hostile: sales_frame()})
+
+    assert list_tables(source) == [hostile]
+    assert source.backend.list_tables() == [hostile]
+
+
+def test_the_guard_is_given_the_sources_dialect() -> None:
+    # Dialect syntax only parses when the guard knows the dialect, so a
+    # DuckDB-only construct reaching the database proves it was passed.
+    source = data_source(sales=sales_frame())
+
+    assert source.query("SELECT * EXCLUDE (order_id, region) FROM sales")[0] == {
+        "revenue": 100.0
+    }

--- a/pkg-py/tests/test_duckdb.py
+++ b/pkg-py/tests/test_duckdb.py
@@ -1,0 +1,62 @@
+"""The in-process DuckDB commons owns, and the lockdown that makes it safe.
+
+``lock_down`` is a security control. Every test here is an attempt, not an
+assertion about configuration: configuration that looks right but does not
+stop the attempt is worth nothing.
+"""
+
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from commons._duckdb import connect, lock_down
+
+
+def test_a_locked_down_connection_cannot_read_the_filesystem(tmp_path: Path) -> None:
+    secret = tmp_path / "secret.csv"
+    secret.write_text("a\n1\n", encoding="utf-8")
+    con = connect()
+    lock_down(con)
+
+    with pytest.raises(duckdb.Error):
+        con.execute(f"SELECT * FROM read_csv_auto('{secret}')").fetchall()
+
+
+def test_a_locked_down_connection_cannot_reopen_external_access() -> None:
+    con = connect()
+    lock_down(con)
+
+    with pytest.raises(duckdb.Error):
+        con.execute("SET enable_external_access = true")
+
+
+def test_a_locked_down_connection_cannot_install_extensions() -> None:
+    con = connect()
+    lock_down(con)
+
+    with pytest.raises(duckdb.Error):
+        con.execute("INSTALL httpfs")
+
+
+def test_registering_a_frame_still_works_after_lockdown() -> None:
+    # lock_configuration() freezes SET statements only, so a table written
+    # after the lockdown still lands. The board path depends on this.
+    con = connect()
+    lock_down(con)
+    con.execute("CREATE TABLE t AS SELECT 1 AS x UNION ALL SELECT 2")
+
+    assert con.execute("SELECT count(*) AS n FROM t").fetchone() == (2,)
+
+
+def test_two_connections_coexist_in_one_process() -> None:
+    # home_directory is a process-global option; setting it on a second
+    # connection must not fail once the first instance exists.
+    first = connect()
+    second = connect()
+
+    home = second.execute("SELECT current_setting('home_directory') AS h").fetchone()
+    assert home is not None
+    assert home[0].endswith("duckdb")
+    first.close()
+    second.close()

--- a/pkg-py/tests/test_sql_guard.py
+++ b/pkg-py/tests/test_sql_guard.py
@@ -1,0 +1,227 @@
+"""The read-only SQL guard.
+
+The guard parses and classifies rather than matching text. The cases below are
+grouped by what they pin: that writes are refused however they are spelled,
+that read-only queries a real agent would send still work, and that anything
+the parser cannot vouch for fails closed.
+"""
+
+import pytest
+
+from commons._sql_guard import check_query
+
+# Writes sqlglot models as a statement type, so the guard can name the
+# operation back to the model.
+NAMED_WRITES = [
+    "DELETE FROM sales",
+    "TRUNCATE sales",
+    "CREATE TABLE t (x INT)",
+    "DROP TABLE sales",
+    "ALTER TABLE sales ADD COLUMN x INT",
+    "GRANT SELECT ON sales TO bob",
+    "REVOKE SELECT ON sales FROM bob",
+    "INSERT INTO sales VALUES (1)",
+    "UPDATE sales SET x = 1",
+    "COPY sales TO '/tmp/out.csv'",
+    "ATTACH '/tmp/other.db' AS o",
+    "INSTALL httpfs",
+    "LOAD httpfs",
+    "VACUUM",
+]
+
+# Writes and side-effecting statements that the parser refuses outright. They
+# are rejected too, just without a keyword to name.
+UNPARSEABLE_WRITES = [
+    "MERGE INTO sales USING t ON TRUE",
+    "REPLACE INTO sales VALUES (1)",
+    "UPSERT INTO sales VALUES (1)",
+    "EXPORT DATABASE '/tmp/dump'",
+]
+
+
+@pytest.mark.parametrize("sql", NAMED_WRITES)
+def test_a_write_is_rejected_and_named(sql: str) -> None:
+    with pytest.raises(ValueError, match="disallowed operation"):
+        check_query(sql, dialect="duckdb")
+
+
+@pytest.mark.parametrize("sql", UNPARSEABLE_WRITES)
+def test_a_write_the_parser_cannot_model_is_still_rejected(sql: str) -> None:
+    with pytest.raises(ValueError):
+        check_query(sql, dialect="duckdb")
+
+
+def test_case_does_not_matter() -> None:
+    with pytest.raises(ValueError, match="disallowed operation"):
+        check_query("drop table sales", dialect="duckdb")
+
+
+# DuckDB accepts DML after a CTE list, so `WITH` is not a safe prefix to trust.
+# A comment or a quote can hide the paren that ends the CTE, which is why the
+# guard parses instead of scanning. Each of these emptied a live table before
+# the guard was parser-backed.
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "WITH t AS (SELECT 1) DELETE FROM sales",
+        "WITH t AS (SELECT 1) INSERT INTO sales VALUES (9)",
+        "WITH t AS (SELECT 1) UPDATE sales SET x = 5",
+        "WITH RECURSIVE t AS (SELECT 1) DELETE FROM sales",
+        "WITH a AS (SELECT 1), b AS (SELECT 2) DELETE FROM sales",
+        "WITH t AS (SELECT 1 -- ) SELECT\n) DELETE FROM sales",
+        "WITH t AS (SELECT 1 /* ) SELECT */\n) DELETE FROM sales",
+        "WITH t AS (SELECT 1 /* ) SELECT /* n */ ) SELECT */ ) DELETE FROM sales",
+        "WITH t AS (SELECT $$ ) $$) DELETE FROM sales",
+        "WITH t AS (SELECT $tag$ ) $tag$) DELETE FROM sales",
+    ],
+)
+def test_a_write_behind_a_cte_list_is_rejected(sql: str) -> None:
+    with pytest.raises(ValueError, match="disallowed operation"):
+        check_query(sql, dialect="duckdb")
+
+
+def test_a_second_statement_is_rejected() -> None:
+    with pytest.raises(ValueError, match="disallowed semicolon"):
+        check_query("SELECT 1 AS ok; DROP TABLE sales;", dialect="duckdb")
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT 'dropped' AS status FROM sales",
+        "WITH total AS (SELECT 1) SELECT * FROM total",
+        "SELECT 1;",
+        "  select 1  ",
+        "SELECT\n  1\nFROM sales",
+        "WITH RECURSIVE t AS (SELECT 1) SELECT * FROM t",
+        "WITH a AS (SELECT 1), b AS (SELECT 2) SELECT * FROM a JOIN b ON TRUE",
+        "(SELECT 1)",
+        "SELECT 1 UNION SELECT 2",
+        "SELECT 1 INTERSECT SELECT 2",
+        "SELECT 1 EXCEPT SELECT 2",
+    ],
+)
+def test_a_read_only_statement_is_accepted(sql: str) -> None:
+    check_query(sql, dialect="duckdb")
+
+
+# A keyword-matching guard would reject these, and they are ordinary SQL.
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT * FROM sales WHERE note = 'DELETE'",
+        "SELECT replace(name, 'a', 'b') FROM sales",
+        "SELECT 1 -- a trailing note",
+        "SELECT 1 /* an inline note */ FROM sales",
+        "SELECT 1 /* outer /* inner */ still outer */ AS n",
+        "WITH t AS (SELECT 1) -- explain the join\nSELECT * FROM t",
+        "SELECT $$ ) not a paren $$ AS n",
+        "SELECT $tag$ ) $tag$ AS n FROM sales",
+        "SELECT 'it''s ) fine' AS n FROM sales",
+    ],
+)
+def test_a_blocked_word_that_is_not_an_operation_is_accepted(sql: str) -> None:
+    check_query(sql, dialect="duckdb")
+
+
+# Dialect syntax a model would plausibly emit against a DuckDB source.
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT * EXCLUDE (region) FROM sales",
+        "SELECT * REPLACE (revenue * 2 AS revenue) FROM sales",
+        "SELECT x FROM sales QUALIFY row_number() OVER (PARTITION BY x) = 1",
+        "FROM sales SELECT region",
+        "SELECT list_transform([1, 2], x -> x * 2) AS n",
+        "SELECT a[1:2] FROM sales",
+        "SELECT {'a': 1} AS s",
+        "SELECT * FROM sales ASOF JOIN t ON sales.x >= t.x",
+    ],
+)
+def test_read_only_dialect_syntax_is_accepted(sql: str) -> None:
+    check_query(sql, dialect="duckdb")
+
+
+def test_sql_the_parser_cannot_read_is_rejected_rather_than_guessed() -> None:
+    # Fail closed: a statement the guard cannot classify is one it cannot
+    # vouch for.
+    with pytest.raises(ValueError, match="could not be parsed"):
+        check_query("SELECT FROM WHERE )(", dialect="duckdb")
+
+
+def test_an_empty_query_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        check_query("   ", dialect="duckdb")
+
+
+def test_an_unknown_dialect_falls_back_rather_than_failing() -> None:
+    # A backend sqlglot has no dialect for still gets the generic grammar,
+    # which is enough to tell a SELECT from a DELETE.
+    check_query("SELECT 1", dialect="some-warehouse")
+    with pytest.raises(ValueError, match="disallowed operation"):
+        check_query("DELETE FROM sales", dialect="some-warehouse")
+
+
+def test_a_sqlalchemy_dialect_name_maps_to_the_parser_name() -> None:
+    check_query("SELECT 1", dialect="postgresql")
+
+
+# A statement whose root node reads can still carry a write underneath it.
+# PostgreSQL runs data-modifying CTEs, and SELECT ... INTO creates a table.
+@pytest.mark.parametrize(
+    ("dialect", "sql"),
+    [
+        ("postgres", "WITH d AS (DELETE FROM sales RETURNING *) SELECT * FROM d"),
+        ("postgres", "WITH i AS (INSERT INTO sales VALUES (1) RETURNING *) SELECT * FROM i"),
+        ("postgres", "WITH u AS (UPDATE sales SET x = 1 RETURNING *) SELECT * FROM u"),
+        ("duckdb", "WITH d AS (DELETE FROM sales RETURNING *) SELECT * FROM d"),
+        ("postgres", "SELECT * INTO new_table FROM sales"),
+        ("tsql", "SELECT * INTO new_table FROM sales"),
+        ("postgres", "SELECT * FROM (WITH d AS (DELETE FROM sales RETURNING *) SELECT * FROM d) q"),
+    ],
+)
+def test_a_write_nested_under_a_read_is_rejected(dialect: str, sql: str) -> None:
+    with pytest.raises(ValueError, match="disallowed operation"):
+        check_query(sql, dialect=dialect)
+
+
+@pytest.mark.parametrize(
+    ("dialect", "sql"),
+    [
+        ("postgres", "WITH d AS (SELECT * FROM sales) SELECT * FROM d"),
+        ("postgres", "SELECT * FROM (SELECT 1 AS x) q"),
+        ("duckdb", "SELECT * FROM sales WHERE x IN (SELECT y FROM other)"),
+    ],
+)
+def test_a_read_nested_under_a_read_is_still_accepted(dialect: str, sql: str) -> None:
+    check_query(sql, dialect=dialect)
+
+
+def test_no_read_only_statement_type_is_also_a_write_node() -> None:
+    # The nested-write check runs over statements the allowlist already
+    # accepted, so an overlap between the two sets would reject every query.
+    from commons._sql_guard import _READ_ONLY, _WRITE_NODES
+
+    for allowed in _READ_ONLY:
+        assert not issubclass(allowed, _WRITE_NODES), allowed.__name__
+
+
+# A locking read does not modify rows, but it takes locks that block writers,
+# which is not the read-only behaviour the guard promises.
+@pytest.mark.parametrize(
+    ("dialect", "sql"),
+    [
+        ("postgres", "SELECT * FROM sales FOR UPDATE"),
+        ("postgres", "SELECT * FROM sales FOR SHARE"),
+        ("postgres", "SELECT * FROM sales FOR UPDATE NOWAIT"),
+        ("postgres", "SELECT * FROM sales FOR NO KEY UPDATE"),
+        ("mysql", "SELECT * FROM sales LOCK IN SHARE MODE"),
+    ],
+)
+def test_a_locking_read_is_rejected(dialect: str, sql: str) -> None:
+    with pytest.raises(ValueError, match="locking"):
+        check_query(sql, dialect=dialect)
+
+
+def test_a_plain_read_of_the_same_table_is_still_accepted() -> None:
+    check_query("SELECT * FROM sales", dialect="postgres")

--- a/pkg-py/tests/test_sql_guard.py
+++ b/pkg-py/tests/test_sql_guard.py
@@ -225,3 +225,19 @@ def test_a_locking_read_is_rejected(dialect: str, sql: str) -> None:
 
 def test_a_plain_read_of_the_same_table_is_still_accepted() -> None:
     check_query("SELECT * FROM sales", dialect="postgres")
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT 'unterminated",
+        'SELECT "unterminated',
+        "SELECT /* unterminated",
+        "SELECT $$ unterminated",
+    ],
+)
+def test_input_the_tokenizer_chokes_on_raises_value_error(sql: str) -> None:
+    # Tokenizing fails before parsing does, and it raises a different sqlglot
+    # exception. Callers catch ValueError, so neither may escape.
+    with pytest.raises(ValueError):
+        check_query(sql, dialect="duckdb")

--- a/pkg-py/uv.lock
+++ b/pkg-py/uv.lock
@@ -211,6 +211,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "raghilda" },
     { name = "sqlalchemy" },
+    { name = "sqlglot" },
 ]
 
 [package.optional-dependencies]
@@ -222,6 +223,8 @@ tracing = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pandas" },
+    { name = "polars" },
     { name = "pyrefly" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -241,11 +244,14 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6" },
     { name = "raghilda", specifier = ">=0.2" },
     { name = "sqlalchemy", specifier = ">=2.0" },
+    { name = "sqlglot", specifier = ">=25" },
 ]
 provides-extras = ["tracing"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pandas", specifier = ">=2" },
+    { name = "polars", specifier = ">=1" },
     { name = "pyrefly" },
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-asyncio" },
@@ -938,6 +944,45 @@ wheels = [
 ]
 
 [[package]]
+name = "pandas"
+version = "3.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/4f/5f3422a2afec5ffc46308b79e53291365a93748b498ac2e58bead0197916/pandas-3.0.5.tar.gz", hash = "sha256:dca3734d6ab7c906e6730f0788b0a1dbb9f2467731f9711f77995c8e9d62d712", size = 4658219, upload-time = "2026-07-22T22:19:28.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/ef/f1fd7431d635bf20015489bf0bd69c17fff1018de773540f651455a3916b/pandas-3.0.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2946e77e4a53cd248cbde631a12f0e51c8324ce354c3eba4d20147c1ad6f4282", size = 10397178, upload-time = "2026-07-22T22:17:48.274Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b4/0eafac990a431561187694126de01f9b12559549b4d86360c0c4bd870fde/pandas-3.0.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71ecc8fb7ed1a7aa4392316b5309a6347e8e7f832f38fd897846b3a1457a9298", size = 9990736, upload-time = "2026-07-22T22:17:52.388Z" },
+    { url = "https://files.pythonhosted.org/packages/de/21/359880af3ea9b7cb23bea5b51e8e70ef3866c03be09da9a2787e18e330a8/pandas-3.0.5-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b173f5951ff6b8b0ec7675e20dff3c97b7e7a57dfcce387c2d7c5afe87cb7899", size = 10814438, upload-time = "2026-07-22T22:17:54.708Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/50/d6cc4d7e508bbccf5d6027314a8312bc7ac73d0ec7f195f53838daafab40/pandas-3.0.5-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2c0cf1dd9b55a22d105fc46c1b489af3bd42264fcba7c66297bf47a9a1d9c78a", size = 11323634, upload-time = "2026-07-22T22:17:56.858Z" },
+    { url = "https://files.pythonhosted.org/packages/70/2b/d5f0a8c90dd0ae04e64ba53b871afb796ec026b615086d382ddc2ade729b/pandas-3.0.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0fac0010c75e4efb6b99e249c183a8993ce0dc95c240f9b120a5e67c727b7928", size = 11850860, upload-time = "2026-07-22T22:17:59.1Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/30/183aec2e19adf778a98d29b5729a0a68f4cc4ebf9b9c3b70d0297355bcb1/pandas-3.0.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:08d24fe11a17dc33bd6e937dc9c665f9cba08fbdc9f657f405713515febe300d", size = 12411100, upload-time = "2026-07-22T22:18:01.485Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/9a/31f4983f191af51ab2a8f2d0c7b33dff3a84da26533f982fff02c2f9e28b/pandas-3.0.5-cp311-cp311-win_amd64.whl", hash = "sha256:b1261758dfb6cf12c3cff8300e21cefad30e7ec709abb4c24ac7318e6a52462a", size = 9968804, upload-time = "2026-07-22T22:18:03.903Z" },
+    { url = "https://files.pythonhosted.org/packages/49/97/7886c89a39045c69ad82cbceaf3343810480c8ef49a216319ce8183860a6/pandas-3.0.5-cp311-cp311-win_arm64.whl", hash = "sha256:679f4e85b30ddb1515458ab1e788d3e260eae369b1f78da7a3aa4cac8ebf4a2a", size = 9205447, upload-time = "2026-07-22T22:18:06.134Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/54/1dc810ea558d1320b597aa140a514f2fdf1d2ea09c38cf556f13ea712ec9/pandas-3.0.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fa290c16964d4963fbfbc358928239cf3bd755b20e988ce944877def2f44471d", size = 10411717, upload-time = "2026-07-22T22:18:08.307Z" },
+    { url = "https://files.pythonhosted.org/packages/68/56/fbe81c09195924d8b7b8d4461a20458fe80a6a5ed6b24f0314da684277e1/pandas-3.0.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c2e26bb46934b8a2ca0c3de1d3d606fc5f6746584791b2db264d58cf370e08dc", size = 9957095, upload-time = "2026-07-22T22:18:10.6Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/51/fac252f4a913ed5eabf3c11b880a9e8d5a6c10f0b2129d0462212d238b4d/pandas-3.0.5-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:73fa87b08a7ef706f8aafda39ddaccf2a99047bea62d8c88a0361bcafb2237bc", size = 10485458, upload-time = "2026-07-22T22:18:12.834Z" },
+    { url = "https://files.pythonhosted.org/packages/12/98/e976540c1addf70442be7842a18cf70884a964abbf69442504f4d2939989/pandas-3.0.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d373ce03ffd84010ed9839fa73672a9c8256990532e158440c0085db7d914b34", size = 10998091, upload-time = "2026-07-22T22:18:15.209Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/8c/1f29b5be8d3fc47dd7567eb167fabba2085879b31e0287ce7cba6d3d2ff4/pandas-3.0.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2a29c53d85ea98c5e792c59ef82ee9fbe6ca902c0d0adb6b23f45ef894cd7bf6", size = 11499501, upload-time = "2026-07-22T22:18:17.689Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e2/bd9c98ad2df7b38bde002adde4cdf353519da51881634323b126c55997f9/pandas-3.0.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a5ad3b02ed6bc7d7ae9b70804b2c6aa31827489d150f8e623ce82491b82085d7", size = 12060559, upload-time = "2026-07-22T22:18:20.147Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/9a/ffbd852d58bd74a617fe2f8ee6a58a96982271ce41cf981eab22190b4a4b/pandas-3.0.5-cp312-cp312-pyemscripten_2024_0_wasm32.whl", hash = "sha256:b2acb4650527eec6822c3dadb2b771277b65e7dae7a267d4bccf65fd1bb3fbce", size = 7197652, upload-time = "2026-07-22T22:18:22.502Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b5/d2d3e9ae73362ba4229651b0ee1455cf78073a1ce585f6ff693782ce263e/pandas-3.0.5-cp312-cp312-win_amd64.whl", hash = "sha256:80a611068e8a3ac23f7398c6c14eb46dc974e5cc9997f653e2dcfd1da74edd41", size = 9831691, upload-time = "2026-07-22T22:18:24.534Z" },
+    { url = "https://files.pythonhosted.org/packages/52/51/dea1e89d6a6796b9c43f85a09b484ee03edb8a4c4842e73e200a8c11301c/pandas-3.0.5-cp312-cp312-win_arm64.whl", hash = "sha256:25ff585b972a18ef1fe9ffa3ac6544d9950508aa76832e5147640b6022821e49", size = 9105796, upload-time = "2026-07-22T22:18:27.064Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/09/7b95c4a0025227d6f118c4039b423412ac6a982db02864166185d812fbc7/pandas-3.0.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c1c05a767fe8e5b4fe9e1c29806829c582052eaedb9120a3da83ba3f69e24a5b", size = 10385742, upload-time = "2026-07-22T22:18:29.346Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0c/dc78fd8c4da477b4b5e8ad37295af352190d21ef63a9ee1bc071753074cc/pandas-3.0.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b86765f268b56f7e665b93bce9d5df69dee7f99e595cf8fb839483ab315942a3", size = 9932067, upload-time = "2026-07-22T22:18:31.833Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/71/3592c055cf44df9808550f9368ceda80ff2b224d355ef73fe251dcda1802/pandas-3.0.5-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c597ecf5616b5c420372c1d4d4c00dbbfba7398bea857dcc984347e1ea48417b", size = 10466756, upload-time = "2026-07-22T22:18:34.195Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/70/4363150359f95b4cb4bcbb34ca23572bb5495749a621a8f3d5a1ddfd293c/pandas-3.0.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b11c36e218331d0387cbe3a0a5f75162357a1d92d57b2b08a336ff94b19b2be", size = 10938525, upload-time = "2026-07-22T22:18:36.81Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/d0/317e7a0c67c0e69fa905a0161409397a7dc2d46ff611f6ca4803352c042b/pandas-3.0.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cf52e1f61d229496da17dc7ab54acdee627357e7008fd4fecba3d0ba2937fa58", size = 11489303, upload-time = "2026-07-22T22:18:39.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/8d/36dade89b49e4f9d5cbdbe863772581f98c0c6d78fc39ad4c557f6f2e17e/pandas-3.0.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:db172144bb56422bd157812f3b021eacc255451470b31e2c633c349490a1cfee", size = 11989004, upload-time = "2026-07-22T22:18:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ba/18c4ec8a746e177da05a9e7a7963781d8ea195780724f854601b6ebd6b78/pandas-3.0.5-cp313-cp313-win_amd64.whl", hash = "sha256:0d298e951f23016ce4699951d044ae6418dbc91bf68cefca0f77666fcbb4e5c6", size = 9826896, upload-time = "2026-07-22T22:18:44.539Z" },
+    { url = "https://files.pythonhosted.org/packages/de/ec/28a57266b753799a87b8bc79e7887ac6fd981b8c6d2978a0b7e7b6bd708c/pandas-3.0.5-cp313-cp313-win_arm64.whl", hash = "sha256:66266d3442a5e8b3c90274c2b8b230bee42dd1c286bc822cc2f9f2c7e12b883e", size = 9094790, upload-time = "2026-07-22T22:18:47.468Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.11.4"
 source = { registry = "https://pypi.org/simple" }
@@ -953,6 +998,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "polars"
+version = "1.44.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/73/258a1fe17bb2744a507199566ed712663144fdd0811b615b59a47dfa38d2/polars-1.44.1.tar.gz", hash = "sha256:ef3c89e9ebbbe8eb343c06873f1945683f8b6f97a1bdf001c60551c6c5e3cda1", size = 765660, upload-time = "2026-08-26T07:09:12.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/f1/59154659081930fbde291ea6225607956b500a71b0ce45d88217b7d32da2/polars-1.44.1-py3-none-any.whl", hash = "sha256:1fa62fc1c88fba77a68b28291b5aabdd69e5f38b34e59721a064ae3169b59bb5", size = 865208, upload-time = "2026-08-26T07:07:44.646Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.44.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/b2/2a76415d047a45df05489f2334c91ff120a274cf655d4ca030c7f54a8743/polars_runtime_32-1.44.1.tar.gz", hash = "sha256:abd10a54ed1caff42228610fcba0f93251f9870bd7cffb0c78bc26f5e0718ce4", size = 3171156, upload-time = "2026-08-26T07:09:14.243Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/93/ef9344dcec16757cf21027dc907ef989197e50742cfe4407f2e87edb0a7f/polars_runtime_32-1.44.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:1dfccb2b52aa50468a7d28e3e61c8338a13fb5bffc8646e388a649f5bdc6b463", size = 53962370, upload-time = "2026-08-26T07:07:47.21Z" },
+    { url = "https://files.pythonhosted.org/packages/10/da/38b32b7901af33f1fee2172ceaa39e9159825657920064298917392d78fa/polars_runtime_32-1.44.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:0580807dc3eed258f0db70bb65d905dd43f0135392119ec25308033ae24258fb", size = 48620468, upload-time = "2026-08-26T07:07:50.436Z" },
+    { url = "https://files.pythonhosted.org/packages/49/51/185af877d1d2236671493cf72bd3327a6046240eeea69c0696d1af2a5acb/polars_runtime_32-1.44.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0627f9aa82cb869725235e5188f698862fd9ada0c8c1cf65c3dc5a49a4a0ec26", size = 52455947, upload-time = "2026-08-26T07:07:53.776Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/0a/0858f60cb5a6f8f73ec4cdd73eccd9f748d66bfc23304c5c23fa3468094a/polars_runtime_32-1.44.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eea4283be8e60822d890dbda20588fe59b4172b508bd5ebf3471e531ca9f50d7", size = 58561262, upload-time = "2026-08-26T07:07:57.508Z" },
+    { url = "https://files.pythonhosted.org/packages/73/08/de4774b5612d7c8739f89ac01b601486b4f057b1da35a5b876bf9276fd95/polars_runtime_32-1.44.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:04e2c0f46e7a9906fffb1897f18f23b079b74f83c56b50060bace9e7b9b49b1a", size = 52636064, upload-time = "2026-08-26T07:08:06.337Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ac/769c598dd106e2a6647798da3ed25ddeee67f2d12c04f5da316cb3da6360/polars_runtime_32-1.44.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:0956f0cae632d8fad3a04b4315bf2bb69b56d10c83c79a75c2c4c5a13b9ce5cc", size = 56447612, upload-time = "2026-08-26T07:08:12.36Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/ee/98408296e15388020b6183323fdbe78ccab4f72c20d8e0d7092c062d3ad2/polars_runtime_32-1.44.1-cp310-abi3-win_amd64.whl", hash = "sha256:159334184e6fbb074c9f4692221ea19970a5e2bed2a479f9d7bdb00b7f3eedb9", size = 53702970, upload-time = "2026-08-26T07:08:15.398Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9d/8b17e075aac73c881a50b6c1f690d20df46db2f3bcabc99f600ecdee1290/polars_runtime_32-1.44.1-cp310-abi3-win_arm64.whl", hash = "sha256:3ba28d638d0513e0b4afbcdab5c0059a85021e5f81d62b5f793e7e23badb2cf7", size = 47281050, upload-time = "2026-08-26T07:08:18.43Z" },
 ]
 
 [[package]]
@@ -1153,6 +1226,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1330,6 +1415,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlglot"
+version = "30.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/d4/da49abcc81beebbb25f29ddf87f2980c63c949569d7f2da40c06d95fa415/sqlglot-30.17.0.tar.gz", hash = "sha256:2d6b8def93304fa300f4d20f48e3909e7f436fda56ca1fafd8975f6c561ef62c", size = 5999019, upload-time = "2026-08-12T19:36:50.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/bc/2a07cef49046e6cf5d1a8b1de553aaef8491b4170dbfe254c8687c764408/sqlglot-30.17.0-py3-none-any.whl", hash = "sha256:84435ac283a60173da31b5fd7d11a725037a1c3fd6ed1e21fb065de74ddb579f", size = 741795, upload-time = "2026-08-12T19:36:48.699Z" },
+]
+
+[[package]]
 name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1381,6 +1475,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
First PR of M2, the Python data layer. It lands `data_source()` for data frames, the in-process DuckDB it writes them into, and the read-only SQL guard that screens every query. Engine and pins-board sources follow in the next PR on this stack; kata `esad` closes with this one, `ec9d` stays open for them.

## The SQL guard is a parser, not a text check

This is the part worth review attention, and it is a departure from how `pkg-r` does it.

The guard started as a denylist plus a first-word test, matching `pkg-r/R/data-source.R`. That is not sound. DuckDB accepts DML after a CTE list, so `WITH t AS (SELECT 1) DELETE FROM sales` passes a first-word test and empties the table. Screening for the paren that closes the CTE only moves the question to what a comment or a quote hides, and DuckDB nests block comments and supports dollar quoting. Three separate bypasses came out of review that way, each reproduced against a live frame-backed source. Implementing our own guard is an exercise in whack-a-mole, when there are better options available in Python.

So the guard parses with [`sqlglot`](https://github.com/tobymao/sqlglot) into an AST and checks what the statement is. Read-only forms are an allowlist, so a form nobody anticipated fails closed instead of falling through a denylist, which is also what refuses `COPY`, `ATTACH`, `INSTALL` and `LOAD`. It searches the whole tree rather than just the root, since you could have write operations deeper inside a CTE. Locking reads such as `FOR UPDATE` are refused too: they change no rows but block writers.

`sqlglot` is a new runtime dependency. It has no dependencies of its own, and it parses every DuckDB construct tested here, including `EXCLUDE`, `QUALIFY`, `ASOF JOIN` and FROM-first syntax, so failing closed on a parse error does not cost real queries.

**`pkg-r`'s `check_query()` classifies statements the same way**, so it accepts DML after a CTE list, data-modifying CTEs, `SELECT INTO` and locking reads, and wrongly refuses a semicolon inside a string literal. Verified against the R function directly and filed as #243, rather than fixed here, because it's the R implementation's issue.

## Rejected alternative

DuckDB's own connection-level read-only mode refuses every bypass, because the engine is a real parser, but it had too many limitations to use:
 - it cannot run in-memory
 - it forbids a writer alongside the reader, which the board path's lazy pin loading needs

## Also here

Frame names reach SQL before the lockdown runs, so they are escaped and the staging relation gets a generated name. Previously a name containing a quote created a table under a truncated name, and `my sales` or `order-lines` failed outright.

The pyrefly CI step now takes explicit paths. Without them it consults the repo's git ignore files, so a worktree under the ignored `.worktrees/` directory type-checked nothing and still exited 0.

## Verification

202 tests, ruff and pyrefly clean. The security tests are written as attempts rather than as assertions about configuration: each bypass is replayed against a live source and the table checked afterwards.
