### PR TITLE
Python data-dict.yaml reader and the three prompt channels

### DIFF
--- a/pkg-py/src/commons/_data_dictionary.py
+++ b/pkg-py/src/commons/_data_dictionary.py
@@ -1,0 +1,359 @@
+"""Read a data dictionary and render the three channels it feeds.
+
+The input is the authored ``data-dict.yaml``, never data-dict's JSON export,
+so the schema validated here is the published data-dict spec. Parsing is
+permissive about fields commons never inspects and strict about the shape it
+does: a ``number(quantity)`` column with no ``range`` reads without complaint,
+because nothing reads that range.
+
+Prose fields stay as authored markdown, because they reach the model verbatim.
+
+The three channels are methods rather than separate structures.
+``pkg-r`` spreads the same rendering across ``R/data-dictionary.R``,
+``R/prompt.R`` and ``R/context-layer.R``; here the dictionary owns it and the
+prompt and context layers call in. That is a difference in shape, not in what
+either produces.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, ConfigDict, model_validator
+
+__all__ = [
+    "Column",
+    "DataDictionary",
+    "Definition",
+    "Relationship",
+    "Table",
+    "as_data_dictionary",
+]
+
+AMBIENT_GLOSSARY_CAP_CHARS = 4000
+
+
+def _prose(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return "\n".join(str(item) for item in value)
+    return str(value)
+
+
+def _key_by_name(entries: Any, what: str) -> dict[str, Any]:
+    """data-dict lists tables and columns as sequences with a `name` field.
+
+    Key them by that name for lookup. A pre-keyed mapping is accepted as-is.
+    """
+    if not entries:
+        return {}
+    if isinstance(entries, dict):
+        return {str(key): value or {} for key, value in entries.items()}
+
+    keyed: dict[str, Any] = {}
+    for entry in entries:
+        name = entry.get("name") if isinstance(entry, dict) else None
+        if not isinstance(name, str) or not name:
+            raise ValueError(f"Each {what} in a data dictionary needs a name.")
+        keyed[name] = {key: value for key, value in entry.items() if key != "name"}
+    return keyed
+
+
+class _Permissive(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+
+class Column(_Permissive):
+    type: str | None = None
+    description: str | None = None
+    details: str | None = None
+    units: str | None = None
+    nullable: bool | None = None
+    values: Any = None
+    range: list[Any] | None = None
+    examples: list[Any] | None = None
+    constraints: list[str] | None = None
+
+
+class Definition(_Permissive):
+    expr: str | None = None
+    label: str | None = None
+    description: str | None = None
+    details: str | None = None
+    todo: str | None = None
+
+
+class Table(_Permissive):
+    description: str | None = None
+    details: str | None = None
+    columns: dict[str, Column] = {}
+    definitions: dict[str, Definition] = {}
+
+    @model_validator(mode="before")
+    @classmethod
+    def _key_children(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        data = dict(data)
+        data["columns"] = _key_by_name(data.get("columns"), "column")
+        data["definitions"] = _key_by_name(data.get("definitions"), "definition")
+        return data
+
+
+class Relationship(_Permissive):
+    join: str | None = None
+    cardinality: str | None = None
+    description: str | None = None
+
+
+class DataDictionary(_Permissive):
+    name: str | None = None
+    description: str | None = None
+    details: str | None = None
+    tables: dict[str, Table] = {}
+    relationships: list[Relationship] = []
+    glossary: dict[str, str] = {}
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        data = dict(data)
+        data["tables"] = _key_by_name(data.get("tables"), "table")
+        for field in ("name", "description", "details"):
+            data[field] = _prose(data.get(field))
+        relationships = data.get("relationships") or []
+        data["relationships"] = [
+            item for item in relationships if isinstance(item, dict)
+        ]
+        glossary = data.get("glossary") or {}
+        data["glossary"] = {
+            str(term): _prose(body) or "" for term, body in glossary.items() if term
+        }
+        return data
+
+    @classmethod
+    def from_path(cls, path: str | Path) -> DataDictionary:
+        """Read a data-dict.yaml file. The YAML is the only input."""
+        text = Path(path).read_text(encoding="utf-8")
+        return cls.model_validate(yaml.safe_load(text) or {})
+
+    # ---- channel 1: always in the prompt ---------------------------------
+
+    def ambient_prompt_text(self) -> str:
+        """The prose that goes into every system prompt for this source."""
+        return "\n\n".join(part for part in (self.description, self.details) if part)
+
+    def ambient_glossary_terms(
+        self, cap_chars: int = AMBIENT_GLOSSARY_CAP_CHARS
+    ) -> list[str]:
+        """Glossary terms that fit the ambient cap, in order of appearance.
+
+        Entries past the cap are co-resolved at first touch and searchable
+        through the context layer, so nothing is lost by capping.
+        """
+        terms: list[str] = []
+        used = 0
+        for term, body in self.glossary.items():
+            used += len(term) + len(body)
+            if used > cap_chars:
+                break
+            terms.append(term)
+        return terms
+
+    # ---- channel 2: first touch ------------------------------------------
+
+    def entry_text(
+        self, table: str, ambient_cap_chars: int = AMBIENT_GLOSSARY_CAP_CHARS
+    ) -> str | None:
+        """The full entry for one table, delivered the first time it is used."""
+        entry = self.tables.get(table)
+        if entry is None:
+            return None
+        columns = self._columns_text(entry)
+        if columns is not None:
+            columns = f"Documented columns:\n\n{columns}"
+        parts = self.entry_parts(table, columns, ambient_cap_chars=ambient_cap_chars)
+        return "\n\n".join([f"Dictionary entry for `{table}`:", *parts])
+
+    def entry_parts(
+        self,
+        table: str,
+        columns_text: str | None,
+        ambient_cap_chars: int = AMBIENT_GLOSSARY_CAP_CHARS,
+    ) -> list[str]:
+        """The body of a table's entry, without the heading.
+
+        `describe_table` composes its own body from these, so it can merge the
+        live schema and keep sample rows.
+        """
+        entry = self.tables.get(table)
+        if entry is None:
+            return []
+        parts = [
+            part
+            for part in (
+                entry.description,
+                entry.details,
+                columns_text,
+                self._relationships_text(table),
+            )
+            if part
+        ]
+        terms = self._terms_text("\n".join(parts), ambient_cap_chars)
+        return [*parts, terms] if terms else parts
+
+    def _columns_text(self, entry: Table) -> str | None:
+        if not entry.columns:
+            return None
+        return "\n".join(
+            _column_line(name, column) for name, column in entry.columns.items()
+        )
+
+    def _relationships_text(self, table: str) -> str | None:
+        lines = []
+        for relationship in self.relationships:
+            text = " ".join(
+                part
+                for part in (relationship.join, relationship.description)
+                if part
+            )
+            if not _word_pattern(table).search(text):
+                continue
+            head = " ".join(
+                part
+                for part in (
+                    relationship.join,
+                    f"({relationship.cardinality})"
+                    if relationship.cardinality
+                    else None,
+                )
+                if part
+            )
+            body = _flatten_inline(relationship.description or "")
+            if not head:
+                lines.append(f"- {body}")
+            elif body:
+                lines.append(f"- {head}: {body}")
+            else:
+                lines.append(f"- {head}")
+        if not lines:
+            return None
+        return "Relationships:\n\n" + "\n".join(lines)
+
+    def _terms_text(self, text: str, ambient_cap_chars: int) -> str | None:
+        """Glossary terms the entry mentions that the prompt does not carry."""
+        ambient = set(self.ambient_glossary_terms(ambient_cap_chars))
+        hits = [
+            term
+            for term in self.glossary
+            if term not in ambient and _word_pattern(term).search(text)
+        ]
+        if not hits:
+            return None
+        lines = [f"- {term}: {_flatten_inline(self.glossary[term])}" for term in hits]
+        return "Definitions:\n\n" + "\n".join(lines)
+
+    # ---- channel 3: the search index -------------------------------------
+
+    def context_chunks(self) -> list[str]:
+        """Table- and dictionary-level prose, chunked for retrieval.
+
+        Column-level content stays out: first touch owns it, and indexing it
+        would pay for a second copy the agent already has.
+        """
+        chunks: list[str] = []
+        if self.details:
+            chunks.append(self.details)
+        for name, entry in self.tables.items():
+            prose = "\n\n".join(
+                part for part in (entry.description, entry.details) if part
+            )
+            if prose:
+                chunks.append(f"Table `{name}`: {prose}")
+        chunks.extend(f"{term}: {body}" for term, body in self.glossary.items())
+        return [chunk for chunk in chunks if chunk]
+
+
+def as_data_dictionary(x: Any) -> DataDictionary | None:
+    if x is None or isinstance(x, DataDictionary):
+        return x
+    if isinstance(x, (str, Path)):
+        return DataDictionary.from_path(x)
+    raise TypeError(
+        f"dictionary must be a path to a data-dict.yaml file, got {type(x).__name__}."
+    )
+
+
+def _flatten_inline(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _word_pattern(word: str) -> re.Pattern[str]:
+    return re.compile(rf"(?<!\w){re.escape(word)}(?!\w)", re.IGNORECASE)
+
+
+def _column_line(name: str, spec: Column) -> str:
+    qualifier = ", ".join(
+        str(part)
+        for part in (
+            spec.type,
+            _nullability_fact(spec.nullable),
+            spec.units,
+            *(spec.constraints or []),
+        )
+        if part
+    )
+    facts = [
+        part
+        for part in (
+            spec.description,
+            _values_fact(spec.values),
+            _range_fact(spec.range),
+            _examples_fact(spec.examples),
+            spec.details,
+        )
+        if part
+    ]
+    detail = _flatten_inline(" ".join(facts))
+
+    line = f"- {name}"
+    if qualifier:
+        line = f"{line} ({qualifier})"
+    if detail:
+        line = f"{line}: {detail}"
+    return line
+
+
+def _nullability_fact(nullable: bool | None) -> str | None:
+    if nullable is None:
+        return None
+    return "nullable" if nullable else "not nullable"
+
+
+def _values_fact(values: Any) -> str | None:
+    """`values` is a sequence ([M, F]) or a map of value to meaning ({M: Male})."""
+    if not values:
+        return None
+    if isinstance(values, dict):
+        rendered = [f"{value} ({label})" for value, label in values.items()]
+    else:
+        rendered = [str(value) for value in values]
+    return f"Values: {', '.join(rendered)}."
+
+
+def _range_fact(bounds: list[Any] | None) -> str | None:
+    if not bounds or len(bounds) < 2:
+        return None
+    return f"Range: {bounds[0]} to {bounds[1]}."
+
+
+def _examples_fact(examples: list[Any] | None) -> str | None:
+    if not examples:
+        return None
+    return f"Examples: {', '.join(str(item) for item in examples)}."

--- a/pkg-py/src/commons/_data_dictionary.py
+++ b/pkg-py/src/commons/_data_dictionary.py
@@ -80,6 +80,13 @@ class Column(_Permissive):
 
 
 class Definition(_Permissive):
+    """One authored governed definition, as written in the YAML.
+
+    `expr` is optional here and required by the export spec, which is what
+    type-checks it and reports where it went wrong. Requiring it twice would
+    mean two places to keep in step.
+    """
+
     expr: str | None = None
     label: str | None = None
     description: str | None = None
@@ -195,6 +202,10 @@ class DataDictionary(_Permissive):
         entry = self.tables.get(table)
         if entry is None:
             return []
+        # Governed definitions belong between the columns and the
+        # relationships, and are added once the compiler can supply them.
+        # They render as compiled SQL, never as the authored expression, so
+        # there is nothing correct to show before compilation happens.
         parts = [
             part
             for part in (
@@ -277,6 +288,8 @@ class DataDictionary(_Permissive):
             if prose:
                 chunks.append(f"Table `{name}`: {prose}")
         chunks.extend(f"{term}: {body}" for term, body in self.glossary.items())
+        # One chunk per governed definition joins these once the compiler can
+        # supply them, for the same reason as the first-touch entry.
         return [chunk for chunk in chunks if chunk]
 
 

--- a/pkg-py/src/commons/_data_source.py
+++ b/pkg-py/src/commons/_data_source.py
@@ -9,13 +9,16 @@ from __future__ import annotations
 
 import string
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import sqlalchemy
 
 from . import _duckdb
 from ._backends import Backend, DuckDBBackend, EngineBackend
 from ._sql_guard import check_query
+
+if TYPE_CHECKING:
+    from ._data_dictionary import DataDictionary
 
 __all__ = ["DataSource", "TableId", "data_source", "list_tables"]
 
@@ -70,6 +73,7 @@ class DataSource:
     tables: list[str]
     table_ids: dict[str, TableId] = field(default_factory=dict)
     pending: _PendingPins | None = None
+    dictionary: DataDictionary | None = None
 
     @classmethod
     def from_frames(cls, **frames: Any) -> DataSource:
@@ -231,23 +235,33 @@ def data_source(*args: Any, **kwargs: Any) -> DataSource:
     """Create a data source from an engine, a pins board, or named frames.
 
     A thin dispatcher over the constructors, which are the documented way in.
-    `tables` is an option for the engine and board forms; with no positional
-    source it is an ordinary frame name, so a frame may be called `tables`.
+
+    `dictionary` applies to every form, so it is always an option rather than
+    a frame name. `tables` is an option for the engine and board forms only;
+    with no positional source it is an ordinary frame name, so a frame may be
+    called `tables`.
     """
+    from ._data_dictionary import as_data_dictionary
+
     if len(args) > 1:
         raise TypeError(
             f"data_source() accepts one positional argument, got {len(args)}."
         )
-    if not args:
-        return DataSource.from_frames(**kwargs)
 
-    tables = kwargs.pop("tables", None)
-    if kwargs:
-        raise TypeError(
-            "Pass either a connection or named data frames, not both. "
-            f"Got a positional argument and the frames {sorted(kwargs)}."
-        )
-    return _from_positional(args[0], tables)
+    dictionary = as_data_dictionary(kwargs.pop("dictionary", None))
+    if args:
+        tables = kwargs.pop("tables", None)
+        if kwargs:
+            raise TypeError(
+                "Pass either a connection or named data frames, not both. "
+                f"Got a positional argument and the frames {sorted(kwargs)}."
+            )
+        source = _from_positional(args[0], tables)
+    else:
+        source = DataSource.from_frames(**kwargs)
+
+    source.dictionary = dictionary
+    return source
 
 
 def _from_positional(value: Any, tables: Any) -> DataSource:

--- a/pkg-py/src/commons/_data_source.py
+++ b/pkg-py/src/commons/_data_source.py
@@ -231,15 +231,22 @@ class DataSource:
         return self.backend.dialect()
 
 
-def data_source(*args: Any, **kwargs: Any) -> DataSource:
+def data_source(
+    *args: Any,
+    tables: Any = None,
+    dictionary: Any = None,
+    **frames: Any,
+) -> DataSource:
     """Create a data source from an engine, a pins board, or named frames.
 
     A thin dispatcher over the constructors, which are the documented way in.
 
-    `dictionary` applies to every form, so it is always an option rather than
-    a frame name. `tables` is an option for the engine and board forms only;
-    with no positional source it is an ordinary frame name, so a frame may be
-    called `tables`.
+    `tables` and `dictionary` are keyword-only options, so both names are
+    reserved in every form: a frame passed under either name is rejected
+    with a TypeError naming it, never silently consumed. `tables` selects
+    tables of the engine and board forms; `dictionary` attaches a data
+    dictionary to any form. To use either as a frame name, call
+    `DataSource.from_frames()` directly.
     """
     from ._data_dictionary import as_data_dictionary
 
@@ -248,19 +255,23 @@ def data_source(*args: Any, **kwargs: Any) -> DataSource:
             f"data_source() accepts one positional argument, got {len(args)}."
         )
 
-    dictionary = as_data_dictionary(kwargs.pop("dictionary", None))
+    resolved = as_data_dictionary(dictionary)
     if args:
-        tables = kwargs.pop("tables", None)
-        if kwargs:
+        if frames:
             raise TypeError(
                 "Pass either a connection or named data frames, not both. "
-                f"Got a positional argument and the frames {sorted(kwargs)}."
+                f"Got a positional argument and the frames {sorted(frames)}."
             )
         source = _from_positional(args[0], tables)
     else:
-        source = DataSource.from_frames(**kwargs)
+        if tables is not None:
+            raise TypeError(
+                "`tables` selects tables of an engine or pins board; with "
+                "named frames there is nothing for it to select."
+            )
+        source = DataSource.from_frames(**frames)
 
-    source.dictionary = dictionary
+    source.dictionary = resolved
     return source
 
 

--- a/pkg-py/tests/test_data_dictionary.py
+++ b/pkg-py/tests/test_data_dictionary.py
@@ -1,0 +1,349 @@
+"""Reading data-dict.yaml and rendering its three channels."""
+
+from pathlib import Path
+
+import pytest
+
+from commons._data_dictionary import DataDictionary, as_data_dictionary
+
+RETAIL = """
+name: retail sales
+description: Order and revenue data for a small retailer.
+details: Rows are order lines, not orders.
+tables:
+  - name: sales
+    description: One row per order line.
+    details: Cancelled lines are retained.
+    columns:
+      - name: revenue
+        type: number(quantity)
+        units: USD
+        description: Line revenue.
+      - name: region
+        type: enum
+        values: [Americas, APAC, EMEA]
+      - name: status
+        type: string
+        nullable: false
+        values: {O: Open, C: Closed}
+        examples: [O, C]
+      - name: score
+        type: number
+        range: [0, 100]
+  - name: regions
+    description: One row per sales region.
+relationships:
+  - join: sales.region = regions.name
+    cardinality: many-to-one
+    description: Each sales line belongs to one region.
+glossary:
+  ARR: Annual recurring revenue.
+  churn: A customer who stopped buying.
+"""
+
+
+@pytest.fixture
+def retail(tmp_path: Path) -> DataDictionary:
+    path = tmp_path / "data-dict.yaml"
+    path.write_text(RETAIL, encoding="utf-8")
+    return DataDictionary.from_path(path)
+
+
+# ---- reading -------------------------------------------------------------
+
+
+def test_tables_and_columns_are_keyed_by_name(retail: DataDictionary) -> None:
+    assert list(retail.tables) == ["sales", "regions"]
+    assert list(retail.tables["sales"].columns) == [
+        "revenue",
+        "region",
+        "status",
+        "score",
+    ]
+
+
+def test_a_pre_keyed_mapping_is_accepted(tmp_path: Path) -> None:
+    path = tmp_path / "d.yaml"
+    path.write_text(
+        "tables:\n  sales:\n    columns:\n      revenue:\n        type: number\n",
+        encoding="utf-8",
+    )
+    dictionary = DataDictionary.from_path(path)
+
+    assert list(dictionary.tables) == ["sales"]
+    assert list(dictionary.tables["sales"].columns) == ["revenue"]
+
+
+def test_a_table_without_a_name_errors(tmp_path: Path) -> None:
+    path = tmp_path / "d.yaml"
+    path.write_text("tables:\n  - description: no name here\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="name"):
+        DataDictionary.from_path(path)
+
+
+def test_a_column_without_a_name_errors(tmp_path: Path) -> None:
+    path = tmp_path / "d.yaml"
+    path.write_text(
+        "tables:\n  - name: sales\n    columns:\n      - type: number\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="column"):
+        DataDictionary.from_path(path)
+
+
+def test_unknown_fields_and_missing_sections_are_tolerated(tmp_path: Path) -> None:
+    path = tmp_path / "d.yaml"
+    path.write_text(
+        "$version: '0.1.0'\nwhat: ever\ntables:\n  - name: t\n    fancy: yes\n",
+        encoding="utf-8",
+    )
+    dictionary = DataDictionary.from_path(path)
+
+    assert list(dictionary.tables) == ["t"]
+    assert dictionary.glossary == {}
+
+
+def test_a_typed_column_missing_its_range_is_not_an_error(
+    retail: DataDictionary,
+) -> None:
+    # The reader ignores the parts of the spec it never inspects.
+    assert retail.tables["sales"].columns["revenue"].range is None
+
+
+def test_an_empty_file_reads_as_an_empty_dictionary(tmp_path: Path) -> None:
+    path = tmp_path / "d.yaml"
+    path.write_text("", encoding="utf-8")
+
+    assert DataDictionary.from_path(path).tables == {}
+
+
+def test_multi_line_prose_is_kept_as_authored(tmp_path: Path) -> None:
+    # Prose reaches the model verbatim, so it stays markdown.
+    path = tmp_path / "d.yaml"
+    path.write_text(
+        "description: |\n  First line.\n\n  Second line.\ntables: []\n",
+        encoding="utf-8",
+    )
+
+    assert DataDictionary.from_path(path).description == (
+        "First line.\n\nSecond line.\n"
+    )
+
+
+def test_as_data_dictionary_accepts_a_path_or_none(tmp_path: Path) -> None:
+    path = tmp_path / "data-dict.yaml"
+    path.write_text(RETAIL, encoding="utf-8")
+
+    assert as_data_dictionary(None) is None
+    assert isinstance(as_data_dictionary(str(path)), DataDictionary)
+    parsed = as_data_dictionary(DataDictionary.from_path(path))
+    assert parsed is not None
+    assert parsed.name == "retail sales"
+
+
+def test_as_data_dictionary_rejects_other_input() -> None:
+    with pytest.raises(TypeError, match="path"):
+        as_data_dictionary(42)
+
+
+def test_a_missing_file_names_the_path(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="nope.yaml"):
+        as_data_dictionary(str(tmp_path / "nope.yaml"))
+
+
+# ---- channel 1: always in the prompt -------------------------------------
+
+
+def test_ambient_text_carries_the_dictionary_prose(retail: DataDictionary) -> None:
+    text = retail.ambient_prompt_text()
+
+    assert "Order and revenue data for a small retailer." in text
+    assert "Rows are order lines, not orders." in text
+
+
+def test_ambient_text_is_empty_without_prose(tmp_path: Path) -> None:
+    path = tmp_path / "d.yaml"
+    path.write_text("tables:\n  - name: sales\n", encoding="utf-8")
+
+    assert DataDictionary.from_path(path).ambient_prompt_text() == ""
+
+
+def test_ambient_glossary_terms_respect_the_cap(retail: DataDictionary) -> None:
+    # "ARR" plus its body is 28 characters, so 28 admits it and 27 does not.
+    assert retail.ambient_glossary_terms() == ["ARR", "churn"]
+    assert retail.ambient_glossary_terms(cap_chars=28) == ["ARR"]
+    assert retail.ambient_glossary_terms(cap_chars=27) == []
+
+
+# ---- channel 2: first touch ----------------------------------------------
+
+
+def test_entry_text_documents_a_tables_columns(retail: DataDictionary) -> None:
+    text = retail.entry_text("sales")
+
+    assert text is not None
+    assert text.startswith("Dictionary entry for `sales`:")
+    assert "One row per order line." in text
+    assert "- revenue (number(quantity), USD): Line revenue." in text
+
+
+def test_entry_text_renders_column_facts(retail: DataDictionary) -> None:
+    text = retail.entry_text("sales")
+
+    assert text is not None
+    assert "Values: Americas, APAC, EMEA." in text
+    assert "O (Open), C (Closed)" in text
+    assert "not nullable" in text
+    assert "Range: 0 to 100." in text
+    assert "Examples: O, C." in text
+
+
+def test_entry_text_includes_relationships_that_mention_the_table(
+    retail: DataDictionary,
+) -> None:
+    text = retail.entry_text("sales")
+
+    assert text is not None
+    assert "Relationships:" in text
+    assert "sales.region = regions.name (many-to-one)" in text
+
+
+def test_entry_text_omits_relationships_that_do_not_mention_the_table(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "d.yaml"
+    path.write_text(
+        "tables:\n  - name: sales\n  - name: other\n"
+        "relationships:\n  - join: other.a = elsewhere.b\n",
+        encoding="utf-8",
+    )
+    dictionary = DataDictionary.from_path(path)
+
+    text = dictionary.entry_text("sales")
+
+    assert text is not None
+    assert "Relationships:" not in text
+
+
+def test_entry_text_is_none_for_an_undocumented_table(retail: DataDictionary) -> None:
+    assert retail.entry_text("nope") is None
+
+
+def test_terms_past_the_ambient_cap_are_co_resolved_at_first_touch(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "d.yaml"
+    path.write_text(
+        "tables:\n"
+        "  - name: sales\n"
+        "    description: Revenue by churn cohort.\n"
+        "glossary:\n"
+        "  ARR: Annual recurring revenue.\n"
+        "  churn: A customer who stopped buying.\n",
+        encoding="utf-8",
+    )
+    dictionary = DataDictionary.from_path(path)
+
+    assert dictionary.ambient_glossary_terms(cap_chars=30) == ["ARR"]
+    past_cap = dictionary.entry_text("sales", ambient_cap_chars=30)
+    assert past_cap is not None
+    assert "Definitions:" in past_cap
+    assert "churn: A customer who stopped buying." in past_cap
+
+
+def test_a_term_already_in_the_prompt_is_not_repeated_at_first_touch(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "d.yaml"
+    path.write_text(
+        "tables:\n"
+        "  - name: sales\n"
+        "    description: Revenue by churn cohort.\n"
+        "glossary:\n"
+        "  churn: A customer who stopped buying.\n",
+        encoding="utf-8",
+    )
+    dictionary = DataDictionary.from_path(path)
+
+    text = dictionary.entry_text("sales")
+
+    assert text is not None
+    assert "Definitions:" not in text
+
+
+# ---- channel 3: the search index -----------------------------------------
+
+
+def test_context_chunks_cover_dictionary_prose_tables_and_glossary(
+    retail: DataDictionary,
+) -> None:
+    chunks = retail.context_chunks()
+
+    assert "Rows are order lines, not orders." in chunks
+    assert any(chunk.startswith("Table `sales`:") for chunk in chunks)
+    assert "ARR: Annual recurring revenue." in chunks
+
+
+def test_context_chunks_skip_tables_with_no_prose(tmp_path: Path) -> None:
+    # Column-level content stays out of the store: first touch owns it, and
+    # indexing it would pay for a second copy the agent already has.
+    path = tmp_path / "d.yaml"
+    path.write_text(
+        "tables:\n  - name: bare\n    columns:\n      - name: x\n        type: number\n",
+        encoding="utf-8",
+    )
+    dictionary = DataDictionary.from_path(path)
+
+    assert dictionary.context_chunks() == []
+
+
+def test_context_chunks_do_not_carry_column_level_content(
+    retail: DataDictionary,
+) -> None:
+    assert not any("Line revenue." in chunk for chunk in retail.context_chunks())
+
+
+# ---- wiring into data_source() -------------------------------------------
+
+
+def test_data_source_accepts_a_dictionary_path(tmp_path: Path) -> None:
+    import pandas as pd
+
+    from commons import data_source
+
+    path = tmp_path / "data-dict.yaml"
+    path.write_text(RETAIL, encoding="utf-8")
+    source = data_source(sales=pd.DataFrame({"revenue": [1.0]}), dictionary=str(path))
+
+    assert source.dictionary is not None
+    assert source.dictionary.name == "retail sales"
+
+
+def test_data_source_rejects_other_dictionary_input() -> None:
+    import pandas as pd
+
+    from commons import data_source
+
+    with pytest.raises(TypeError, match="path"):
+        data_source(sales=pd.DataFrame({"revenue": [1.0]}), dictionary=42)
+
+
+def test_a_source_without_a_dictionary_has_none() -> None:
+    import pandas as pd
+
+    from commons import data_source
+
+    assert data_source(sales=pd.DataFrame({"revenue": [1.0]})).dictionary is None
+
+
+def test_a_frame_named_dictionary_fails_loudly_rather_than_silently() -> None:
+    # `dictionary` applies to every source form, so unlike `tables` it cannot
+    # double as a frame name. The failure must be named, not a silent drop.
+    import pandas as pd
+
+    from commons import data_source
+
+    with pytest.raises(TypeError, match="DataFrame"):
+        data_source(dictionary=pd.DataFrame({"revenue": [1.0]}))

--- a/pkg-py/tests/test_data_source.py
+++ b/pkg-py/tests/test_data_source.py
@@ -6,7 +6,7 @@ import duckdb
 import pandas as pd
 import pytest
 
-from commons import data_source, list_tables
+from commons import DataSource, data_source, list_tables
 
 
 def sales_frame() -> pd.DataFrame:
@@ -105,19 +105,18 @@ def test_the_guard_is_given_the_sources_dialect() -> None:
     }
 
 
-def test_a_frame_may_be_named_tables() -> None:
-    # `tables` is an option for engine and board sources only. Consuming it
-    # when no positional source was given would silently drop a frame.
-    source = data_source(tables=sales_frame())
+def test_tables_is_reserved_in_the_dispatcher() -> None:
+    # `tables` is a keyword-only option, so the dispatcher rejects it as a
+    # frame name rather than silently consuming the frame.
+    with pytest.raises(TypeError, match="`tables` selects tables"):
+        data_source(tables=sales_frame())
+
+
+def test_a_frame_may_be_named_tables_via_from_frames() -> None:
+    source = DataSource.from_frames(tables=sales_frame())
 
     assert list_tables(source) == ["tables"]
     assert source.query("SELECT count(*) AS n FROM tables") == [{"n": 3}]
-
-
-def test_a_frame_named_tables_alongside_others_is_not_dropped() -> None:
-    source = data_source(sales=sales_frame(), tables=sales_frame())
-
-    assert sorted(list_tables(source)) == ["sales", "tables"]
 
 
 def test_frame_names_colliding_only_by_case_are_rejected() -> None:


### PR DESCRIPTION
Third PR of M2. Reads the authored `data-dict.yaml` into pydantic models and renders the three channels a dictionary feeds. Closes the dictionary issue for M2.

## What it reads

The input is the authored YAML, never data-dict's JSON export, so what is validated is the published data-dict spec. Parsing is permissive about fields commons never inspects and strict about the shape it does: a `number(quantity)` column with no `range` reads without complaint, because nothing reads that range. Tables and columns may be authored as sequences with a `name` field or as a pre-keyed mapping, and both key the same way.

Prose stays as authored markdown, because it reaches the model verbatim.

## The three channels

They are methods on the dictionary rather than separate structures: `ambient_prompt_text()` and `ambient_glossary_terms()`, `entry_text(table)` for first touch, and `context_chunks()` for the search index.

`pkg-r` spreads the same rendering across `R/data-dictionary.R`, `R/prompt.R` and `R/context-layer.R`. Putting it on the dictionary means the prompt and context layers call in rather than reaching into its internals. That is a difference in shape, not in what either produces.

Glossary entries are ambient up to a size cap, and entries past it are co-resolved at first touch when an entry mentions them, so capping loses nothing. Column-level content deliberately stays out of the search index: first touch owns it, and indexing it would pay for a second copy the agent already has.

## Known gap: Governed definitions are parsed but not yet rendered

`definitions` in a data-dict  are parsed into the model, and neither channel renders them yet.

This is a known gap at this point and is staged to be implemented in a later task on M2. First touch shows a definition's **compiled SQL**, never the expression authored in the data-dict file, which `pkg-r`'s own test asserts by checking the expression is absent from the entry. Nothing correct can be shown until the compiler produces export records, so both channels will be wired in at that point. Comments mark both seams.

For the same reason `expr` is optional on the model. `pkg-r` validates it in the export spec, not in the reader, and aborts the whole read when it fails. Checking it in both places would be two spellings of one rule to keep in step.

## Two reserved keywords

`tables` and `dictionary` are explicit keyword-only parameters, so both names are reserved in every form of `data_source()`. A frame passed under either name is rejected with a TypeError naming it, never silently consumed. Frames genuinely named `tables` remain available via `DataSource.from_frames()`.

## Verification

274 tests, ruff and pyrefly clean.

