### PR TITLE
Pin the measure schema block as a shared fixture, and fix the R array bug it exposes

### DIFF
--- a/pkg-py/src/commons/_measures.py
+++ b/pkg-py/src/commons/_measures.py
@@ -282,7 +282,8 @@ def measure_schema_text(
     if details:
         details = f"\n\n{details}"
 
-    return f"### {heading or measure.name}\n{measure.description}{details}"
+    resolved_heading = measure.name if heading is None else heading
+    return f"### {resolved_heading}\n{measure.description}{details}"
 
 
 def _argument_detail(prop: dict[str, Any]) -> str:

--- a/pkg-py/src/commons/_measures.py
+++ b/pkg-py/src/commons/_measures.py
@@ -248,6 +248,60 @@ def measure(
     return decorate
 
 
+def measure_schema_text(
+    measure: Measure,
+    source_names: Sequence[str] = (),
+    heading: str | None = None,
+) -> str:
+    """Render the block search_pool shows the model for one measure.
+
+    The exact text is a cross-language contract pinned by
+    ``tests/shared/measure-schema.json``; change that fixture, not just this
+    function.
+    """
+    schema = measure.params.model_json_schema()
+    properties: dict[str, Any] = schema.get("properties", {})
+    required = set(schema.get("required", ()))
+
+    details = ""
+    # Naming the source a measure queries points the SQL fallback at the right
+    # one. `source_names` is empty for single-source agents, so the line never
+    # appears there.
+    named = [name for name in measure.injected if name in set(source_names)]
+    if named:
+        details += f"sources: {', '.join(named)}\n"
+    if properties:
+        lines = [
+            f"  - {name} ({_argument_detail(prop)}, "
+            f"{'required' if name in required else 'optional'}) "
+            f"{prop.get('description', '')}"
+            for name, prop in properties.items()
+        ]
+        details += "arguments:\n" + "\n".join(lines)
+    details = details.removesuffix("\n")
+    if details:
+        details = f"\n\n{details}"
+
+    return f"### {heading or measure.name}\n{measure.description}{details}"
+
+
+def _argument_detail(prop: dict[str, Any]) -> str:
+    if "enum" in prop:
+        return f"one of {{{', '.join(str(value) for value in prop['enum'])}}}"
+    if prop.get("type") == "array":
+        return f"array of {{{_items_label(prop.get('items', {}))}}}"
+    return str(prop.get("type", "string"))
+
+
+def _items_label(items: dict[str, Any]) -> str:
+    # An array's items can be an enum, whose vocabulary is worth listing, or a
+    # basic type, which is named. Not `_argument_detail`: that would nest the
+    # enum branch's "one of" inside "array of".
+    if "enum" in items:
+        return ", ".join(str(value) for value in items["enum"])
+    return str(items.get("type", "string"))
+
+
 def as_measure(obj: Any) -> Measure | None:
     """Recognize a measure, whether decorated function or bare record."""
     if isinstance(obj, Measure):

--- a/pkg-py/src/commons/_measures.py
+++ b/pkg-py/src/commons/_measures.py
@@ -288,7 +288,7 @@ def measure_schema_text(
 
 
 def _argument_detail(prop: dict[str, Any], defs: dict[str, Any]) -> str:
-    resolved = _resolve_ref(prop, defs)
+    resolved = _resolve_node(prop, defs)
     if "enum" in resolved:
         return f"one of {{{', '.join(str(value) for value in resolved['enum'])}}}"
     if resolved.get("type") == "array":
@@ -300,15 +300,36 @@ def _items_label(items: dict[str, Any], defs: dict[str, Any]) -> str:
     # An array's items can be an enum, whose vocabulary is worth listing, or a
     # basic type, which is named. Not `_argument_detail`: that would nest the
     # enum branch's "one of" inside "array of".
-    resolved = _resolve_ref(items, defs)
+    resolved = _resolve_node(items, defs)
     if "enum" in resolved:
         return ", ".join(str(value) for value in resolved["enum"])
     return str(resolved.get("type", "string"))
 
 
+def _resolve_node(node: dict[str, Any], defs: dict[str, Any]) -> dict[str, Any]:
+    """Reduce a JSON Schema node to the single shape it actually describes.
+
+    pydantic emits two shapes ``_argument_detail`` and ``_items_label`` must
+    see through, in this order: a nullable field or item is an `anyOf` union
+    with a `{"type": "null"}` branch, and a bare `enum.Enum` (unlike a
+    `Literal`, which is inlined) is a `$ref` into `$defs`. Unwrapping the
+    union before resolving the reference means a nullable bare enum, and a
+    nullable array of them, both resolve the same as a required one.
+    """
+    return _resolve_ref(_unwrap_any_of(node), defs)
+
+
+def _unwrap_any_of(node: dict[str, Any]) -> dict[str, Any]:
+    branches = node.get("anyOf")
+    if branches is None:
+        return node
+    non_null = [branch for branch in branches if branch.get("type") != "null"]
+    # A union of more than one real type has no single detail to derive; leave
+    # it as is; it falls through to `string` below, same as before this fix.
+    return non_null[0] if len(non_null) == 1 else node
+
+
 def _resolve_ref(node: dict[str, Any], defs: dict[str, Any]) -> dict[str, Any]:
-    # A bare enum.Enum argument schema is a `$ref` into `$defs`, unlike a
-    # Literal, which pydantic inlines. Resolve it before reading the type.
     ref = node.get("$ref")
     if ref is None:
         return node

--- a/pkg-py/src/commons/_measures.py
+++ b/pkg-py/src/commons/_measures.py
@@ -217,7 +217,8 @@ def measure(
     """Mark a function as a measure.
 
     The decorated function is returned unchanged, so measures and the helpers
-    they call stay ordinary callables.
+    they call stay ordinary callables. Model-supplied arguments are limited to
+    scalars, enums, and arrays of those.
     """
 
     def decorate(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -249,7 +250,7 @@ def measure(
 
 
 def measure_schema_text(
-    measure: Measure,
+    record: Measure,
     source_names: Sequence[str] = (),
     heading: str | None = None,
 ) -> str:
@@ -259,7 +260,7 @@ def measure_schema_text(
     ``tests/shared/measure-schema.json``; change that fixture, not just this
     function.
     """
-    schema = measure.params.model_json_schema()
+    schema = record.params.model_json_schema()
     properties: dict[str, Any] = schema.get("properties", {})
     required = set(schema.get("required", ()))
     defs: dict[str, Any] = schema.get("$defs", {})
@@ -268,7 +269,8 @@ def measure_schema_text(
     # Naming the source a measure queries points the SQL fallback at the right
     # one. `source_names` is empty for single-source agents, so the line never
     # appears there.
-    named = [name for name in measure.injected if name in set(source_names)]
+    named_sources = set(source_names)
+    named = [name for name in record.injected if name in named_sources]
     if named:
         details += f"sources: {', '.join(named)}\n"
     if properties:
@@ -283,8 +285,8 @@ def measure_schema_text(
     if details:
         details = f"\n\n{details}"
 
-    resolved_heading = measure.name if heading is None else heading
-    return f"### {resolved_heading}\n{measure.description}{details}"
+    resolved_heading = record.name if heading is None else heading
+    return f"### {resolved_heading}\n{record.description}{details}"
 
 
 def _argument_detail(prop: dict[str, Any], defs: dict[str, Any]) -> str:

--- a/pkg-py/src/commons/_measures.py
+++ b/pkg-py/src/commons/_measures.py
@@ -262,6 +262,7 @@ def measure_schema_text(
     schema = measure.params.model_json_schema()
     properties: dict[str, Any] = schema.get("properties", {})
     required = set(schema.get("required", ()))
+    defs: dict[str, Any] = schema.get("$defs", {})
 
     details = ""
     # Naming the source a measure queries points the SQL fallback at the right
@@ -272,7 +273,7 @@ def measure_schema_text(
         details += f"sources: {', '.join(named)}\n"
     if properties:
         lines = [
-            f"  - {name} ({_argument_detail(prop)}, "
+            f"  - {name} ({_argument_detail(prop, defs)}, "
             f"{'required' if name in required else 'optional'}) "
             f"{prop.get('description', '')}"
             for name, prop in properties.items()
@@ -286,21 +287,32 @@ def measure_schema_text(
     return f"### {resolved_heading}\n{measure.description}{details}"
 
 
-def _argument_detail(prop: dict[str, Any]) -> str:
-    if "enum" in prop:
-        return f"one of {{{', '.join(str(value) for value in prop['enum'])}}}"
-    if prop.get("type") == "array":
-        return f"array of {{{_items_label(prop.get('items', {}))}}}"
-    return str(prop.get("type", "string"))
+def _argument_detail(prop: dict[str, Any], defs: dict[str, Any]) -> str:
+    resolved = _resolve_ref(prop, defs)
+    if "enum" in resolved:
+        return f"one of {{{', '.join(str(value) for value in resolved['enum'])}}}"
+    if resolved.get("type") == "array":
+        return f"array of {{{_items_label(resolved.get('items', {}), defs)}}}"
+    return str(resolved.get("type", "string"))
 
 
-def _items_label(items: dict[str, Any]) -> str:
+def _items_label(items: dict[str, Any], defs: dict[str, Any]) -> str:
     # An array's items can be an enum, whose vocabulary is worth listing, or a
     # basic type, which is named. Not `_argument_detail`: that would nest the
     # enum branch's "one of" inside "array of".
-    if "enum" in items:
-        return ", ".join(str(value) for value in items["enum"])
-    return str(items.get("type", "string"))
+    resolved = _resolve_ref(items, defs)
+    if "enum" in resolved:
+        return ", ".join(str(value) for value in resolved["enum"])
+    return str(resolved.get("type", "string"))
+
+
+def _resolve_ref(node: dict[str, Any], defs: dict[str, Any]) -> dict[str, Any]:
+    # A bare enum.Enum argument schema is a `$ref` into `$defs`, unlike a
+    # Literal, which pydantic inlines. Resolve it before reading the type.
+    ref = node.get("$ref")
+    if ref is None:
+        return node
+    return defs[ref.removeprefix("#/$defs/")]
 
 
 def as_measure(obj: Any) -> Measure | None:

--- a/pkg-py/src/commons/_measures.py
+++ b/pkg-py/src/commons/_measures.py
@@ -217,8 +217,9 @@ def measure(
     """Mark a function as a measure.
 
     The decorated function is returned unchanged, so measures and the helpers
-    they call stay ordinary callables. Model-supplied arguments are limited to
-    scalars, enums, and arrays of those.
+    they call stay ordinary callables. Model-supplied arguments are expected
+    to be scalars, enums, or arrays of those; richer shapes are not rejected,
+    but the schema block renders them only approximately.
     """
 
     def decorate(func: Callable[..., Any]) -> Callable[..., Any]:

--- a/pkg-py/tests/test_measures.py
+++ b/pkg-py/tests/test_measures.py
@@ -469,3 +469,55 @@ def test_measure_schema_text_names_a_bare_enum_arrays_vocabulary() -> None:
     rendered = measure_schema_text(_as_measure(regional_orders))
 
     assert "regions (array of {EMEA, AMER}, required) Regions to include." in rendered
+
+
+def test_measure_schema_text_names_a_nullable_bare_enum_arguments_vocabulary() -> None:
+    """pydantic wraps a nullable field in `anyOf` with a null branch."""
+
+    class Region(str, enum.Enum):
+        EMEA = "EMEA"
+        AMER = "AMER"
+
+    @measure(description="Orders by region.")
+    def regional_orders(
+        region: Annotated[
+            Region | None, Field(description="Bare enum, nullable.")
+        ] = None,
+    ) -> int:
+        return 1
+
+    rendered = measure_schema_text(_as_measure(regional_orders))
+
+    assert "region (one of {EMEA, AMER}, optional) Bare enum, nullable." in rendered
+
+
+def test_measure_schema_text_names_a_nullable_literal_arguments_vocabulary() -> None:
+    @measure(description="Orders by region.")
+    def regional_orders(
+        region: Annotated[
+            Literal["EMEA", "AMER"] | None, Field(description="Literal, nullable.")
+        ] = None,
+    ) -> int:
+        return 1
+
+    rendered = measure_schema_text(_as_measure(regional_orders))
+
+    assert "region (one of {EMEA, AMER}, optional) Literal, nullable." in rendered
+
+
+def test_measure_schema_text_names_a_nullable_enum_arrays_vocabulary() -> None:
+    class Region(str, enum.Enum):
+        EMEA = "EMEA"
+        AMER = "AMER"
+
+    @measure(description="Orders by region.")
+    def regional_orders(
+        regions: Annotated[
+            list[Region] | None, Field(description="Enum array, nullable.")
+        ] = None,
+    ) -> int:
+        return 1
+
+    rendered = measure_schema_text(_as_measure(regional_orders))
+
+    assert "regions (array of {EMEA, AMER}, optional) Enum array, nullable." in rendered

--- a/pkg-py/tests/test_measures.py
+++ b/pkg-py/tests/test_measures.py
@@ -6,7 +6,7 @@ from dataclasses import FrozenInstanceError
 from typing import Annotated, Any, Literal, get_args, get_origin
 
 import pytest
-from pydantic import ConfigDict, Field, ValidationError, create_model
+from pydantic import Field, ValidationError
 
 from commons._measures import (
     INJECTED,
@@ -396,30 +396,45 @@ def _fixture_annotation(spec: dict[str, Any]) -> Any:
 
 
 def _fixture_measure(spec: dict[str, Any]) -> Measure:
-    """Build a measure from a fixture spec; see test-measures.R for the sibling
-    runner.
+    """Build a measure from a fixture spec and decorate it with the production
+    @measure, so this runner enters through the same front door as
+    test-measures.R's runner enters measure().
+
+    A real function is generated because @measure inspects a signature, not a
+    spec; each described argument keeps its position, required arguments and
+    injected arguments come first (Python requires that), and defaulted
+    arguments follow. No existing fixture case mixes required-after-optional
+    or optional-before-injected, so this ordering renders identically to
+    declaration order for every case in measure-schema.json.
     """
-    fields: dict[str, Any] = {}
+    namespace: dict[str, Any] = {}
+    required_params: list[str] = []
+    optional_params: list[str] = []
+
     for argument in spec["arguments"]:
-        annotation = Annotated[
-            _fixture_annotation(argument),
-            Field(description=argument["description"]),
+        type_name = f"_{argument['name']}_type"
+        namespace[type_name] = Annotated[
+            _fixture_annotation(argument), Field(description=argument["description"])
         ]
-        default = ... if argument["required"] else argument["default"]
-        fields[argument["name"]] = (annotation, default)
+        if argument["required"]:
+            required_params.append(f"{argument['name']}: {type_name}")
+        else:
+            default_name = f"_{argument['name']}_default"
+            namespace[default_name] = argument["default"]
+            optional_params.append(f"{argument['name']}: {type_name} = {default_name}")
 
-    def unused() -> None: ...  # pragma: no cover - the renderer never calls it
+    injected_params: list[str] = []
+    for injected_name in spec["injected"]:
+        type_name = f"_{injected_name}_type"
+        namespace[type_name] = Injected[Any]
+        injected_params.append(f"{injected_name}: {type_name}")
 
-    return Measure(
-        name=spec["name"],
-        title=spec["name"].replace("_", " "),
-        description=spec["description"],
-        func=unused,
-        params=create_model(
-            spec["name"], __config__=ConfigDict(extra="forbid"), **fields
-        ),
-        injected=tuple(spec["injected"]),
-    )
+    params = ", ".join(required_params + injected_params + optional_params)
+    exec(f"def {spec['name']}({params}) -> None: ...", namespace)  # noqa: S102
+    func = namespace[spec["name"]]
+
+    decorated = measure(description=spec["description"], name=spec["name"])(func)
+    return _as_measure(decorated)
 
 
 def test_schema_fixture_is_not_empty() -> None:

--- a/pkg-py/tests/test_measures.py
+++ b/pkg-py/tests/test_measures.py
@@ -403,10 +403,21 @@ def _fixture_measure(spec: dict[str, Any]) -> Measure:
     A real function is generated because @measure inspects a signature, not a
     spec; each described argument keeps its position, required arguments and
     injected arguments come first (Python requires that), and defaulted
-    arguments follow. No existing fixture case mixes required-after-optional
-    or optional-before-injected, so this ordering renders identically to
-    declaration order for every case in measure-schema.json.
+    arguments follow. A case declaring a required argument after an optional
+    one cannot be built without reordering, which would render a different
+    argument order than the R runner, so it is rejected rather than built.
     """
+    optional_seen = False
+    for argument in spec["arguments"]:
+        if argument["required"] and optional_seen:
+            raise ValueError(
+                f"Fixture case {spec['name']!r} declares required argument "
+                f"{argument['name']!r} after an optional one; Python requires "
+                "defaulted parameters last, so this runner cannot preserve "
+                "declaration order for that case."
+            )
+        optional_seen = optional_seen or not argument["required"]
+
     namespace: dict[str, Any] = {}
     required_params: list[str] = []
     optional_params: list[str] = []

--- a/pkg-py/tests/test_measures.py
+++ b/pkg-py/tests/test_measures.py
@@ -5,7 +5,7 @@ from dataclasses import FrozenInstanceError
 from typing import Annotated, Any, Literal, get_args, get_origin
 
 import pytest
-from pydantic import Field, ValidationError
+from pydantic import ConfigDict, Field, ValidationError, create_model
 
 from commons._measures import (
     INJECTED,
@@ -14,7 +14,10 @@ from commons._measures import (
     _split_parameters,
     as_measure,
     measure,
+    measure_schema_text,
 )
+
+from ._shared import load_shared_fixture
 
 
 def test_injected_alias_carries_the_marker() -> None:
@@ -368,3 +371,64 @@ def test_measure_is_frozen() -> None:
     m = _count_measure()
     with pytest.raises(FrozenInstanceError):
         m.name = "other"  # type: ignore[misc]
+
+
+SCHEMA_CASES: list[dict[str, Any]] = load_shared_fixture("measure-schema")[
+    "measure_schema_text"
+]["cases"]
+
+_SCALARS: dict[str, Any] = {
+    "string": str,
+    "integer": int,
+    "number": float,
+    "boolean": bool,
+}
+
+
+def _fixture_annotation(spec: dict[str, Any]) -> Any:
+    kind = spec["type"]
+    if kind == "enum":
+        return Literal[tuple(spec["values"])]
+    if kind == "array":
+        return list[_fixture_annotation(spec["items"])]
+    return _SCALARS[kind]
+
+
+def _fixture_measure(spec: dict[str, Any]) -> Measure:
+    """Build a measure from a fixture spec, mirroring the R runner's helper."""
+    fields: dict[str, Any] = {}
+    for argument in spec["arguments"]:
+        annotation = Annotated[
+            _fixture_annotation(argument),
+            Field(description=argument["description"]),
+        ]
+        default = ... if argument["required"] else argument["default"]
+        fields[argument["name"]] = (annotation, default)
+
+    def unused() -> None: ...  # pragma: no cover - the renderer never calls it
+
+    return Measure(
+        name=spec["name"],
+        title=spec["name"].replace("_", " "),
+        description=spec["description"],
+        func=unused,
+        params=create_model(
+            spec["name"], __config__=ConfigDict(extra="forbid"), **fields
+        ),
+        injected=tuple(spec["injected"]),
+    )
+
+
+def test_schema_fixture_is_not_empty() -> None:
+    assert SCHEMA_CASES
+
+
+@pytest.mark.parametrize("case", SCHEMA_CASES, ids=lambda case: case["name"])
+def test_measure_schema_text_matches_the_shared_fixture(case: dict[str, Any]) -> None:
+    rendered = measure_schema_text(
+        _fixture_measure(case["measure"]),
+        source_names=case["source_names"],
+        heading=case.get("heading"),
+    )
+
+    assert rendered == case["expected"]

--- a/pkg-py/tests/test_measures.py
+++ b/pkg-py/tests/test_measures.py
@@ -1,5 +1,6 @@
 """The semantic layer: measures, their schemas, and injected arguments."""
 
+import enum
 from collections.abc import AsyncIterator
 from dataclasses import FrozenInstanceError
 from typing import Annotated, Any, Literal, get_args, get_origin
@@ -388,14 +389,16 @@ _SCALARS: dict[str, Any] = {
 def _fixture_annotation(spec: dict[str, Any]) -> Any:
     kind = spec["type"]
     if kind == "enum":
-        return Literal[tuple(spec["values"])]
+        return Literal[tuple(spec["values"])]  # type: ignore[misc]
     if kind == "array":
         return list[_fixture_annotation(spec["items"])]
     return _SCALARS[kind]
 
 
 def _fixture_measure(spec: dict[str, Any]) -> Measure:
-    """Build a measure from a fixture spec, mirroring the R runner's helper."""
+    """Build a measure from a fixture spec; see test-measures.R for the sibling
+    runner.
+    """
     fields: dict[str, Any] = {}
     for argument in spec["arguments"]:
         annotation = Annotated[
@@ -432,3 +435,37 @@ def test_measure_schema_text_matches_the_shared_fixture(case: dict[str, Any]) ->
     )
 
     assert rendered == case["expected"]
+
+
+def test_measure_schema_text_names_a_bare_enum_arguments_vocabulary() -> None:
+    """pydantic schemas a bare enum.Enum as a `$ref` into `$defs`, not inline."""
+
+    class Region(str, enum.Enum):
+        EMEA = "EMEA"
+        AMER = "AMER"
+
+    @measure(description="Orders by region.")
+    def regional_orders(
+        region: Annotated[Region, Field(description="The sales region.")],
+    ) -> int:
+        return 1
+
+    rendered = measure_schema_text(_as_measure(regional_orders))
+
+    assert "region (one of {EMEA, AMER}, required) The sales region." in rendered
+
+
+def test_measure_schema_text_names_a_bare_enum_arrays_vocabulary() -> None:
+    class Region(str, enum.Enum):
+        EMEA = "EMEA"
+        AMER = "AMER"
+
+    @measure(description="Orders by region.")
+    def regional_orders(
+        regions: Annotated[list[Region], Field(description="Regions to include.")],
+    ) -> int:
+        return 1
+
+    rendered = measure_schema_text(_as_measure(regional_orders))
+
+    assert "regions (array of {EMEA, AMER}, required) Regions to include." in rendered

--- a/pkg-r/R/measures.R
+++ b/pkg-r/R/measures.R
@@ -336,14 +336,21 @@ arg_schema_line <- function(name, type) {
   detail <- switch(
     kind,
     enum = sprintf("one of {%s}", paste(type_values(type), collapse = ", ")),
-    array = sprintf(
-      "array of {%s}",
-      paste(type_values(S7::prop(type, "items")), collapse = ", ")
-    ),
+    array = sprintf("array of {%s}", array_items_label(S7::prop(type, "items"))),
     kind
   )
   desc <- S7::prop(type, "description") %||% ""
   sprintf("  - %s (%s, %s) %s", name, detail, required, desc)
+}
+
+# An array's items can be an enum, whose vocabulary is worth listing, or a
+# basic type, which has no `values` property to read.
+array_items_label <- function(items) {
+  if (identical(type_kind(items), "enum")) {
+    paste(type_values(items), collapse = ", ")
+  } else {
+    type_kind(items)
+  }
 }
 
 # The provider sees only `call_measure`, so measure arguments are checked here.

--- a/pkg-r/tests/testthat/fixtures/shared/measure-schema.json
+++ b/pkg-r/tests/testthat/fixtures/shared/measure-schema.json
@@ -1,0 +1,167 @@
+{
+  "description": "The block search_pool shows the model for one measure: a heading, the description, an optional sources line naming the data sources the measure takes, and the model-visible arguments with their type, requiredness, and description. Both packages must emit the same bytes, because this text is part of what the agent reads. Each case builds a measure from `measure` and renders it with `source_names`; `heading` overrides the default heading when present.",
+  "measure_schema_text": {
+    "cases": [
+      {
+        "name": "a measure without arguments renders heading and description only",
+        "measure": {
+          "name": "order_count",
+          "description": "Count of orders.",
+          "arguments": [],
+          "injected": []
+        },
+        "source_names": [],
+        "expected": "### order_count\nCount of orders."
+      },
+      {
+        "name": "arguments render with type, requiredness, and description",
+        "measure": {
+          "name": "order_count",
+          "description": "Count of orders.",
+          "arguments": [
+            {
+              "name": "region",
+              "type": "enum",
+              "values": ["EMEA", "AMER"],
+              "required": true,
+              "description": "The sales region."
+            },
+            {
+              "name": "revenue_under",
+              "type": "number",
+              "required": false,
+              "default": 0,
+              "description": "Cap."
+            }
+          ],
+          "injected": []
+        },
+        "source_names": [],
+        "expected": "### order_count\nCount of orders.\n\narguments:\n  - region (one of {EMEA, AMER}, required) The sales region.\n  - revenue_under (number, optional) Cap."
+      },
+      {
+        "name": "the sources line names only injected arguments that match a source",
+        "measure": {
+          "name": "region_revenue",
+          "description": "Total revenue for a region.",
+          "arguments": [
+            {
+              "name": "region",
+              "type": "string",
+              "required": true,
+              "description": "The sales region."
+            }
+          ],
+          "injected": ["warehouse", "cache"]
+        },
+        "source_names": ["warehouse", "finance"],
+        "expected": "### region_revenue\nTotal revenue for a region.\n\nsources: warehouse\narguments:\n  - region (string, required) The sales region."
+      },
+      {
+        "name": "no sources line when the agent has a single unnamed source",
+        "measure": {
+          "name": "region_revenue",
+          "description": "Total revenue for a region.",
+          "arguments": [
+            {
+              "name": "region",
+              "type": "string",
+              "required": true,
+              "description": "The sales region."
+            }
+          ],
+          "injected": ["warehouse", "cache"]
+        },
+        "source_names": [],
+        "expected": "### region_revenue\nTotal revenue for a region.\n\narguments:\n  - region (string, required) The sales region."
+      },
+      {
+        "name": "a sources line without arguments",
+        "measure": {
+          "name": "warehouse_health",
+          "description": "Warehouse status.",
+          "arguments": [],
+          "injected": ["warehouse"]
+        },
+        "source_names": ["warehouse", "finance"],
+        "expected": "### warehouse_health\nWarehouse status.\n\nsources: warehouse"
+      },
+      {
+        "name": "a string array names its item type",
+        "measure": {
+          "name": "tagged_orders",
+          "description": "Orders by tag.",
+          "arguments": [
+            {
+              "name": "tags",
+              "type": "array",
+              "items": {"type": "string"},
+              "required": true,
+              "description": "Tags to match."
+            }
+          ],
+          "injected": []
+        },
+        "source_names": [],
+        "expected": "### tagged_orders\nOrders by tag.\n\narguments:\n  - tags (array of {string}, required) Tags to match."
+      },
+      {
+        "name": "an enum array lists its vocabulary",
+        "measure": {
+          "name": "regional_orders",
+          "description": "Orders by region.",
+          "arguments": [
+            {
+              "name": "regions",
+              "type": "array",
+              "items": {"type": "enum", "values": ["EMEA", "AMER"]},
+              "required": false,
+              "default": [],
+              "description": "Regions to include."
+            }
+          ],
+          "injected": []
+        },
+        "source_names": [],
+        "expected": "### regional_orders\nOrders by region.\n\narguments:\n  - regions (array of {EMEA, AMER}, optional) Regions to include."
+      },
+      {
+        "name": "integer and boolean arguments name their type",
+        "measure": {
+          "name": "recent_orders",
+          "description": "Recent orders.",
+          "arguments": [
+            {
+              "name": "days",
+              "type": "integer",
+              "required": true,
+              "description": "How many days back."
+            },
+            {
+              "name": "include_cancelled",
+              "type": "boolean",
+              "required": false,
+              "default": false,
+              "description": "Include cancelled orders."
+            }
+          ],
+          "injected": []
+        },
+        "source_names": [],
+        "expected": "### recent_orders\nRecent orders.\n\narguments:\n  - days (integer, required) How many days back.\n  - include_cancelled (boolean, optional) Include cancelled orders."
+      },
+      {
+        "name": "an explicit heading replaces the measure name",
+        "measure": {
+          "name": "order_count",
+          "description": "Count of orders.",
+          "arguments": [],
+          "injected": []
+        },
+        "source_names": [],
+        "heading": "order_count (measure)",
+        "expected": "### order_count (measure)\nCount of orders."
+      }
+    ]
+  }
+}

--- a/pkg-r/tests/testthat/fixtures/shared/measure-schema.json
+++ b/pkg-r/tests/testthat/fixtures/shared/measure-schema.json
@@ -161,6 +161,18 @@
         "source_names": [],
         "heading": "order_count (measure)",
         "expected": "### order_count (measure)\nCount of orders."
+      },
+      {
+        "name": "an explicit empty heading is rendered verbatim, not treated as absent",
+        "measure": {
+          "name": "order_count",
+          "description": "Count of orders.",
+          "arguments": [],
+          "injected": []
+        },
+        "source_names": [],
+        "heading": "",
+        "expected": "### \nCount of orders."
       }
     ]
   }

--- a/pkg-r/tests/testthat/test-measures.R
+++ b/pkg-r/tests/testthat/test-measures.R
@@ -206,11 +206,14 @@ test_that("measure_schema_text matches the shared fixture", {
   expect_gt(length(cases), 0)
 
   for (case in cases) {
-    rendered <- measure_schema_text(
+    args <- list(
       fixture_measure(case$measure),
-      source_names = unlist(case$source_names) %||% character(),
-      heading = case$heading %||% case$measure$name
+      source_names = unlist(case$source_names) %||% character()
     )
+    if (!is.null(case$heading)) {
+      args$heading <- case$heading
+    }
+    rendered <- do.call(measure_schema_text, args)
     expect_identical(rendered, case$expected, info = case$name)
   }
 })

--- a/pkg-r/tests/testthat/test-measures.R
+++ b/pkg-r/tests/testthat/test-measures.R
@@ -151,3 +151,66 @@ test_that("search_pool_text reports when nothing matches", {
     "Nothing in the semantic layer"
   )
 })
+
+fixture_scalar_type <- function(kind, description = "", required = TRUE) {
+  switch(
+    kind,
+    integer = ellmer::type_integer(description, required = required),
+    number = ellmer::type_number(description, required = required),
+    boolean = ellmer::type_boolean(description, required = required),
+    ellmer::type_string(description, required = required)
+  )
+}
+
+fixture_type <- function(arg) {
+  required <- isTRUE(arg$required)
+  if (identical(arg$type, "enum")) {
+    return(ellmer::type_enum(
+      values = unlist(arg$values),
+      description = arg$description,
+      required = required
+    ))
+  }
+  if (identical(arg$type, "array")) {
+    items <- if (identical(arg$items$type, "enum")) {
+      ellmer::type_enum(values = unlist(arg$items$values))
+    } else {
+      fixture_scalar_type(arg$items$type)
+    }
+    return(ellmer::type_array(
+      items = items,
+      description = arg$description,
+      required = required
+    ))
+  }
+  fixture_scalar_type(arg$type, arg$description, required)
+}
+
+# Build a measure from a fixture spec. The injected arguments only have to
+# exist as formals; measure() marks them as hidden from the model.
+fixture_measure <- function(spec) {
+  arguments <- list()
+  for (arg in spec$arguments) {
+    arguments[[arg$name]] <- fixture_type(arg)
+  }
+  formal_names <- c(names(arguments), unlist(spec$injected))
+  fn <- as.function(c(
+    stats::setNames(rep(list(quote(expr = )), length(formal_names)), formal_names),
+    list(NULL)
+  ))
+  measure(spec$name, spec$description, fn, arguments = arguments)
+}
+
+test_that("measure_schema_text matches the shared fixture", {
+  cases <- shared_fixture("measure-schema")$measure_schema_text$cases
+  expect_gt(length(cases), 0)
+
+  for (case in cases) {
+    rendered <- measure_schema_text(
+      fixture_measure(case$measure),
+      source_names = unlist(case$source_names) %||% character(),
+      heading = case$heading %||% case$measure$name
+    )
+    expect_identical(rendered, case$expected, info = case$name)
+  }
+})

--- a/tests/shared/measure-schema.json
+++ b/tests/shared/measure-schema.json
@@ -1,0 +1,167 @@
+{
+  "description": "The block search_pool shows the model for one measure: a heading, the description, an optional sources line naming the data sources the measure takes, and the model-visible arguments with their type, requiredness, and description. Both packages must emit the same bytes, because this text is part of what the agent reads. Each case builds a measure from `measure` and renders it with `source_names`; `heading` overrides the default heading when present.",
+  "measure_schema_text": {
+    "cases": [
+      {
+        "name": "a measure without arguments renders heading and description only",
+        "measure": {
+          "name": "order_count",
+          "description": "Count of orders.",
+          "arguments": [],
+          "injected": []
+        },
+        "source_names": [],
+        "expected": "### order_count\nCount of orders."
+      },
+      {
+        "name": "arguments render with type, requiredness, and description",
+        "measure": {
+          "name": "order_count",
+          "description": "Count of orders.",
+          "arguments": [
+            {
+              "name": "region",
+              "type": "enum",
+              "values": ["EMEA", "AMER"],
+              "required": true,
+              "description": "The sales region."
+            },
+            {
+              "name": "revenue_under",
+              "type": "number",
+              "required": false,
+              "default": 0,
+              "description": "Cap."
+            }
+          ],
+          "injected": []
+        },
+        "source_names": [],
+        "expected": "### order_count\nCount of orders.\n\narguments:\n  - region (one of {EMEA, AMER}, required) The sales region.\n  - revenue_under (number, optional) Cap."
+      },
+      {
+        "name": "the sources line names only injected arguments that match a source",
+        "measure": {
+          "name": "region_revenue",
+          "description": "Total revenue for a region.",
+          "arguments": [
+            {
+              "name": "region",
+              "type": "string",
+              "required": true,
+              "description": "The sales region."
+            }
+          ],
+          "injected": ["warehouse", "cache"]
+        },
+        "source_names": ["warehouse", "finance"],
+        "expected": "### region_revenue\nTotal revenue for a region.\n\nsources: warehouse\narguments:\n  - region (string, required) The sales region."
+      },
+      {
+        "name": "no sources line when the agent has a single unnamed source",
+        "measure": {
+          "name": "region_revenue",
+          "description": "Total revenue for a region.",
+          "arguments": [
+            {
+              "name": "region",
+              "type": "string",
+              "required": true,
+              "description": "The sales region."
+            }
+          ],
+          "injected": ["warehouse", "cache"]
+        },
+        "source_names": [],
+        "expected": "### region_revenue\nTotal revenue for a region.\n\narguments:\n  - region (string, required) The sales region."
+      },
+      {
+        "name": "a sources line without arguments",
+        "measure": {
+          "name": "warehouse_health",
+          "description": "Warehouse status.",
+          "arguments": [],
+          "injected": ["warehouse"]
+        },
+        "source_names": ["warehouse", "finance"],
+        "expected": "### warehouse_health\nWarehouse status.\n\nsources: warehouse"
+      },
+      {
+        "name": "a string array names its item type",
+        "measure": {
+          "name": "tagged_orders",
+          "description": "Orders by tag.",
+          "arguments": [
+            {
+              "name": "tags",
+              "type": "array",
+              "items": {"type": "string"},
+              "required": true,
+              "description": "Tags to match."
+            }
+          ],
+          "injected": []
+        },
+        "source_names": [],
+        "expected": "### tagged_orders\nOrders by tag.\n\narguments:\n  - tags (array of {string}, required) Tags to match."
+      },
+      {
+        "name": "an enum array lists its vocabulary",
+        "measure": {
+          "name": "regional_orders",
+          "description": "Orders by region.",
+          "arguments": [
+            {
+              "name": "regions",
+              "type": "array",
+              "items": {"type": "enum", "values": ["EMEA", "AMER"]},
+              "required": false,
+              "default": [],
+              "description": "Regions to include."
+            }
+          ],
+          "injected": []
+        },
+        "source_names": [],
+        "expected": "### regional_orders\nOrders by region.\n\narguments:\n  - regions (array of {EMEA, AMER}, optional) Regions to include."
+      },
+      {
+        "name": "integer and boolean arguments name their type",
+        "measure": {
+          "name": "recent_orders",
+          "description": "Recent orders.",
+          "arguments": [
+            {
+              "name": "days",
+              "type": "integer",
+              "required": true,
+              "description": "How many days back."
+            },
+            {
+              "name": "include_cancelled",
+              "type": "boolean",
+              "required": false,
+              "default": false,
+              "description": "Include cancelled orders."
+            }
+          ],
+          "injected": []
+        },
+        "source_names": [],
+        "expected": "### recent_orders\nRecent orders.\n\narguments:\n  - days (integer, required) How many days back.\n  - include_cancelled (boolean, optional) Include cancelled orders."
+      },
+      {
+        "name": "an explicit heading replaces the measure name",
+        "measure": {
+          "name": "order_count",
+          "description": "Count of orders.",
+          "arguments": [],
+          "injected": []
+        },
+        "source_names": [],
+        "heading": "order_count (measure)",
+        "expected": "### order_count (measure)\nCount of orders."
+      }
+    ]
+  }
+}

--- a/tests/shared/measure-schema.json
+++ b/tests/shared/measure-schema.json
@@ -161,6 +161,18 @@
         "source_names": [],
         "heading": "order_count (measure)",
         "expected": "### order_count (measure)\nCount of orders."
+      },
+      {
+        "name": "an explicit empty heading is rendered verbatim, not treated as absent",
+        "measure": {
+          "name": "order_count",
+          "description": "Count of orders.",
+          "arguments": [],
+          "injected": []
+        },
+        "source_names": [],
+        "heading": "",
+        "expected": "### \nCount of orders."
       }
     ]
   }


### PR DESCRIPTION
Second of four stacked PRs building the Python semantic layer (M3). Based on #247.

## What this is, in plain terms

When the agent asks "what can I calculate?", the `search_pool` tool answers with a short block of text for each matching measure: its name, what it does, and what arguments it takes. The model reads that text to decide how to call the measure — so the words matter, and the R and Python packages must produce **exactly the same words**. If they drift, nothing errors; the agent just quietly behaves differently depending on the language.

This PR writes the expected text down once, in a shared file (`tests/shared/measure-schema.json`), and makes both test suites prove they match it byte for byte. Each suite has a small "runner" that builds a measure from each case in the file and checks the rendered block against it. Change the rendering in either language without updating the file, and that language's tests fail.

Building that file immediately paid off: it exposed a crash in the R package, fixed here. It also caught two Python rendering bugs, fixed here too.

## The R bug (the only reason this PR touches `pkg-r/`)

(@simonpcouch as a heads-up. I don't think this is big enough to require review, but just FYI)

Rendering a measure with an array-of-strings argument didn't produce bad output — it **crashed** with `Can't find property <ellmer::TypeBasic>@values`. The array branch of `arg_schema_line()` asked the array's item type for its `values`, but only enum types have that property; a plain string item type does not.

The fix is a five-line helper: if the array's items are an enum, list the allowed values as before; otherwise just name the type (`array of {string}`). The enum path is character-for-character the old code, so no existing output changes. The only reachable effect is that a measure with a non-enum array argument now appears in `search_pool` output instead of raising. The full R suite passes (6649 tests), and the new fixture runner failed on exactly this case before the fix and passes after it.

One thing worth a look: the helper reuses `type_kind()` to name a basic item type, so `array of {string}` reads consistently with `(string, required)` — but the fixture now pins that wording for both languages, so if you'd prefer different words, say so.

## The Python fixes

- An explicit `heading=""` was treated as "no heading given"; R passes it through. Now only `None` means absent, and the fixture has a case pinning the empty-heading output.
- An argument typed with a bare `enum.Enum`, or any nullable argument, rendered as plain `string` — hiding the allowed values from the model. That happened because pydantic describes those shapes with `$ref` pointers and `anyOf` unions, which the renderer didn't unwrap. Two small helpers now see through both shapes. These have Python-only tests rather than fixture cases because R has no equivalent concept, so there is no cross-language contract to pin.

## Deliberate choices

- **Both runners enter through the front door.** The Python runner generates a real function and decorates it with the production `@measure` (and rejects a fixture case it would have to reorder to build), rather than hand-building the internal model. A change to how `measure()` builds its model would otherwise leave the fixture test green while production rendered something else.
- **Python's `measure_schema_text()` has no caller yet** — this stack builds the feature bottom-up; `search_pool` arrives in a later PR.
- **Known gap, on purpose:** a multi-type union like `Region | OtherEnum | None` still renders as `string`. No measure constructs one, and a code comment records it.

No hand-written R tests were deleted. `pkg-r/tests/testthat/fixtures/shared/measure-schema.json` is generated by `scripts/sync-shared-fixtures.sh` and needs no review.


> for my own future reference, the thumbs up below is an indication that I've approved this PR for myself, while the remaining PRs in the stack are awaiting my manual reivew
