### PR TITLE
Add Python data sources over a SQLAlchemy engine and a pins board

### DIFF
--- a/pkg-py/pyproject.toml
+++ b/pkg-py/pyproject.toml
@@ -32,7 +32,7 @@ tracing = [
 ]
 
 [dependency-groups]
-dev = ["pytest>=8", "pytest-asyncio", "ruff", "pyrefly", "pandas>=2", "polars>=1"]
+dev = ["pytest>=8", "pytest-asyncio", "ruff", "pyrefly", "pandas>=2", "polars>=1", "pins>=0.9"]
 
 [build-system]
 requires = ["hatchling"]

--- a/pkg-py/src/commons/_backends.py
+++ b/pkg-py/src/commons/_backends.py
@@ -9,6 +9,7 @@ are DuckDB-specific and gain nothing from it.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Protocol
 
 import duckdb
@@ -30,6 +31,15 @@ class Backend(Protocol):
     def quote(self, table_id: TableId) -> str: ...
 
     def dialect(self) -> str: ...
+
+    def inspector(self) -> Callable[[TableId], bool] | None:
+        """A predicate answering whether a table exists, if the backend can.
+
+        Used to tell a table that is genuinely absent from one that a failing
+        query only made look absent. A backend that cannot answer returns
+        None, and the caller re-raises the original error rather than guessing.
+        """
+        ...
 
 
 class DuckDBBackend:
@@ -61,6 +71,11 @@ class DuckDBBackend:
     def dialect(self) -> str:
         return "duckdb"
 
+    def inspector(self) -> Callable[[TableId], bool] | None:
+        # Frame and pin sources build their own tables, so nothing reaches
+        # the existence check by this route.
+        return None
+
 
 class EngineBackend:
     def __init__(self, engine: sqlalchemy.Engine) -> None:
@@ -87,3 +102,11 @@ class EngineBackend:
 
     def dialect(self) -> str:
         return self._engine.dialect.name
+
+    def inspector(self) -> Callable[[TableId], bool] | None:
+        inspector = sqlalchemy.inspect(self._engine)
+
+        def exists(table_id: TableId) -> bool:
+            return inspector.has_table(table_id.table, schema=table_id.schema)
+
+        return exists

--- a/pkg-py/src/commons/_backends.py
+++ b/pkg-py/src/commons/_backends.py
@@ -1,10 +1,10 @@
 """What a data source needs from whatever holds its tables.
 
-The protocol exists so the in-process DuckDB commons builds from frames can
-hold a raw connection while a caller-supplied connection stays a SQLAlchemy
-engine (D2 makes the engine the connection currency). The raw path is not
-routed through SQLAlchemy because the lockdown and the deferred pin writes are
-DuckDB-specific and gain nothing from it.
+Two implementations: a SQLAlchemy `Engine` for connections a caller supplies
+(D2 makes the engine the connection currency), and a raw DuckDB connection for
+the in-process database commons builds from frames and pins. The raw path is
+not routed through SQLAlchemy because the lockdown and the deferred pin writes
+are DuckDB-specific and gain nothing from it.
 """
 
 from __future__ import annotations
@@ -12,13 +12,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Protocol
 
 import duckdb
+import sqlalchemy
 
 from ._duckdb import quote_identifier
 
 if TYPE_CHECKING:
     from ._data_source import TableId
 
-__all__ = ["Backend", "DuckDBBackend"]
+__all__ = ["Backend", "DuckDBBackend", "EngineBackend"]
 
 
 class Backend(Protocol):
@@ -59,3 +60,30 @@ class DuckDBBackend:
 
     def dialect(self) -> str:
         return "duckdb"
+
+
+class EngineBackend:
+    def __init__(self, engine: sqlalchemy.Engine) -> None:
+        self._engine = engine
+
+    @property
+    def engine(self) -> sqlalchemy.Engine:
+        return self._engine
+
+    def query(self, sql: str) -> list[dict[str, Any]]:
+        with self._engine.connect() as connection:
+            result = connection.execute(sqlalchemy.text(sql))
+            return [dict(row) for row in result.mappings()]
+
+    def list_tables(self) -> list[str]:
+        return list(sqlalchemy.inspect(self._engine).get_table_names())
+
+    def quote(self, table_id: TableId) -> str:
+        preparer = self._engine.dialect.identifier_preparer
+        quoted = preparer.quote(table_id.table)
+        if table_id.schema:
+            return f"{preparer.quote_schema(table_id.schema)}.{quoted}"
+        return quoted
+
+    def dialect(self) -> str:
+        return self._engine.dialect.name

--- a/pkg-py/src/commons/_data_source.py
+++ b/pkg-py/src/commons/_data_source.py
@@ -7,6 +7,7 @@ the constructor functions, which is where a bad argument can still be named.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -33,12 +34,26 @@ class TableId:
 
 
 @dataclass
+class _PendingPins:
+    """The deferred-read state a board source carries.
+
+    Shared by every alias of the source, so a read through one is seen by all.
+    A pin leaves `pins` only after a successful read, which is what makes a
+    failure surface to the caller and get retried on the next touch.
+    """
+
+    board: Any
+    pins: dict[str, str]
+
+
+@dataclass
 class DataSource:
     """Tables an agent can query, and the dictionary that describes them."""
 
     backend: Backend
     tables: list[str]
     table_ids: dict[str, TableId] = field(default_factory=dict)
+    pending: _PendingPins | None = None
 
     @classmethod
     def from_frames(cls, **frames: Any) -> DataSource:
@@ -85,10 +100,91 @@ class DataSource:
         _check_tables_exist(backend, registry)
         return cls(backend=backend, tables=list(registry), table_ids=registry)
 
+    @classmethod
+    def from_board(cls, board: Any, tables: Any) -> DataSource:
+        """Expose a pins board's pins as tables, each read on first use."""
+        if not isinstance(tables, dict):
+            raise TypeError(
+                "For a pins board, tables must be a mapping of table name to "
+                f"pin name, got {type(tables).__name__}."
+            )
+        if not tables:
+            raise ValueError("tables must name at least one pin.")
+
+        # One listing call validates every pin name, so a typo fails
+        # construction rather than a conversation.
+        available = set(board.pin_list())
+        missing = sorted({pin for pin in tables.values() if pin not in available})
+        if missing:
+            raise ValueError(
+                f"The board has no pins named: {', '.join(missing)}. "
+                f"Available pins: {', '.join(sorted(available))}."
+            )
+
+        # Lock down before any writes: lock_configuration() only freezes SET
+        # statements, so a deferred read still lands its table afterwards.
+        con = _duckdb.connect()
+        _duckdb.lock_down(con)
+
+        labels = list(tables)
+        return cls(
+            backend=DuckDBBackend(con),
+            tables=labels,
+            table_ids={label: TableId(table=label) for label in labels},
+            pending=_PendingPins(board=board, pins=dict(tables)),
+        )
+
     def query(self, sql: str) -> list[dict[str, Any]]:
         """Run one read-only statement, rejecting anything else first."""
         check_query(sql, dialect=self.backend.dialect())
-        return self.backend.query(sql)
+        if self.pending is None:
+            return self.backend.query(sql)
+        return self._query_loading_pins(sql)
+
+    def _query_loading_pins(self, sql: str) -> list[dict[str, Any]]:
+        # Let DuckDB resolve the query's table references and drive loading off
+        # the tables it reports missing: run it, load the pending tables the
+        # error names, retry. A genuine error (bad column, syntax) surfaces
+        # unchanged, and each pass either loads a table or stops, so the loop
+        # is bounded.
+        while True:
+            try:
+                return self.backend.query(sql)
+            except Exception as error:
+                todo = self._pending_tables_named_in(str(error))
+                if not todo:
+                    raise
+                self._load_pins(todo)
+
+    def _pending_tables_named_in(self, message: str) -> list[str]:
+        assert self.pending is not None
+        return [
+            label
+            for label in self.pending.pins
+            if re.search(rf"\b{re.escape(label)}\b", message)
+        ]
+
+    def _load_pins(self, labels: list[str]) -> None:
+        assert self.pending is not None
+        backend = self.backend
+        assert isinstance(backend, DuckDBBackend)
+        for position, label in enumerate(labels):
+            pin = self.pending.pins[label]
+            value = self.pending.board.pin_read(pin)
+            if not _is_frame(value):
+                raise TypeError(
+                    f"Pin {pin!r} is a {type(value).__name__}, not a data frame, "
+                    f"so it cannot become the table {label!r}."
+                )
+            staging = f"_commons_pin_{position}"
+            backend.connection.register(staging, value)
+            backend.connection.execute(
+                f"CREATE TABLE {_duckdb.quote_identifier(label)} AS "
+                f"SELECT * FROM {staging}"
+            )
+            backend.connection.unregister(staging)
+            # Only after the write succeeds, so a failure is retried.
+            del self.pending.pins[label]
 
     def dialect(self) -> str:
         """A hint for the system prompt, not a contract."""
@@ -117,6 +213,8 @@ def data_source(*args: Any, tables: Any = None, **frames: Any) -> DataSource:
 def _from_positional(value: Any, tables: Any) -> DataSource:
     if isinstance(value, sqlalchemy.Engine):
         return DataSource.from_engine(value, tables=tables)
+    if hasattr(value, "pin_list") and hasattr(value, "pin_read"):
+        return DataSource.from_board(value, tables)
     raise TypeError(
         "data_source() takes a SQLAlchemy Engine, a pins board, or named data "
         f"frames. Got {type(value).__name__}."

--- a/pkg-py/src/commons/_data_source.py
+++ b/pkg-py/src/commons/_data_source.py
@@ -7,7 +7,6 @@ the constructor functions, which is where a bad argument can still be named.
 
 from __future__ import annotations
 
-import re
 import string
 from dataclasses import dataclass, field
 from typing import Any
@@ -20,11 +19,12 @@ from ._sql_guard import check_query
 
 __all__ = ["DataSource", "TableId", "data_source", "list_tables"]
 
-# DuckDB's catalog error names the relation it could not find. Anchored to the
-# head of the message, because DuckDB echoes the failing statement afterwards
-# and a string literal there could otherwise pose as a second missing table.
-# The name runs to the fixed trailer, since a quoted label may contain spaces.
-_MISSING_RELATION = re.compile(r"Catalog Error: Table with name (.+?) does not exist")
+# DuckDB's catalog error names the relation it could not find. Each pending
+# label is tested against the whole phrase rather than the name being parsed
+# out of it, because a label may itself contain the trailer and there would be
+# no way to tell where the name ended.
+_MISSING_PREFIX = "Catalog Error: Table with name "
+_MISSING_SUFFIX = " does not exist"
 
 # DuckDB folds identifiers over ASCII only, so "Ä" and "ä" are two tables
 # while "sales" and "SALES" are one. Python's casefold() is broader (it maps
@@ -185,11 +185,16 @@ class DataSource:
         error repeats whatever case the query used.
         """
         assert self.pending is not None
-        found = _MISSING_RELATION.match(message.lstrip())
-        if found is None:
+        head = _fold(message.lstrip())
+        if not head.startswith(_fold(_MISSING_PREFIX)):
             return []
-        named = _fold(found.group(1))
-        return [label for label in self.pending.pins if _fold(label) == named]
+        # DuckDB reports one missing relation at a time, so at most one label
+        # matches and the caller loads exactly what the error named.
+        return [
+            label
+            for label in self.pending.pins
+            if head.startswith(_fold(f"{_MISSING_PREFIX}{label}{_MISSING_SUFFIX}"))
+        ]
 
     def _load_pins(self, labels: list[str]) -> None:
         assert self.pending is not None

--- a/pkg-py/src/commons/_data_source.py
+++ b/pkg-py/src/commons/_data_source.py
@@ -8,6 +8,7 @@ the constructor functions, which is where a bad argument can still be named.
 from __future__ import annotations
 
 import re
+import string
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -24,6 +25,15 @@ __all__ = ["DataSource", "TableId", "data_source", "list_tables"]
 # and a string literal there could otherwise pose as a second missing table.
 # The name runs to the fixed trailer, since a quoted label may contain spaces.
 _MISSING_RELATION = re.compile(r"Catalog Error: Table with name (.+?) does not exist")
+
+# DuckDB folds identifiers over ASCII only, so "Ä" and "ä" are two tables
+# while "sales" and "SALES" are one. Python's casefold() is broader (it maps
+# "ß" to "ss") and would merge names DuckDB keeps apart.
+_ASCII_FOLD = str.maketrans(string.ascii_uppercase, string.ascii_lowercase)
+
+
+def _fold(name: str) -> str:
+    return name.translate(_ASCII_FOLD)
 
 
 @dataclass(frozen=True)
@@ -178,8 +188,8 @@ class DataSource:
         found = _MISSING_RELATION.match(message.lstrip())
         if found is None:
             return []
-        named = found.group(1).casefold()
-        return [label for label in self.pending.pins if label.casefold() == named]
+        named = _fold(found.group(1))
+        return [label for label in self.pending.pins if _fold(label) == named]
 
     def _load_pins(self, labels: list[str]) -> None:
         assert self.pending is not None
@@ -367,7 +377,7 @@ def _check_labels_distinct(labels: list[str]) -> None:
     """
     seen: dict[str, str] = {}
     for label in labels:
-        first = seen.setdefault(label.casefold(), label)
+        first = seen.setdefault(_fold(label), label)
         if first != label:
             raise ValueError(
                 f"Table names {first!r} and {label!r} differ only by case, and "

--- a/pkg-py/src/commons/_data_source.py
+++ b/pkg-py/src/commons/_data_source.py
@@ -19,6 +19,10 @@ from ._sql_guard import check_query
 
 __all__ = ["DataSource", "TableId", "data_source", "list_tables"]
 
+# DuckDB's catalog error names the relation it could not find. The name runs
+# to the fixed trailer, because a quoted label may contain spaces.
+_MISSING_RELATION = re.compile(r"Table with name (.+?) does not exist")
+
 
 @dataclass(frozen=True)
 class TableId:
@@ -127,6 +131,7 @@ class DataSource:
         _duckdb.lock_down(con)
 
         labels = list(tables)
+        _check_labels_free(con, labels)
         return cls(
             backend=DuckDBBackend(con),
             tables=labels,
@@ -157,12 +162,17 @@ class DataSource:
                 self._load_pins(todo)
 
     def _pending_tables_named_in(self, message: str) -> list[str]:
+        """Pending labels DuckDB reported as missing relations.
+
+        Only the catalog error's own relation name is used. DuckDB echoes the
+        failing statement in its message, so scanning the whole text would
+        load a pin whose label merely appears in a string literal. Names are
+        compared case-insensitively, because DuckDB identifiers are, and its
+        error repeats whatever case the query used.
+        """
         assert self.pending is not None
-        return [
-            label
-            for label in self.pending.pins
-            if re.search(rf"\b{re.escape(label)}\b", message)
-        ]
+        named = {name.casefold() for name in _MISSING_RELATION.findall(message)}
+        return [label for label in self.pending.pins if label.casefold() in named]
 
     def _load_pins(self, labels: list[str]) -> None:
         assert self.pending is not None
@@ -191,23 +201,27 @@ class DataSource:
         return self.backend.dialect()
 
 
-def data_source(*args: Any, tables: Any = None, **frames: Any) -> DataSource:
+def data_source(*args: Any, **kwargs: Any) -> DataSource:
     """Create a data source from an engine, a pins board, or named frames.
 
     A thin dispatcher over the constructors, which are the documented way in.
+    `tables` is an option for the engine and board forms; with no positional
+    source it is an ordinary frame name, so a frame may be called `tables`.
     """
-    if args and frames:
-        raise TypeError(
-            "Pass either a connection or named data frames, not both. "
-            f"Got a positional argument and the frames {sorted(frames)}."
-        )
     if len(args) > 1:
         raise TypeError(
             f"data_source() accepts one positional argument, got {len(args)}."
         )
-    if args:
-        return _from_positional(args[0], tables)
-    return DataSource.from_frames(**frames)
+    if not args:
+        return DataSource.from_frames(**kwargs)
+
+    tables = kwargs.pop("tables", None)
+    if kwargs:
+        raise TypeError(
+            "Pass either a connection or named data frames, not both. "
+            f"Got a positional argument and the frames {sorted(kwargs)}."
+        )
+    return _from_positional(args[0], tables)
 
 
 def _from_positional(value: Any, tables: Any) -> DataSource:
@@ -299,8 +313,8 @@ def _table_entry_id(entry: Any) -> TableId:
 def _check_tables_exist(backend: Backend, registry: dict[str, TableId]) -> None:
     """Fail construction naming every table the connection does not have."""
     # One zero-row probe per table costs a round trip each, which dominates
-    # startup against a remote warehouse. Probe them all in one statement and
-    # fall back to per-table probes only to name the ones that are missing.
+    # startup against a remote warehouse, so probe them all in one statement
+    # and only work out what is missing when that fails.
     probe = " UNION ALL ".join(
         f"SELECT 1 FROM {backend.quote(table_id)} WHERE 1 = 0"
         for table_id in registry.values()
@@ -310,8 +324,8 @@ def _check_tables_exist(backend: Backend, registry: dict[str, TableId]) -> None:
     except Exception as error:
         missing = _missing_tables(backend, registry)
         if not missing:
-            # The probe failed for some other reason, and that error is more
-            # informative than anything this function could say.
+            # Permissions, connectivity, a dialect quirk in the probe: the
+            # original error says more than a missing-table message could.
             raise
         available = ", ".join(sorted(backend.list_tables()))
         raise ValueError(
@@ -321,10 +335,41 @@ def _check_tables_exist(backend: Backend, registry: dict[str, TableId]) -> None:
 
 
 def _missing_tables(backend: Backend, registry: dict[str, TableId]) -> list[str]:
-    missing = []
-    for label, table_id in registry.items():
-        try:
-            backend.query(f"SELECT 1 FROM {backend.quote(table_id)} WHERE 1 = 0")
-        except Exception:  # noqa: BLE001 - absence is the answer, not the error
-            missing.append(label)
-    return missing
+    """Which requested tables the backend says it does not have.
+
+    Absence is asked of the backend rather than inferred from a failed query,
+    so a permissions or connectivity failure is not reported as a typo.
+    """
+    inspector = backend.inspector()
+    if inspector is None:
+        return []
+    return [
+        label
+        for label, table_id in registry.items()
+        if not inspector(table_id)
+    ]
+
+
+def _check_labels_free(con: Any, labels: list[str]) -> None:
+    """Reject a table label that DuckDB already resolves.
+
+    A board label such as `duckdb_tables` would resolve to DuckDB's own
+    relation, so the pin would never load and the agent would silently query
+    something else.
+    """
+    taken = [label for label in labels if _relation_resolves(con, label)]
+    if taken:
+        raise ValueError(
+            f"These table names are already built-in DuckDB relations: "
+            f"{', '.join(taken)}. Choose a different name for each."
+        )
+
+
+def _relation_resolves(con: Any, label: str) -> bool:
+    try:
+        con.execute(
+            f"SELECT 1 FROM {_duckdb.quote_identifier(label)} WHERE 1 = 0"
+        ).fetchall()
+    except Exception:  # noqa: BLE001 - failing to resolve is the answer
+        return False
+    return True

--- a/pkg-py/src/commons/_data_source.py
+++ b/pkg-py/src/commons/_data_source.py
@@ -19,9 +19,11 @@ from ._sql_guard import check_query
 
 __all__ = ["DataSource", "TableId", "data_source", "list_tables"]
 
-# DuckDB's catalog error names the relation it could not find. The name runs
-# to the fixed trailer, because a quoted label may contain spaces.
-_MISSING_RELATION = re.compile(r"Table with name (.+?) does not exist")
+# DuckDB's catalog error names the relation it could not find. Anchored to the
+# head of the message, because DuckDB echoes the failing statement afterwards
+# and a string literal there could otherwise pose as a second missing table.
+# The name runs to the fixed trailer, since a quoted label may contain spaces.
+_MISSING_RELATION = re.compile(r"Catalog Error: Table with name (.+?) does not exist")
 
 
 @dataclass(frozen=True)
@@ -63,6 +65,7 @@ class DataSource:
     def from_frames(cls, **frames: Any) -> DataSource:
         """Load named data frames into a locked-down in-process DuckDB."""
         _check_named_frames(frames)
+        _check_labels_distinct(list(frames))
         con = _duckdb.connect()
         for position, (name, frame) in enumerate(frames.items()):
             # The registered relation gets a generated name rather than one
@@ -131,6 +134,7 @@ class DataSource:
         _duckdb.lock_down(con)
 
         labels = list(tables)
+        _check_labels_distinct(labels)
         _check_labels_free(con, labels)
         return cls(
             backend=DuckDBBackend(con),
@@ -171,8 +175,11 @@ class DataSource:
         error repeats whatever case the query used.
         """
         assert self.pending is not None
-        named = {name.casefold() for name in _MISSING_RELATION.findall(message)}
-        return [label for label in self.pending.pins if label.casefold() in named]
+        found = _MISSING_RELATION.match(message.lstrip())
+        if found is None:
+            return []
+        named = found.group(1).casefold()
+        return [label for label in self.pending.pins if label.casefold() == named]
 
     def _load_pins(self, labels: list[str]) -> None:
         assert self.pending is not None
@@ -340,14 +347,32 @@ def _missing_tables(backend: Backend, registry: dict[str, TableId]) -> list[str]
     Absence is asked of the backend rather than inferred from a failed query,
     so a permissions or connectivity failure is not reported as a typo.
     """
-    inspector = backend.inspector()
-    if inspector is None:
+    try:
+        inspector = backend.inspector()
+        if inspector is None:
+            return []
+        return [
+            label for label, table_id in registry.items() if not inspector(table_id)
+        ]
+    except Exception:  # noqa: BLE001 - inconclusive; the caller re-raises
         return []
-    return [
-        label
-        for label, table_id in registry.items()
-        if not inspector(table_id)
-    ]
+
+
+def _check_labels_distinct(labels: list[str]) -> None:
+    """Reject labels that DuckDB would resolve to the same relation.
+
+    DuckDB matches identifiers case-insensitively even when quoted, so
+    `sales` and `SALES` are one table. Left unchecked, the second write
+    fails with a raw DuckDB catalog error instead of naming the problem.
+    """
+    seen: dict[str, str] = {}
+    for label in labels:
+        first = seen.setdefault(label.casefold(), label)
+        if first != label:
+            raise ValueError(
+                f"Table names {first!r} and {label!r} differ only by case, and "
+                "DuckDB treats them as one table. Choose distinct names."
+            )
 
 
 def _check_labels_free(con: Any, labels: list[str]) -> None:

--- a/pkg-py/src/commons/_data_source.py
+++ b/pkg-py/src/commons/_data_source.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+import sqlalchemy
+
 from . import _duckdb
-from ._backends import Backend, DuckDBBackend
+from ._backends import Backend, DuckDBBackend, EngineBackend
 from ._sql_guard import check_query
 
 __all__ = ["DataSource", "TableId", "data_source", "list_tables"]
@@ -62,6 +64,27 @@ class DataSource:
             table_ids={name: TableId(table=name) for name in tables},
         )
 
+    @classmethod
+    def from_engine(cls, engine: sqlalchemy.Engine, tables: Any = None) -> DataSource:
+        """Query a caller's database directly. Nothing is copied.
+
+        With `tables` unset the backend's own listing is taken as given: it
+        reports what exists, so there is nothing to check and no round trip
+        worth paying for.
+        """
+        backend = EngineBackend(engine)
+        if tables is None:
+            discovered = backend.list_tables()
+            return cls(
+                backend=backend,
+                tables=discovered,
+                table_ids={name: TableId(table=name) for name in discovered},
+            )
+
+        registry = normalize_table_registry(tables)
+        _check_tables_exist(backend, registry)
+        return cls(backend=backend, tables=list(registry), table_ids=registry)
+
     def query(self, sql: str) -> list[dict[str, Any]]:
         """Run one read-only statement, rejecting anything else first."""
         check_query(sql, dialect=self.backend.dialect())
@@ -72,19 +95,32 @@ class DataSource:
         return self.backend.dialect()
 
 
-def data_source(*args: Any, **frames: Any) -> DataSource:
-    """Create a data source from named data frames.
+def data_source(*args: Any, tables: Any = None, **frames: Any) -> DataSource:
+    """Create a data source from an engine, a pins board, or named frames.
 
     A thin dispatcher over the constructors, which are the documented way in.
-    Engine and pins-board sources land alongside `DataSource.from_engine` and
-    `DataSource.from_board`.
     """
-    if args:
+    if args and frames:
         raise TypeError(
-            "data_source() takes named data frames. Got a positional "
-            f"{type(args[0]).__name__}."
+            "Pass either a connection or named data frames, not both. "
+            f"Got a positional argument and the frames {sorted(frames)}."
         )
+    if len(args) > 1:
+        raise TypeError(
+            f"data_source() accepts one positional argument, got {len(args)}."
+        )
+    if args:
+        return _from_positional(args[0], tables)
     return DataSource.from_frames(**frames)
+
+
+def _from_positional(value: Any, tables: Any) -> DataSource:
+    if isinstance(value, sqlalchemy.Engine):
+        return DataSource.from_engine(value, tables=tables)
+    raise TypeError(
+        "data_source() takes a SQLAlchemy Engine, a pins board, or named data "
+        f"frames. Got {type(value).__name__}."
+    )
 
 
 def list_tables(source: DataSource) -> list[str]:
@@ -112,3 +148,85 @@ def _is_frame(value: Any) -> bool:
     # Duck-typed rather than imported: pandas and polars are both optional at
     # this boundary, and DuckDB accepts either through the same registration.
     return hasattr(value, "__dataframe__") or hasattr(value, "columns")
+
+
+def normalize_table_registry(tables: Any) -> dict[str, TableId]:
+    """Turn a `tables` argument into label -> `TableId`.
+
+    Strings containing dots are read as schema-qualified. A literal table name
+    containing a dot is spelled as a `TableId`.
+    """
+    if isinstance(tables, (str, TableId)):
+        entries: list[Any] = [tables]
+    elif isinstance(tables, (list, tuple)):
+        entries = list(tables)
+    else:
+        raise TypeError(
+            "tables must be a string, a TableId, or a list of them, got "
+            f"{type(tables).__name__}."
+        )
+
+    registry: dict[str, TableId] = {}
+    for entry in entries:
+        table_id = _table_entry_id(entry)
+        if table_id.label in registry:
+            raise ValueError(
+                f"tables must not contain duplicate labels: {table_id.label}."
+            )
+        registry[table_id.label] = table_id
+    return registry
+
+
+def _table_entry_id(entry: Any) -> TableId:
+    if isinstance(entry, TableId):
+        if not entry.table or (entry.schema is not None and not entry.schema):
+            raise ValueError("TableId entries must not contain empty name components.")
+        return entry
+    if not isinstance(entry, str) or not entry:
+        raise TypeError(
+            f"Each entry in tables must be a table name or a TableId, got {entry!r}."
+        )
+
+    parts = entry.split(".")
+    if any(part == "" for part in parts):
+        raise ValueError(
+            "Schema-qualified entries in tables must not contain empty name "
+            f"components: {entry!r}."
+        )
+    if len(parts) == 1:
+        return TableId(table=entry)
+    return TableId(table=parts[-1], schema=".".join(parts[:-1]))
+
+
+def _check_tables_exist(backend: Backend, registry: dict[str, TableId]) -> None:
+    """Fail construction naming every table the connection does not have."""
+    # One zero-row probe per table costs a round trip each, which dominates
+    # startup against a remote warehouse. Probe them all in one statement and
+    # fall back to per-table probes only to name the ones that are missing.
+    probe = " UNION ALL ".join(
+        f"SELECT 1 FROM {backend.quote(table_id)} WHERE 1 = 0"
+        for table_id in registry.values()
+    )
+    try:
+        backend.query(probe)
+    except Exception as error:
+        missing = _missing_tables(backend, registry)
+        if not missing:
+            # The probe failed for some other reason, and that error is more
+            # informative than anything this function could say.
+            raise
+        available = ", ".join(sorted(backend.list_tables()))
+        raise ValueError(
+            f"tables names tables that are missing from the connection: "
+            f"{', '.join(missing)}. Available tables: {available}."
+        ) from error
+
+
+def _missing_tables(backend: Backend, registry: dict[str, TableId]) -> list[str]:
+    missing = []
+    for label, table_id in registry.items():
+        try:
+            backend.query(f"SELECT 1 FROM {backend.quote(table_id)} WHERE 1 = 0")
+        except Exception:  # noqa: BLE001 - absence is the answer, not the error
+            missing.append(label)
+    return missing

--- a/pkg-py/src/commons/_data_source.py
+++ b/pkg-py/src/commons/_data_source.py
@@ -188,13 +188,17 @@ class DataSource:
         head = _fold(message.lstrip())
         if not head.startswith(_fold(_MISSING_PREFIX)):
             return []
-        # DuckDB reports one missing relation at a time, so at most one label
-        # matches and the caller loads exactly what the error named.
-        return [
+        matches = [
             label
             for label in self.pending.pins
             if head.startswith(_fold(f"{_MISSING_PREFIX}{label}{_MISSING_SUFFIX}"))
         ]
+        if not matches:
+            return []
+        # One label can be a prefix of another up to the trailer, so `sales`
+        # also matches the error for `sales does not exist archive`. DuckDB
+        # names one relation, and the longest match is the one it named.
+        return [max(matches, key=len)]
 
     def _load_pins(self, labels: list[str]) -> None:
         assert self.pending is not None

--- a/pkg-py/tests/test_data_source.py
+++ b/pkg-py/tests/test_data_source.py
@@ -125,3 +125,12 @@ def test_frame_names_colliding_only_by_case_are_rejected() -> None:
     # table. Without a check the second write raises a raw DuckDB error.
     with pytest.raises(ValueError, match="differ only by case"):
         data_source(sales=sales_frame(), SALES=sales_frame())
+
+
+def test_non_ascii_names_that_duckdb_keeps_distinct_are_allowed() -> None:
+    # DuckDB folds ASCII only, so these are two tables. Python's casefold()
+    # maps "ß" to "ss" and would have rejected them as one.
+    source = data_source(straße=sales_frame(), STRASSE=sales_frame())
+
+    assert sorted(list_tables(source)) == ["STRASSE", "straße"]
+    assert source.query('SELECT count(*) AS n FROM "straße"') == [{"n": 3}]

--- a/pkg-py/tests/test_data_source.py
+++ b/pkg-py/tests/test_data_source.py
@@ -103,3 +103,18 @@ def test_the_guard_is_given_the_sources_dialect() -> None:
     assert source.query("SELECT * EXCLUDE (order_id, region) FROM sales")[0] == {
         "revenue": 100.0
     }
+
+
+def test_a_frame_may_be_named_tables() -> None:
+    # `tables` is an option for engine and board sources only. Consuming it
+    # when no positional source was given would silently drop a frame.
+    source = data_source(tables=sales_frame())
+
+    assert list_tables(source) == ["tables"]
+    assert source.query("SELECT count(*) AS n FROM tables") == [{"n": 3}]
+
+
+def test_a_frame_named_tables_alongside_others_is_not_dropped() -> None:
+    source = data_source(sales=sales_frame(), tables=sales_frame())
+
+    assert sorted(list_tables(source)) == ["sales", "tables"]

--- a/pkg-py/tests/test_data_source.py
+++ b/pkg-py/tests/test_data_source.py
@@ -118,3 +118,10 @@ def test_a_frame_named_tables_alongside_others_is_not_dropped() -> None:
     source = data_source(sales=sales_frame(), tables=sales_frame())
 
     assert sorted(list_tables(source)) == ["sales", "tables"]
+
+
+def test_frame_names_colliding_only_by_case_are_rejected() -> None:
+    # DuckDB resolves quoted identifiers case-insensitively, so these are one
+    # table. Without a check the second write raises a raw DuckDB error.
+    with pytest.raises(ValueError, match="differ only by case"):
+        data_source(sales=sales_frame(), SALES=sales_frame())

--- a/pkg-py/tests/test_data_source_board.py
+++ b/pkg-py/tests/test_data_source_board.py
@@ -223,3 +223,18 @@ def test_pin_matching_folds_over_ascii_only(
 
     assert source.query('SELECT count(*) AS n FROM "STRAßE"') == [{"n": 1}]
     assert reads == ["strasse-pin"]
+
+
+def test_a_label_containing_the_error_wording_still_loads(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # DuckDB's message is "Table with name <label> does not exist", so a label
+    # that itself contains that phrase makes the delimiter ambiguous.
+    label = "sales does not exist archive"
+    board = pins.board_folder(str(tmp_path))
+    board.pin_write(pd.DataFrame({"revenue": [1.0]}), "odd-pin", type="csv")
+    source = data_source(board, tables={label: "odd-pin"})
+    reads = record_reads(board, monkeypatch)
+
+    assert source.query(f'SELECT count(*) AS n FROM "{label}"') == [{"n": 1}]
+    assert reads == ["odd-pin"]

--- a/pkg-py/tests/test_data_source_board.py
+++ b/pkg-py/tests/test_data_source_board.py
@@ -205,3 +205,21 @@ def test_a_query_cannot_smuggle_a_missing_table_phrase(
     )
 
     assert reads == ["sales-pin"]
+
+
+def test_pin_matching_folds_over_ascii_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # DuckDB keeps "straße" and "STRASSE" apart, so a query for the latter
+    # must not read the former's pin. Only the ASCII case variant matches.
+    board = pins.board_folder(str(tmp_path))
+    board.pin_write(pd.DataFrame({"revenue": [1.0]}), "strasse-pin", type="csv")
+    source = data_source(board, tables={"straße": "strasse-pin"})
+    reads = record_reads(board, monkeypatch)
+
+    with pytest.raises(Exception, match="STRASSE"):
+        source.query('SELECT count(*) AS n FROM "STRASSE"')
+    assert reads == []
+
+    assert source.query('SELECT count(*) AS n FROM "STRAßE"') == [{"n": 1}]
+    assert reads == ["strasse-pin"]

--- a/pkg-py/tests/test_data_source_board.py
+++ b/pkg-py/tests/test_data_source_board.py
@@ -238,3 +238,21 @@ def test_a_label_containing_the_error_wording_still_loads(
 
     assert source.query(f'SELECT count(*) AS n FROM "{label}"') == [{"n": 1}]
     assert reads == ["odd-pin"]
+
+
+def test_overlapping_labels_load_only_the_one_the_error_named(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # "sales" is a prefix of the longer label up to the error's trailer, so a
+    # naive phrase match selects both. Only the relation DuckDB named loads.
+    long_label = "sales does not exist archive"
+    board = pins.board_folder(str(tmp_path))
+    board.pin_write(pd.DataFrame({"revenue": [1.0]}), "short-pin", type="csv")
+    board.pin_write(pd.DataFrame({"revenue": [2.0, 3.0]}), "long-pin", type="csv")
+    source = data_source(
+        board, tables={"sales": "short-pin", long_label: "long-pin"}
+    )
+    reads = record_reads(board, monkeypatch)
+
+    assert source.query(f'SELECT count(*) AS n FROM "{long_label}"') == [{"n": 2}]
+    assert reads == ["long-pin"]

--- a/pkg-py/tests/test_data_source_board.py
+++ b/pkg-py/tests/test_data_source_board.py
@@ -181,3 +181,27 @@ def test_a_label_colliding_with_a_built_in_relation_is_rejected(board: Any) -> N
     # never load and the agent would silently query the wrong thing.
     with pytest.raises(ValueError, match="duckdb_tables"):
         data_source(board, tables={"duckdb_tables": "sales-pin"})
+
+
+def test_board_labels_colliding_only_by_case_are_rejected(board: Any) -> None:
+    with pytest.raises(ValueError, match="differ only by case"):
+        data_source(board, tables={"sales": "sales-pin", "SALES": "regions-pin"})
+
+
+def test_a_query_cannot_smuggle_a_missing_table_phrase(
+    board: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # DuckDB echoes the failing statement, so a literal repeating its own
+    # error wording must not be read as naming a second missing relation.
+    source = data_source(
+        board, tables={"sales": "sales-pin", "regions": "regions-pin"}
+    )
+    reads = record_reads(board, monkeypatch)
+
+    source.query(
+        "SELECT count(*) AS n, "
+        "'Catalog Error: Table with name regions does not exist' AS tag "
+        "FROM sales"
+    )
+
+    assert reads == ["sales-pin"]

--- a/pkg-py/tests/test_data_source_board.py
+++ b/pkg-py/tests/test_data_source_board.py
@@ -1,0 +1,145 @@
+"""Data sources over a pins board.
+
+Pin names are validated at construction, in one listing call. Each pin is read
+only when its table is first used, and a table then reflects that value for the
+lifetime of the source.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from commons import data_source, list_tables
+
+pins = pytest.importorskip("pins")
+
+
+@pytest.fixture
+def board(tmp_path: Path) -> Any:
+    board = pins.board_folder(str(tmp_path))
+    board.pin_write(pd.DataFrame({"revenue": [1.0, 2.0]}), "sales-pin", type="csv")
+    board.pin_write(pd.DataFrame({"name": ["EMEA"]}), "regions-pin", type="csv")
+    return board
+
+
+def record_reads(board: Any, monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Watch which pins get read, without replacing the read itself."""
+    reads: list[str] = []
+    original = board.pin_read
+
+    def watched(name: str) -> Any:
+        reads.append(name)
+        return original(name)
+
+    monkeypatch.setattr(board, "pin_read", watched)
+    return reads
+
+
+def test_pins_are_not_read_at_construction(
+    board: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    reads = record_reads(board, monkeypatch)
+
+    source = data_source(board, tables={"sales": "sales-pin"})
+
+    assert list_tables(source) == ["sales"]
+    assert reads == []
+
+
+def test_a_pin_is_read_on_first_use(board: Any) -> None:
+    source = data_source(board, tables={"sales": "sales-pin"})
+
+    assert source.query("SELECT count(*) AS n FROM sales") == [{"n": 2}]
+
+
+def test_a_second_query_does_not_reread_the_pin(
+    board: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = data_source(board, tables={"sales": "sales-pin"})
+    reads = record_reads(board, monkeypatch)
+
+    source.query("SELECT count(*) AS n FROM sales")
+    source.query("SELECT count(*) AS n FROM sales")
+
+    assert reads == ["sales-pin"]
+
+
+def test_a_query_loads_only_the_tables_it_names(
+    board: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = data_source(
+        board, tables={"sales": "sales-pin", "regions": "regions-pin"}
+    )
+    reads = record_reads(board, monkeypatch)
+
+    source.query("SELECT count(*) AS n FROM sales")
+
+    assert reads == ["sales-pin"]
+
+
+def test_a_missing_pin_is_caught_at_construction(board: Any) -> None:
+    with pytest.raises(ValueError, match="nope"):
+        data_source(board, tables={"sales": "nope"})
+
+
+def test_the_construction_error_names_the_available_pins(board: Any) -> None:
+    with pytest.raises(ValueError, match="sales-pin"):
+        data_source(board, tables={"sales": "nope"})
+
+
+def test_a_failed_read_surfaces_at_use_and_is_retried(
+    board: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A pin leaves the pending set only after a successful read, so a network
+    # failure surfaces to the caller and the next touch tries again.
+    original = board.pin_read
+    calls = {"n": 0}
+
+    def flaky(name: str) -> Any:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("network down")
+        return original(name)
+
+    monkeypatch.setattr(board, "pin_read", flaky)
+    source = data_source(board, tables={"sales": "sales-pin"})
+
+    with pytest.raises(RuntimeError, match="network down"):
+        source.query("SELECT count(*) AS n FROM sales")
+    assert source.query("SELECT count(*) AS n FROM sales") == [{"n": 2}]
+
+
+def test_tables_must_be_a_mapping_of_labels_to_pin_names(board: Any) -> None:
+    with pytest.raises(TypeError, match="mapping"):
+        data_source(board, tables=["sales-pin"])
+
+
+def test_at_least_one_pin_is_required(board: Any) -> None:
+    with pytest.raises(ValueError, match="at least one pin"):
+        data_source(board, tables={})
+
+
+def test_a_pin_that_is_not_a_frame_errors_clearly(board: Any) -> None:
+    board.pin_write([1, 2, 3], "list-pin", type="json")
+    source = data_source(board, tables={"nums": "list-pin"})
+
+    with pytest.raises(TypeError, match="list-pin"):
+        source.query("SELECT count(*) AS n FROM nums")
+
+
+def test_a_board_source_is_locked_down_too(board: Any, tmp_path: Path) -> None:
+    secret = tmp_path / "secret.csv"
+    secret.write_text("a\n1\n", encoding="utf-8")
+    source = data_source(board, tables={"sales": "sales-pin"})
+
+    with pytest.raises(Exception, match="disabled"):
+        source.query(f"SELECT * FROM read_csv_auto('{secret}')")
+
+
+def test_a_genuine_query_error_is_not_masked_by_pin_loading(board: Any) -> None:
+    source = data_source(board, tables={"sales": "sales-pin"})
+
+    with pytest.raises(Exception, match="nosuchcolumn"):
+        source.query("SELECT nosuchcolumn FROM sales")

--- a/pkg-py/tests/test_data_source_board.py
+++ b/pkg-py/tests/test_data_source_board.py
@@ -143,3 +143,41 @@ def test_a_genuine_query_error_is_not_masked_by_pin_loading(board: Any) -> None:
 
     with pytest.raises(Exception, match="nosuchcolumn"):
         source.query("SELECT nosuchcolumn FROM sales")
+
+
+def test_a_pin_named_only_in_a_string_literal_is_not_loaded(
+    board: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # DuckDB echoes the failing statement in its error text, so scanning the
+    # whole message would load a pin whose label merely appears in a literal.
+    source = data_source(
+        board, tables={"sales": "sales-pin", "regions": "regions-pin"}
+    )
+    reads = record_reads(board, monkeypatch)
+
+    source.query("SELECT count(*) AS n, 'regions' AS tag FROM sales")
+
+    assert reads == ["sales-pin"]
+
+
+def test_a_table_referenced_in_another_case_still_loads(board: Any) -> None:
+    # DuckDB identifiers are case-insensitive, and its error repeats the case
+    # the query used.
+    source = data_source(board, tables={"sales": "sales-pin"})
+
+    assert source.query("SELECT count(*) AS n FROM SALES") == [{"n": 2}]
+
+
+def test_a_label_that_is_not_a_bare_identifier_still_loads(tmp_path: Path) -> None:
+    board = pins.board_folder(str(tmp_path))
+    board.pin_write(pd.DataFrame({"revenue": [1.0]}), "odd-pin", type="csv")
+    source = data_source(board, tables={"my sales": "odd-pin"})
+
+    assert source.query('SELECT count(*) AS n FROM "my sales"') == [{"n": 1}]
+
+
+def test_a_label_colliding_with_a_built_in_relation_is_rejected(board: Any) -> None:
+    # Such a label would resolve to DuckDB's own relation, so the pin would
+    # never load and the agent would silently query the wrong thing.
+    with pytest.raises(ValueError, match="duckdb_tables"):
+        data_source(board, tables={"duckdb_tables": "sales-pin"})

--- a/pkg-py/tests/test_data_source_engine.py
+++ b/pkg-py/tests/test_data_source_engine.py
@@ -1,0 +1,118 @@
+"""Data sources over a SQLAlchemy engine."""
+
+from pathlib import Path
+
+import pytest
+import sqlalchemy
+
+from commons import data_source, list_tables
+from commons._data_source import TableId, normalize_table_registry
+
+
+@pytest.fixture
+def engine(tmp_path: Path) -> sqlalchemy.Engine:
+    engine = sqlalchemy.create_engine(f"sqlite:///{tmp_path / 'db.sqlite'}")
+    with engine.begin() as connection:
+        connection.execute(
+            sqlalchemy.text("CREATE TABLE sales (id INTEGER, revenue REAL)")
+        )
+        connection.execute(
+            sqlalchemy.text("INSERT INTO sales VALUES (1, 100.0), (2, 250.0)")
+        )
+        connection.execute(sqlalchemy.text("CREATE TABLE regions (name TEXT)"))
+    return engine
+
+
+def test_a_string_becomes_an_unqualified_table_id() -> None:
+    assert normalize_table_registry(["sales"]) == {"sales": TableId(table="sales")}
+
+
+def test_a_dotted_string_is_read_as_schema_qualified() -> None:
+    registry = normalize_table_registry(["analytics.sales"])
+
+    assert registry == {"analytics.sales": TableId(table="sales", schema="analytics")}
+
+
+def test_an_explicit_table_id_bypasses_dot_splitting() -> None:
+    # A literal table name containing a dot is spelled as a TableId, which is
+    # why the dispatcher accepts them alongside strings.
+    literal = TableId(table="a.b")
+
+    assert normalize_table_registry([literal]) == {"a.b": literal}
+
+
+def test_an_empty_name_component_is_rejected() -> None:
+    with pytest.raises(ValueError, match="empty name components"):
+        normalize_table_registry(["analytics."])
+
+
+def test_duplicate_labels_are_rejected() -> None:
+    with pytest.raises(ValueError, match="duplicate labels"):
+        normalize_table_registry(["sales", "sales"])
+
+
+def test_a_bare_string_is_accepted_as_one_table() -> None:
+    assert normalize_table_registry("sales") == {"sales": TableId(table="sales")}
+
+
+def test_a_non_name_entry_is_rejected() -> None:
+    with pytest.raises(TypeError, match="table name or a TableId"):
+        normalize_table_registry([42])
+
+
+def test_an_engine_is_queried_without_copying(engine: sqlalchemy.Engine) -> None:
+    source = data_source(engine, tables=["sales"])
+
+    assert list_tables(source) == ["sales"]
+    assert source.query("SELECT count(*) AS n FROM sales") == [{"n": 2}]
+
+
+def test_leaving_tables_unset_discovers_every_table(engine: sqlalchemy.Engine) -> None:
+    source = data_source(engine)
+
+    assert sorted(list_tables(source)) == ["regions", "sales"]
+
+
+def test_default_discovery_is_not_validated(engine: sqlalchemy.Engine) -> None:
+    # Discovery returns what the backend reports, so there is nothing to check
+    # and nothing to pay a round trip for.
+    source = data_source(engine)
+
+    assert source.table_ids["sales"] == TableId(table="sales")
+
+
+def test_a_table_absent_from_the_connection_errors(engine: sqlalchemy.Engine) -> None:
+    with pytest.raises(ValueError, match="nope"):
+        data_source(engine, tables=["sales", "nope"])
+
+
+def test_the_error_names_what_is_available(engine: sqlalchemy.Engine) -> None:
+    with pytest.raises(ValueError, match="regions"):
+        data_source(engine, tables=["nope"])
+
+
+def test_the_dialect_comes_from_the_engine(engine: sqlalchemy.Engine) -> None:
+    assert data_source(engine, tables=["sales"]).dialect() == "sqlite"
+
+
+def test_the_guard_applies_to_engine_sources_too(engine: sqlalchemy.Engine) -> None:
+    source = data_source(engine, tables=["sales"])
+
+    with pytest.raises(ValueError, match="disallowed operation"):
+        source.query("DELETE FROM sales")
+    assert source.query("SELECT count(*) AS n FROM sales") == [{"n": 2}]
+
+
+def test_an_engine_and_frames_together_are_rejected(engine: sqlalchemy.Engine) -> None:
+    with pytest.raises(TypeError, match="not both"):
+        data_source(engine, sales=object())
+
+
+def test_two_positional_arguments_are_rejected(engine: sqlalchemy.Engine) -> None:
+    with pytest.raises(TypeError, match="one positional argument"):
+        data_source(engine, engine)
+
+
+def test_an_unsupported_positional_argument_is_named(engine: sqlalchemy.Engine) -> None:
+    with pytest.raises(TypeError, match="int"):
+        data_source(42)

--- a/pkg-py/tests/test_data_source_engine.py
+++ b/pkg-py/tests/test_data_source_engine.py
@@ -132,3 +132,23 @@ def test_a_probe_failure_that_is_not_absence_is_not_blamed_on_the_tables(
 
     with pytest.raises(RuntimeError, match="connection reset"):
         data_source(engine, tables=["sales"])
+
+
+def test_an_inspection_failure_does_not_mask_the_probe_error(
+    engine: sqlalchemy.Engine, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # If the connection is down, asking whether a table exists fails too. That
+    # answer is inconclusive, so the original probe error is what surfaces.
+    import commons._backends as backends
+
+    def broken_query(self: object, sql: str) -> list[dict[str, object]]:
+        raise RuntimeError("connection reset by peer")
+
+    def broken_inspector(self: object) -> object:
+        raise RuntimeError("inspection also failed")
+
+    monkeypatch.setattr(backends.EngineBackend, "query", broken_query)
+    monkeypatch.setattr(backends.EngineBackend, "inspector", broken_inspector)
+
+    with pytest.raises(RuntimeError, match="connection reset"):
+        data_source(engine, tables=["sales"])

--- a/pkg-py/tests/test_data_source_engine.py
+++ b/pkg-py/tests/test_data_source_engine.py
@@ -116,3 +116,19 @@ def test_two_positional_arguments_are_rejected(engine: sqlalchemy.Engine) -> Non
 def test_an_unsupported_positional_argument_is_named(engine: sqlalchemy.Engine) -> None:
     with pytest.raises(TypeError, match="int"):
         data_source(42)
+
+
+def test_a_probe_failure_that_is_not_absence_is_not_blamed_on_the_tables(
+    engine: sqlalchemy.Engine, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Every table exists, so a failing probe means something else is wrong and
+    # that error is more informative than a missing-table message.
+    import commons._backends as backends
+
+    def broken(self: object, sql: str) -> list[dict[str, object]]:
+        raise RuntimeError("connection reset by peer")
+
+    monkeypatch.setattr(backends.EngineBackend, "query", broken)
+
+    with pytest.raises(RuntimeError, match="connection reset"):
+        data_source(engine, tables=["sales"])

--- a/pkg-py/uv.lock
+++ b/pkg-py/uv.lock
@@ -35,6 +35,15 @@ wheels = [
 ]
 
 [[package]]
+name = "appdirs"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41", size = 13470, upload-time = "2020-05-11T07:59:51.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128", size = 9566, upload-time = "2020-05-11T07:59:49.499Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -169,6 +178,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -224,6 +242,7 @@ tracing = [
 [package.dev-dependencies]
 dev = [
     { name = "pandas" },
+    { name = "pins" },
     { name = "polars" },
     { name = "pyrefly" },
     { name = "pytest" },
@@ -251,11 +270,21 @@ provides-extras = ["tracing"]
 [package.metadata.requires-dev]
 dev = [
     { name = "pandas", specifier = ">=2" },
+    { name = "pins", specifier = ">=0.9" },
     { name = "polars", specifier = ">=1" },
     { name = "pyrefly" },
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
+]
+
+[[package]]
+name = "databackend"
+version = "0.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/fb/0f8c739f42008957e4ba334cbf3d0b512946ed6d120e912d3f63f9f1d550/databackend-0.0.3.tar.gz", hash = "sha256:3f047f21b5d92dcfdc85545c679d024b6595bb10a72bd61ef514d8f5857e22f9", size = 12407, upload-time = "2024-08-21T21:09:42.425Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/84/582e1daf3f2eb296573c11b774abf10223e9858d4c5c5c936180b643a720/databackend-0.0.3-py3-none-any.whl", hash = "sha256:2ded97ff85a0ca272d752fbc0513f70512d2c23325e3c72de15613df7e959ef5", size = 7001, upload-time = "2024-08-21T21:09:41.137Z" },
 ]
 
 [[package]]
@@ -302,6 +331,15 @@ version = "25.12.19"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2025.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/02/0835e6ab9cfc03916fe3f78c0956cfcdb6ff2669ffa6651065d5ebf7fc98/fsspec-2025.7.0.tar.gz", hash = "sha256:786120687ffa54b8283d942929540d8bc5ccfa820deb555a2b5d0ed2b737bf58", size = 304432, upload-time = "2025-07-15T16:05:21.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/e0/014d5d9d7a4564cf1c40b5039bc882db69fd881111e03ab3657ac0b218e2/fsspec-2025.7.0-py3-none-any.whl", hash = "sha256:8b012e39f63c7d5f10474de957f3ab793b47b45ae7d39f2fb735f8bbe25c0e21", size = 199597, upload-time = "2025-07-15T16:05:19.529Z" },
 ]
 
 [[package]]
@@ -425,12 +463,42 @@ wheels = [
 ]
 
 [[package]]
+name = "humanize"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/ea/13a1ef3c12d12662905801495283530251918b70d62d368f1d2e0272c70d/humanize-4.16.0.tar.gz", hash = "sha256:7dc2244a2f84a4bfb1d36c37bac80cd78e35cdc5c119206d87b018e1445f3a3f", size = 89515, upload-time = "2026-06-30T16:17:29.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/aa/0b7365d30fed43e7a3449aba1fe20a0a7174d9cf13e282af4e69ac825441/humanize-4.16.0-py3-none-any.whl", hash = "sha256:353eb2f34c09d098b2880eee8bef21832eae6d174f48c5762fff7e5fcb74d01d", size = 137209, upload-time = "2026-06-30T16:17:28.36Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.19"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "9.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/7e/1e7e8dc30634b93ebb3d58a3dea569ad146e656218d3960ab04f62047b29/importlib_metadata-9.0.1.tar.gz", hash = "sha256:ab830580bc0ef3db61ce8fae716389e5462b67e033018bab6d8f80ef17172f99", size = 59124, upload-time = "2026-08-28T15:30:34.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/55/ecca97ae19075f1fac62def77731e7f535e6c1fb8f92ff08160c5e6dade8/importlib_metadata-9.0.1-py3-none-any.whl", hash = "sha256:bba5600596a7e21f3eef53281cf28d6a5195634d2f2b78ff9501a3272c6eaab0", size = 27920, upload-time = "2026-08-28T15:30:33.433Z" },
+]
+
+[[package]]
+name = "importlib-resources"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708", size = 44985, upload-time = "2026-04-12T16:36:09.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1", size = 37232, upload-time = "2026-04-12T16:36:08.219Z" },
 ]
 
 [[package]]
@@ -510,6 +578,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
     { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
     { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
+]
+
+[[package]]
+name = "joblib"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/1d/537ab090f302b838943a1b56497dd53059b9a9b46a074936470173a2e207/joblib-1.6.0.tar.gz", hash = "sha256:2ccc96785b12046c08fd6d55839c12857831b54a3c1673ffadd2f04bfc4eda03", size = 327903, upload-time = "2026-08-31T09:39:04.122Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/53/84099323c2ec4be98d935f63c033ac4151ee83836ca1050ede3b3aadf155/joblib-1.6.0-py3-none-any.whl", hash = "sha256:3dbbf9f6e4b592a2357b854608e980fe6390d131d7a82f011a377ef2ebef7aba", size = 306115, upload-time = "2026-08-31T09:39:02.298Z" },
 ]
 
 [[package]]
@@ -980,6 +1060,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/8d/36dade89b49e4f9d5cbdbe863772581f98c0c6d78fc39ad4c557f6f2e17e/pandas-3.0.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:db172144bb56422bd157812f3b021eacc255451470b31e2c633c349490a1cfee", size = 11989004, upload-time = "2026-07-22T22:18:42.208Z" },
     { url = "https://files.pythonhosted.org/packages/9c/ba/18c4ec8a746e177da05a9e7a7963781d8ea195780724f854601b6ebd6b78/pandas-3.0.5-cp313-cp313-win_amd64.whl", hash = "sha256:0d298e951f23016ce4699951d044ae6418dbc91bf68cefca0f77666fcbb4e5c6", size = 9826896, upload-time = "2026-07-22T22:18:44.539Z" },
     { url = "https://files.pythonhosted.org/packages/de/ec/28a57266b753799a87b8bc79e7887ac6fd981b8c6d2978a0b7e7b6bd708c/pandas-3.0.5-cp313-cp313-win_arm64.whl", hash = "sha256:66266d3442a5e8b3c90274c2b8b230bee42dd1c286bc822cc2f9f2c7e12b883e", size = 9094790, upload-time = "2026-07-22T22:18:47.468Z" },
+]
+
+[[package]]
+name = "pins"
+version = "0.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "appdirs" },
+    { name = "databackend" },
+    { name = "fsspec" },
+    { name = "humanize" },
+    { name = "importlib-metadata" },
+    { name = "importlib-resources" },
+    { name = "jinja2" },
+    { name = "joblib" },
+    { name = "pandas" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/2a/a84eff130a088fd2166927c3d5508f584b9aa99fbfaaebbdb04d902e0c60/pins-0.9.1.tar.gz", hash = "sha256:d163f0342cf57f5fa40aefb700914da4a7e6554c52dc760903eaefaeace13311", size = 119829, upload-time = "2025-10-03T17:04:52.523Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/61/eea269bf29eb2123c8dba9cd8de46887b13f182d5acc3b24c7b88357d6ac/pins-0.9.1-py2.py3-none-any.whl", hash = "sha256:fa0c7294554470496f362aeee682f02c1e17d351aa0a3f09533b2e0c5e9c3738", size = 122063, upload-time = "2025-10-03T17:04:51.379Z" },
 ]
 
 [[package]]
@@ -1493,4 +1597,96 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "xxhash"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/a5/1386f35da1475fcaeef42581deae73417c6d2a6a0b2d2e8914de18844dcd/xxhash-4.0.1.tar.gz", hash = "sha256:d55bf4ef10eb09b8b6866790e083d26d087d84caa3cc0946ba87c3ca7ecaf7b7", size = 101513, upload-time = "2026-08-17T08:24:08.557Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/58/bc81e25cceab76ce4b400441e3a43312bf3887fedbb2e5f80cc5a7dd7f75/xxhash-4.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8b4477edc03091f51f5309406d230851c23cf4822029e3bf40b8df53093fff1c", size = 38473, upload-time = "2026-08-17T08:20:34.303Z" },
+    { url = "https://files.pythonhosted.org/packages/64/8d/d95e810c9a2930906f1fbd0e38f77554abb8e042a190aa9cbb24da39e9a2/xxhash-4.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:04f9a24de11a6647666d5302fd73d6a5224ce50ddc965fb0bb44cee736e6bd7c", size = 36228, upload-time = "2026-08-17T08:20:36.641Z" },
+    { url = "https://files.pythonhosted.org/packages/72/be/ebcded2a32ba664a17a1737a91b6baa298bcda6942acdad81af81660b74c/xxhash-4.0.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6a8c5ce76b94ba49f3be8a8f2611abc6564210702c72ac9e237ca2bebfd17794", size = 253292, upload-time = "2026-08-17T08:21:27.206Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/72d31d787d988d1130253bc34d249c553f02c9387e7dda789b6d5aa7963b/xxhash-4.0.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4c8842fb19d78b5e8c2a52baf4c8357658cc56c62bc822b86ce0f942f28e286", size = 276545, upload-time = "2026-08-17T08:20:26.726Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ae/048f3b1f283a340bef3697fe5a9d4f10de1696a379af9af6b2352c24d82a/xxhash-4.0.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a43418e1a90b4809a9caf64aeb8b0696e3e1f300a323acc1e6ee2f93ae319fcf", size = 296295, upload-time = "2026-08-17T08:20:15.759Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/43/e9a593c81445c8e8d669402edb8264144624e7e5e2406df7d33e3c164d90/xxhash-4.0.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b3662719007e059abde7eddacf8517142ba076ddc7b30c807260e57d28c3c191", size = 279966, upload-time = "2026-08-17T08:21:22.217Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/4c/29da2b166955a300521c0abd498ad4481916c3743949b106192b781f58fc/xxhash-4.0.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06d7fbd609503c3be5e65cdb6bb2f040d6a98574404e2e1d5c60815c97fff4aa", size = 509850, upload-time = "2026-08-17T08:20:32.731Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ff/e39e1900179ce7f0f23e7000d9fc672471a8d05b6b2dc657cb496c8975d0/xxhash-4.0.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:101aa300de6ceef3d9c77569706330d8921fc45dd82bceed2084f1e9f2557a24", size = 261005, upload-time = "2026-08-17T08:20:40.735Z" },
+    { url = "https://files.pythonhosted.org/packages/89/79/76ee26720d13219458f4b2ec0b22f539fe2bcb1f83dc22a24be4cda4e285/xxhash-4.0.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e4296fcc790876a8b0f297edc83d3b088457b774d8f67b4636807f8a2ec69a79", size = 339620, upload-time = "2026-08-17T08:20:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/c7/56b53252d64ecb2f3a0d283b41033561b1bec9c268095150153b694c2e52/xxhash-4.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:57d7fa8f23908d173001c21a9e82bfc6ad997d1b6c270fb121812b7ed158891c", size = 272558, upload-time = "2026-08-17T08:21:33.883Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/76/83101a2f2ad3eb6b4b5d571e0aa394a576e3e23121707d507d80197ac385/xxhash-4.0.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:85e402dab0f9acd3604539747c6fcc57dc188a18af6ab07eb8189351cd32466c", size = 300417, upload-time = "2026-08-17T08:20:36.183Z" },
+    { url = "https://files.pythonhosted.org/packages/34/5d/5be1166ec4fc4bc896e508dc51189a2dad200b373269a430e214fb152693/xxhash-4.0.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:fb59a0dd61fb2ad481c03fda399d78ce57dab6bb62c2c8fdb446a7ba4754b89a", size = 259286, upload-time = "2026-08-17T08:20:21.51Z" },
+    { url = "https://files.pythonhosted.org/packages/77/6c/42f6201f13278787c58a6b3a1cd597b47e8665a7d4f68a3440d001c05a75/xxhash-4.0.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:0b20a06454b34f1531fc677c54efe2ecdec691ef9224f7fa919bf2c1363f7ff1", size = 278230, upload-time = "2026-08-17T08:21:47.62Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/37/3cb7f149a5a469c628604c33bec6d79764698b315700a4bbf1c6fb15622b/xxhash-4.0.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:f7db035447a0ac8959aa230c5d36545ecf9f547413eb1711c0ca6f0ba1418925", size = 329846, upload-time = "2026-08-17T08:35:10.922Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ee/934eb1e11f4d0e95f3828825f8da4b6d59e338235d63edc3d929769262d2/xxhash-4.0.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:34ed93e20bfd98d722b902121643791eeb4b1641871e2dc63d0d4c2d93f187df", size = 477285, upload-time = "2026-08-17T08:20:46.297Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/0b/77835dcd7aec970db74f5724c94207ada83b3e2f5e1474ab44b9c8fe5ea5/xxhash-4.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f6247f5e23ee94f2557ac9dab738a336f607c6ff476fcf66ca70c3aef5eee15a", size = 257552, upload-time = "2026-08-17T08:20:58.211Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6c/a3ce7a1a9c4ec9ad8babba591a996a71c474ff9630c5fb04c8c9d8b995ca/xxhash-4.0.1-cp311-cp311-win32.whl", hash = "sha256:348c8f288dc961d6bbd1985c8152a3ed7a85c95df00e82320f0c5215d922a399", size = 34630, upload-time = "2026-08-17T08:21:53.323Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/58/60d2170e8cda0891aab25dcaa74797b420c3c6cde8a5bc8372f17b30c0cf/xxhash-4.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:ac0f291ab6485bd71f33941f9b92771318332a05d505460b41e893a549caadc0", size = 36992, upload-time = "2026-08-17T08:20:41.973Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/de/b229a39f9bbbe30cbcf9afaaa8993cb65286715c90a3b058c3769196ae02/xxhash-4.0.1-cp311-cp311-win_arm64.whl", hash = "sha256:72f34834518157a75e7090f328ee7a16c70c804cfc7c694fa069cc888e9fc03e", size = 33289, upload-time = "2026-08-17T08:20:32.176Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6c/dc7cffeadd06336cd934947187cd38abb263103bbc552ca0f55fe4ff595a/xxhash-4.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1ee523f51718e41753f04f7102bb4dc55a18d2ea5cbaceef8ec7ca08571bd428", size = 38444, upload-time = "2026-08-17T08:21:54.332Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c9/cf736f6db8c3273af18925061572db0d4357818a9ce425f4b5fb0021918e/xxhash-4.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:515a822c73abbf6a0b7c70976d9662be342835c9d78b8dc7c023411f39c35dbc", size = 36195, upload-time = "2026-08-17T08:35:13.004Z" },
+    { url = "https://files.pythonhosted.org/packages/da/a2/ca1929354b6851529d0148f7f335b5e2b0281f83bab3e19f0896dc579796/xxhash-4.0.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f5d031f35962e5483a613214e61f09fe24ab523062c3646d592dc16c4a217451", size = 253113, upload-time = "2026-08-17T08:20:52.152Z" },
+    { url = "https://files.pythonhosted.org/packages/de/bb/542005206af59518bc8d78a210f1e0172217bc53beb32f64a5b632e72b6b/xxhash-4.0.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da0264844a09b538c894e5eff25313d941deb4dedec2131b98418a71a3c9944e", size = 276525, upload-time = "2026-08-17T08:21:01.886Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/df/607cff25dcb0f1d35c3b04493f6ad8471edb03fd4eacbdcc5ceddef1f3e9/xxhash-4.0.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:1642907941ee4b75aacc3db688af52ea02ca2305ab22af7ee686ed726b332684", size = 297703, upload-time = "2026-08-17T08:21:57.958Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ba/9d2275eea0b9d9c6b02921be23f7588356c60df95c763b25f0e045894d43/xxhash-4.0.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4af350bc3f329970c0e3a59af84a8a30998bf8a9167eb50cd48e59baaa1d7bec", size = 280252, upload-time = "2026-08-17T08:20:47.299Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/aa/2299d9f6369e550aef2abb64945e39daa34412725aa46a20d99b74d76f67/xxhash-4.0.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8ba782ca3bf1e81492611152b9a0d5264971339e95e34d69de0ac2c926be496d", size = 511041, upload-time = "2026-08-17T08:20:36.771Z" },
+    { url = "https://files.pythonhosted.org/packages/83/97/31bd8b8279e6935a0719f6910ced15e9d5a2cd554b253f6027ce1b5a1c2c/xxhash-4.0.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:237b8f63a2a0fcfb1ffc06e21dad23add44e6d354b2b014364a1d41e419a4dee", size = 261812, upload-time = "2026-08-17T08:22:00.469Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c1/d180a2da23c105d8e0b02d54f9f5841013fc81c233010ec781e31f1aee4c/xxhash-4.0.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:81507a68ba84c55241fb61cce1469f473a5da4205fc8ef6f698e5948eea8dd88", size = 339878, upload-time = "2026-08-17T08:35:17.626Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3d/f584cd3172fe934f0f5a0a3917d0d7ce781f74d794fd43bb72be71c3ef6f/xxhash-4.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5f1ea31d61bcd2cd2f3ec4ca80a64187bbd7948f490b63cf0dcbc6e717b4c1e9", size = 272871, upload-time = "2026-08-17T08:20:56.067Z" },
+    { url = "https://files.pythonhosted.org/packages/34/50/2c7956b2b551682e00b9aebce9ceb0a991a131d65f9850c09f5f9760be2e/xxhash-4.0.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:06713a5aaf1d0905c5579416c020c02e42b3ceb931e86c7d3b7fb85403dee3f3", size = 301440, upload-time = "2026-08-17T08:21:35.911Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a2/0739f6482184a8026f4b022718f5f815d352059312e80696825433f0a8e7/xxhash-4.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e8cda075b10bb3917b002c74a04f9e02b7d13b5bf732571404d51c52b11c7329", size = 260157, upload-time = "2026-08-17T08:22:01.416Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/25/b31a7bcf1d7d116842812e54f9b944843b4236ea4fa85634e8259f342212/xxhash-4.0.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c10b9206753b64aa791b35b201485477525b26fdec5bf86e8364c388a03e2592", size = 278233, upload-time = "2026-08-17T08:21:15.674Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e8/5293bae090fc6119dbc5fcf5c4cc0e1536394b52d73b7904d033836c73db/xxhash-4.0.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:f3e1a44af01b6692de0ec6caba5f0bf93ceb36896e02b7fc00952c6ea7ef39e1", size = 330270, upload-time = "2026-08-17T08:20:51.128Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9e/e2ab12d40921f3f34c9317637d65e011aeababf8288356ea8d527de2c1d0/xxhash-4.0.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:c6fc415b5568bd9accc7187f1729a99707330c0a67a8b9f93c1149ed573ed75d", size = 478555, upload-time = "2026-08-17T08:22:04.183Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/32/c6148d39a49efa95f39b4cf0d41ef35a487f3b30f6fb1fc8fe8d8eab577e/xxhash-4.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:96d8de55029d42251945531f6aa7590c32b48163c66a43bf29d8657d7446a377", size = 258174, upload-time = "2026-08-17T08:35:21.18Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fb/0b04b68d6c5bc71c7a2c344f1287327b67e607f28fbcfd937697caca64b6/xxhash-4.0.1-cp312-cp312-pyemscripten_2024_0_wasm32.whl", hash = "sha256:0163b5d259de23ae9e07b7eabf435ce4704f6f205589a2b154e6af4be985ce1b", size = 20767, upload-time = "2026-08-17T08:21:00.806Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/be/476092aba34d1fcd313e1613a3bb3bc692f253d167b54bc90049043b5034/xxhash-4.0.1-cp312-cp312-win32.whl", hash = "sha256:1216f7ba5683f17a89eb7dcb4bc50a0b743dfe1902278d7b3d0786f538118433", size = 34669, upload-time = "2026-08-17T08:21:49.486Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/02/f9413d94fae43cec6d1a74c4f12156c6f4a7f5fd50e1d34defebdee3dec9/xxhash-4.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c2d525a3afabcd8e3549d85fc7e111fde6bc302d06a1893fe73adb79823415e", size = 37073, upload-time = "2026-08-17T08:22:04.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/83/6fe93c1b95acf962bc61a246df09dc2dcce895ccfc1080c9f48d0b652b92/xxhash-4.0.1-cp312-cp312-win_arm64.whl", hash = "sha256:86b2b12bec60c678ed8f5cca0258ad93a8928ebddb6ca7732f0875afe1451d1a", size = 33299, upload-time = "2026-08-17T08:35:12.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/dd/c707286b527722f776e1fb81dd202c45623355ba1a2972337a2a26075b2b/xxhash-4.0.1-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:8c9fe122444e129881afd1d4d1c7ac0d3ce2d91b68c2b40173b6025ff1c31f9a", size = 43639, upload-time = "2026-08-17T08:20:54.945Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/3b/bb71639a0f95635f61936a6f2653599c4261b645ddddd8d00f9dfe3613e2/xxhash-4.0.1-cp313-cp313-android_24_x86_64.whl", hash = "sha256:1f3346c5c287ac3c7f38b20380f55e8768230e7252af59fabcf3b87ab21e4256", size = 40657, upload-time = "2026-08-17T08:22:12.616Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/91/76f3f5385faa9886a36f21fcc603f40b4c0c40ce622382f133160c48b4d9/xxhash-4.0.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:4e5141543c7f7fe3087500bbb4ac2845cb528a980aa91f8f1e661e2292ff4a5d", size = 34708, upload-time = "2026-08-17T08:35:24.614Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/4a/f48f0e3e1b1ab072979fff2a5be899234e28090883e8b519d0b10215d708/xxhash-4.0.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f09ee747e2a5f876cc5ad56947734811828335e13b403dd8ea1e06d77a9dd48d", size = 35650, upload-time = "2026-08-17T08:21:09.337Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/53/b73d7472b196101ad1f57ed0674af3af803ac3e9ec2feadd650a7b262562/xxhash-4.0.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:acf52474b2494ef66dc7e0fb6d5e2b50c18313039ad4d275fbf9f9907c804bc5", size = 37958, upload-time = "2026-08-17T08:22:10.616Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/f2/024946ad8fa532074af4e4380179da54b7ec9facc8bd0b279ec0fac4e63a/xxhash-4.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1b3cccf75eeb5b01639b2feadb042a8e07889293b7ca72fa2985e7dcb64763cf", size = 38032, upload-time = "2026-08-17T08:22:09.535Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e0/934af8d99bb5885711006bec30a691f728edd513d2c40f053f887d8e7577/xxhash-4.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cd878d32f5c6cbce9783f8d6897561fb772211edba9dde49d85672b88ed45276", size = 35895, upload-time = "2026-08-17T08:35:16.53Z" },
+    { url = "https://files.pythonhosted.org/packages/20/5f/a8011f6a1558f7ca66d9077bb4f192b1871afcea62fbd5733605d2015755/xxhash-4.0.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:41e579025a6e13a99e6d71e39c9cfc621a0dcdbbf19106325e145fa858f2d794", size = 259464, upload-time = "2026-08-17T08:21:06.72Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/89/9665a44397547e7a3d58c0942425a976d58dcfd4b538f33220a312bf6912/xxhash-4.0.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74379a577a9f3b6afbdedf1b90e5c7764467051977f18a326d7d607336d743bd", size = 283949, upload-time = "2026-08-17T08:22:17.003Z" },
+    { url = "https://files.pythonhosted.org/packages/34/2d/78774141266457468f29f3f5803092df4db87d8148ba74e4debd041649db/xxhash-4.0.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:acb31ecdd1a97fab5cd39a84ee9f515e727d319f796fec48703b8339b9998360", size = 303898, upload-time = "2026-08-17T08:35:27.951Z" },
+    { url = "https://files.pythonhosted.org/packages/59/48/d78d22de576b42528bff87c14207de50de4f0b888221a50ff7c9d675d670/xxhash-4.0.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5b7875ac1a2edcb691f27642b8b94b904baa6bcecb7d79c72df2228ba8cb5c51", size = 287241, upload-time = "2026-08-17T08:21:13.042Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/de/7a1755a59c59fd46176f293bbdd99e399a6537ba9537fc723aa4d1bf6e27/xxhash-4.0.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4751f1d7eecae6b2d2a773630f1a7248f125c9a92a456694d03c15bceffc9d68", size = 519856, upload-time = "2026-08-17T08:22:15.35Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/fb/76580c08e916507859b0f335393cb5fdc59452c4402edbc6bcca6e47e7df/xxhash-4.0.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9a51b061d54cda8b83e62c44458bfbf0dabbef9b975dd9649952ba5076b9f349", size = 268572, upload-time = "2026-08-17T08:22:14.533Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/1abde3e07b8f2077a38b4fbfaf764115008bfe0ff03bc7756a52c9fd0607/xxhash-4.0.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:74a164e8b63f1e9cf35c9a7809d082b033d1a00e7375d5d814415436e7867e57", size = 344967, upload-time = "2026-08-17T08:35:23.569Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/15/80b6ddf0732eef48a8b5fe717398274794392bd6dbe82af38d189d214772/xxhash-4.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f5e5c6df4b703afcbe9352d238a51efd97c3b91fdc3a2052e40fdacb1e7505f", size = 279956, upload-time = "2026-08-17T08:21:24.97Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e0/11cbc43c205bf81fad50d69c7319cd1b1ccc01a66cd4fb8766357126c43d/xxhash-4.0.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:d54b8ae068af532c8cdf56abb9e09a60fbe7b10792444c9c27987bb6d3b450fa", size = 307583, upload-time = "2026-08-17T08:22:22.541Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/11/cf0bc07feb2791045b6ac075d4bf64f1a5beedef2f46ae70d7104d63a19f/xxhash-4.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1749f0688020209fe0d357ce1e1cd9ec9c6161ed0405ea949d24581c4c43fa91", size = 265848, upload-time = "2026-08-17T08:35:31.298Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/c4/7ada4bea2a2795073dfc42d96842930efbe7a0c1857ef4b522e4e90e5d83/xxhash-4.0.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:94ac8a6b8c47951173f0b67bf862bcb971bf24e493b9fbbdb0e010cbbc7d9f54", size = 284409, upload-time = "2026-08-17T08:21:23.156Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f4/d8ce83dd6b99ccfbdadaf2db968ae40334d2e5f73a0297e593b9ddb3df39/xxhash-4.0.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a33de7633c948ab2dc144af370a66e7e7af29b425dcd0f7e4f59689fb9391b53", size = 335921, upload-time = "2026-08-17T08:22:21.802Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9f/f47d8724bd8bc45b395b06b7cacea2dae0d00031af1b707184a091161df6/xxhash-4.0.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:247ece770647c0aef080561fa996f9774b4dadce2d0c42eeb98229db7dcf820d", size = 487023, upload-time = "2026-08-17T08:22:19.729Z" },
+    { url = "https://files.pythonhosted.org/packages/57/54/2d87098f3371cc1e42dd04d2285ad56bca4c56667bc501bff02d2b9fd6b5/xxhash-4.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a4553d36cc0b7fce1f35ba8a94dfd775aa3ed12f5eab2dc3b46ac75a0706b0bb", size = 264333, upload-time = "2026-08-17T08:35:27.001Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b8/93795ca5898ec7d7d0455283ad261c0fc76b4f0c0a69e86233bd7badb0bd/xxhash-4.0.1-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:87aa309a93bd5ec13f14309a305ff4e9bf74c5363fc46c264c0a22edfd5b0670", size = 20581, upload-time = "2026-08-17T08:21:39.207Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/96/926f7335a0a1647952c00421e8da877f658094f61336306c7cadc335c94d/xxhash-4.0.1-cp313-cp313-win32.whl", hash = "sha256:cba763d84b06bda2c38d5185dee76f1b9dfdc0789e96e476d9e10005526d0788", size = 34449, upload-time = "2026-08-17T08:22:29.362Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/61/8a5aeb811de093bab3434e77eff0e9461624a1a56a6a93d315d080aab2aa/xxhash-4.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:97b94fb29abf21f5f0bde15f7dbdd3a4aa2dc59f37026adc7b4bee8563b84375", size = 36520, upload-time = "2026-08-17T08:35:34.852Z" },
+    { url = "https://files.pythonhosted.org/packages/04/14/97f3c74000ca36955e9cb86f6d270dcd5848b5c65afa623453f5cf2d83d6/xxhash-4.0.1-cp313-cp313-win_arm64.whl", hash = "sha256:08ed8da18cd4fd0a6a5d6a444852d8fbd0e565388a74a4937085451b5f1a312a", size = 33428, upload-time = "2026-08-17T08:21:31.713Z" },
+    { url = "https://files.pythonhosted.org/packages/86/79/9127ff42a887a348dc4ce3211cf1a962836887adee6f57078132bfba78b4/xxhash-4.0.1-graalpy312-graalpy250_312_native-macosx_10_13_x86_64.whl", hash = "sha256:ff48915bf1871a1f19f74c11834c6329443d306cedc0c05fe7fe617810422a80", size = 31836, upload-time = "2026-08-17T08:36:28.261Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/e6/f238693bfdd642adb59c99683964d46d9947fe721ff44d3bd850ae675407/xxhash-4.0.1-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:4a76345f5aceb4ec404918edf9c7f2b5507db864dc0d7455982009ac0890b57b", size = 34453, upload-time = "2026-08-17T08:23:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/40/4b/796ace33cdfb75c91ba6d11615c3bd436355b9f3103e05865bbee9abce57/xxhash-4.0.1-graalpy312-graalpy250_312_native-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:31d86f9e81f3e84e00131ac7c54caf5119ae4ddd82c09c31cff597c813ce1ee2", size = 38488, upload-time = "2026-08-17T08:23:59.901Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/23/2d549e5d5d7759eaf9ac2d2d2ab81ff60f1bb2b52cdaae8e5ec5c6524354/xxhash-4.0.1-graalpy312-graalpy250_312_native-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:deca2a30d983d240b8375ec2ee0a4288e72042827fc61df2f7671f8467e4cb2f", size = 38206, upload-time = "2026-08-17T08:36:32.193Z" },
+    { url = "https://files.pythonhosted.org/packages/79/98/1ee576b27f78e6107ee4ea8ac03e8a52888dff256e57d560f8282c195563/xxhash-4.0.1-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:7c343ee174d417a44d0c3355602c0cbbfa52a04d1bbbf1723378c7d2c8f60626", size = 37127, upload-time = "2026-08-17T08:23:42.705Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/4f/e0648288a17d0d1084ca4f7bef206097831988fc86af74aa1dff8f1fbd68/xxhash-4.0.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:554f87034635bcec47c5d72447bf3db7e02da1bf493a0ada010db28a76f891c6", size = 36333, upload-time = "2026-08-17T08:23:52.913Z" },
+    { url = "https://files.pythonhosted.org/packages/22/15/34b7f72e9b5a8bfd7e6178de9e1e342bc3de9f07111a5ae26c00506d9edf/xxhash-4.0.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:3c2445edafc300cc40feb6a25a8356a971c30cd0bf47b5349c2ad74c508343b1", size = 33519, upload-time = "2026-08-17T08:36:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/06/4b/e0af324ccf701bf84a7a060bef11c915d45d9e3c5b9caf5b94d62ecb040b/xxhash-4.0.1-pp311-pypy311_pp73-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bdd16718b63aa3ebd68aabb79021a40e47c81374852d41a306b9453141bbcbee", size = 47995, upload-time = "2026-08-17T08:24:14.335Z" },
+    { url = "https://files.pythonhosted.org/packages/59/46/cc7130e6ca6b41ab72eb6a03177b933c7c74145545c99a8610ecc208c449/xxhash-4.0.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b99ebaf9e816ac5069423b1367ee7e8078fbcebcf62545506bb0608d2f4f468", size = 42725, upload-time = "2026-08-17T08:36:34.144Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/24/4f26ff9a7dd0998f6d1036bdddef7ce3e78972a74f7fffa7967e7bc3b7e4/xxhash-4.0.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f484ed57bb3e4142f9d6439568658c38be5f94b702ba00a1ff32c69783b6c66d", size = 39532, upload-time = "2026-08-17T08:23:57.556Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f3/1ac078fc8fceadcf066469acecacb35d2821cbfaf7d6fc5ac2107c7a314d/xxhash-4.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:fac4832b638000106207bc44e44b9616a6a416aaee56c62b01d61f3705e49f58", size = 37252, upload-time = "2026-08-17T08:24:06.652Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
Completes `data_source()` with its two remaining forms, over a SQLAlchemy engine and over a pins board. Closes the data-source issue for M2.

## Engine sources

`from_engine()` queries a caller's database directly and copies nothing. With `tables` unset the backend's own listing is taken as given, since it reports what exists. Named tables are checked, because a typo there should fail construction rather than a conversation, and the check is one `UNION ALL` probe rather than a round trip per table, which dominates startup against a remote warehouse.

Absence is asked of the backend through SQLAlchemy inspection rather than inferred from a failed query, so a permissions or connectivity failure surfaces as itself instead of being reported as a missing table. If inspection also fails the answer is inconclusive, and the original probe error propagates.

## Board sources

Pin names are validated in one listing call at construction. Reads are deferred: a table reflects its pin's value at first use and is not refreshed afterwards. A pin leaves the pending set only after its write succeeds, so a network failure surfaces to the caller and is retried on the next touch instead of caching an empty table.

Loading is driven off DuckDB's own catalog error rather than by parsing SQL, so a genuine error such as a bad column surfaces unchanged and each pass either loads a table or stops.

## Specific identifier handling

Handling identifiers surfaced a number of issues during implementation that the agent struggled with, so calling them out here for posterity. Matching a pending label against an error message is fiddly, and five defects came out of review, each reproduced against a live board before fixing:

- **Scanning the message for labels was too broad.** DuckDB echoes the failing statement, so a label appearing only in a string literal triggered a read. Matching is anchored to the head of the message now.
- **Parsing the label out of the phrase needed a delimiter that labels may contain.** A pending `sales does not exist archive` was read as `sales`, so its pin never loaded. Each label is tested against the complete phrase instead, which removes the ambiguity and drops the regex.
- **That in turn let one label match another's error**, since `sales` is a prefix of the longer label up to the trailer. DuckDB names one relation per error, so the longest match is the one it named.
- **Case collisions were unhandled.** DuckDB folds identifiers even when quoted, so `sales` and `SALES` are one table. Board labels differing only by case selected each other, and the frames path failed with a raw DuckDB error rather than a named one. Both paths reject the collision at construction.
- **Folding is ASCII-only, matching DuckDB rather than Python.** `casefold()` maps `ß` to `ss` and merged `straße` with `STRASSE`, which DuckDB keeps apart, as it does `Ä` and `ä`.

`tables` is also no longer an explicit parameter. As one it reserved a frame name, so `data_source(sales=df, tables=df2)` silently dropped `df2`. It is read out of the keywords only when a positional source was supplied.

## Deliberate divergence from `pkg-r`

`pkg-r` has the equivalent built-in-relation check, but no case-collision check, and its pending-table matching searches the whole error unanchored with locale-aware case folding. Treating that as implementation detail rather than aligning the two or pinning it in `tests/shared/`: both differences need a contrived input, and both fail in the safe direction, with Python refusing at construction where R raises a raw DuckDB error later.

## Verification

246 tests, ruff and pyrefly clean. `pins` is a dev-only dependency, since a caller passing a board already has it.