### PR TITLE
Python semantic layer: injection resolution and the public API

### DIFF
--- a/pkg-py/README.md
+++ b/pkg-py/README.md
@@ -2,6 +2,6 @@
 
 `commons` is a constructor for trustworthy data agents. Once implemented, this package will give an LLM data, semantic, and context layers to work with, tools for querying them, and A/B/C provenance tags so every answer carries a classification as to its trustworthiness.
 
-**Status: pre-alpha.** The package installs, imports, lints, type-checks, and tests, but exports nothing yet: `commons.__all__` is empty and there is no public API. Python 3.11 or later is required.
+**Status: pre-alpha.** The package exports the data and semantic layers (`data_source`, `measure`, `semantic_layer`, and their types); the agent constructor that ties them together is not implemented yet. Python 3.11 or later is required.
 
 Behavior that both implementations must agree on belongs in [`tests/shared/`](https://github.com/posit-dev/commons/tree/main/tests/shared) at the repository root, which that directory's README defines as the authority. The provenance tag rules and display copy are the first behavior governed that way; both suites run those cases.

--- a/pkg-py/README.md
+++ b/pkg-py/README.md
@@ -2,6 +2,6 @@
 
 `commons` is a constructor for trustworthy data agents. Once implemented, this package will give an LLM data, semantic, and context layers to work with, tools for querying them, and A/B/C provenance tags so every answer carries a classification as to its trustworthiness.
 
-**Status: pre-alpha.** The package exports the data and semantic layers (`data_source`, `measure`, `semantic_layer`, and their types); the agent constructor that ties them together is not implemented yet. Python 3.11 or later is required.
+**Status: pre-alpha.** The package exports the data and semantic layers (`data_source`, `list_tables`, `measure`, `semantic_layer`, and their types); the agent constructor that ties them together is not implemented yet. Python 3.11 or later is required.
 
 Behavior that both implementations must agree on belongs in [`tests/shared/`](https://github.com/posit-dev/commons/tree/main/tests/shared) at the repository root, which that directory's README defines as the authority. The provenance tag rules and display copy are the first behavior governed that way; both suites run those cases.

--- a/pkg-py/src/commons/__init__.py
+++ b/pkg-py/src/commons/__init__.py
@@ -6,5 +6,15 @@ classification as to how much it can be trusted.
 """
 
 from ._data_source import DataSource, data_source, list_tables
+from ._measures import Injected, Measure, SemanticLayer, measure, semantic_layer
 
-__all__: list[str] = ["DataSource", "data_source", "list_tables"]
+__all__: list[str] = [
+    "DataSource",
+    "Injected",
+    "Measure",
+    "SemanticLayer",
+    "data_source",
+    "list_tables",
+    "measure",
+    "semantic_layer",
+]

--- a/pkg-py/src/commons/_measures.py
+++ b/pkg-py/src/commons/_measures.py
@@ -363,6 +363,55 @@ def _resolve_ref(node: dict[str, Any], defs: dict[str, Any]) -> dict[str, Any]:
     return defs[ref.removeprefix("#/$defs/")]
 
 
+def resolve_injections(
+    measures: Mapping[str, Measure],
+    injectables: Mapping[str, Any],
+) -> dict[str, dict[str, Any]]:
+    """Bind each measure's injected arguments to the agent's named sources.
+
+    An argument named after a data source receives that source's connection,
+    even when the argument has a default. An argument matching no source keeps
+    its default; one with no default is an error, raised here so a measure
+    that can never run is caught at construction rather than mid-conversation.
+    """
+    resolved: dict[str, dict[str, Any]] = {}
+
+    for name, record in measures.items():
+        defaults = inspect.signature(record.func).parameters
+        bound: dict[str, Any] = {}
+        unresolvable: list[str] = []
+
+        for argument in record.injected:
+            if argument in injectables:
+                bound[argument] = injectables[argument]
+            elif defaults[argument].default is inspect.Parameter.empty:
+                unresolvable.append(argument)
+
+        if unresolvable:
+            raise ValueError(_unresolvable_message(name, unresolvable, injectables))
+
+        resolved[name] = bound
+
+    return resolved
+
+
+def _unresolvable_message(
+    name: str,
+    unresolvable: Sequence[str],
+    injectables: Mapping[str, Any],
+) -> str:
+    available = (
+        f"Available sources: {', '.join(injectables)}."
+        if injectables
+        else "The agent has no named data sources."
+    )
+    return (
+        f"Measure {name!r} has injected arguments matching no data source: "
+        f"{', '.join(unresolvable)}.\n"
+        f"{available}"
+    )
+
+
 @dataclass(frozen=True)
 class SemanticLayer:
     """The trusted calculations an agent can run.

--- a/pkg-py/src/commons/_measures.py
+++ b/pkg-py/src/commons/_measures.py
@@ -373,6 +373,8 @@ def resolve_injections(
     even when the argument has a default. An argument matching no source keeps
     its default; one with no default is an error, raised here so a measure
     that can never run is caught at construction rather than mid-conversation.
+    The error names the first measure with an unresolvable argument; measures
+    after it are not checked.
     """
     resolved: dict[str, dict[str, Any]] = {}
 

--- a/pkg-py/tests/measure_sources/collision_a/uses_shared.py
+++ b/pkg-py/tests/measure_sources/collision_a/uses_shared.py
@@ -4,7 +4,7 @@ that name for the rest of the process.
 
 from shared_lib import value  # type: ignore[missing-import]
 
-from commons._measures import measure
+from commons import measure
 
 
 @measure(description="From directory a.")

--- a/pkg-py/tests/measure_sources/duplicate_helpers/a_file.py
+++ b/pkg-py/tests/measure_sources/duplicate_helpers/a_file.py
@@ -1,6 +1,6 @@
 """First file, sorted before b_file.py in this directory."""
 
-from commons._measures import measure
+from commons import measure
 
 
 def helper() -> int:

--- a/pkg-py/tests/measure_sources/duplicate_helpers/b_file.py
+++ b/pkg-py/tests/measure_sources/duplicate_helpers/b_file.py
@@ -4,7 +4,7 @@ Proves directory scanning keeps the first file's source for a colliding
 helper name.
 """
 
-from commons._measures import measure
+from commons import measure
 
 
 def helper() -> int:

--- a/pkg-py/tests/measure_sources/nested/orders.py
+++ b/pkg-py/tests/measure_sources/nested/orders.py
@@ -4,7 +4,7 @@ Directory loading must not reach it, and loading it explicitly must not
 collide with the other orders.py in sys.modules.
 """
 
-from commons._measures import measure
+from commons import measure
 
 
 @measure(description="Count of nested orders.")

--- a/pkg-py/tests/measure_sources/orders.py
+++ b/pkg-py/tests/measure_sources/orders.py
@@ -4,7 +4,7 @@ from typing import Annotated, Any
 
 from pydantic import Field
 
-from commons._measures import Injected, measure
+from commons import Injected, measure
 
 
 def double(x: int) -> int:

--- a/pkg-py/tests/measure_sources/reentrant/composes_a_sibling.py
+++ b/pkg-py/tests/measure_sources/reentrant/composes_a_sibling.py
@@ -7,7 +7,7 @@ acquire it again on the same thread.
 
 from pathlib import Path
 
-from commons._measures import measure, semantic_layer
+from commons import measure, semantic_layer
 
 NESTED_LAYER = semantic_layer(Path(__file__).parent.parent / "nested" / "orders.py")
 

--- a/pkg-py/tests/measure_sources/revenue.py
+++ b/pkg-py/tests/measure_sources/revenue.py
@@ -1,6 +1,6 @@
 """A second file in the same directory, to prove directory loading."""
 
-from commons._measures import measure
+from commons import measure
 
 
 @measure(description="Total revenue.")

--- a/pkg-py/tests/measure_sources/sibling_imports/uses_helper.py
+++ b/pkg-py/tests/measure_sources/sibling_imports/uses_helper.py
@@ -4,7 +4,7 @@ Python module does.
 
 from helper_lib import double  # type: ignore[missing-import]
 
-from commons._measures import measure
+from commons import measure
 
 
 @measure(description="Doubled count.")

--- a/pkg-py/tests/measure_sources/stdlib_collision/json.py
+++ b/pkg-py/tests/measure_sources/stdlib_collision/json.py
@@ -2,7 +2,7 @@
 before the directory ever goes on sys.path.
 """
 
-from commons._measures import measure
+from commons import measure
 
 
 @measure(description="Should never load.")

--- a/pkg-py/tests/test_measures.py
+++ b/pkg-py/tests/test_measures.py
@@ -2,7 +2,6 @@
 
 import enum
 import importlib
-import inspect
 import os
 import py_compile
 import sys
@@ -20,6 +19,7 @@ from commons._measures import (
     INJECTED,
     Injected,
     Measure,
+    SemanticLayer,
     _from_module,
     _load_module_from_path,
     _load_mtimes,
@@ -979,17 +979,18 @@ def test_a_same_named_module_without_a_spec_is_a_construction_error(
         sys.modules.pop("planted", None)
 
 
-def _region_revenue(default: Any = inspect.Parameter.empty) -> Measure:
-    if default is inspect.Parameter.empty:
+def _region_revenue() -> Measure:
+    @measure(description="Revenue for a region.")
+    def region_revenue(warehouse: Injected[Any]) -> int:
+        return 0
 
-        @measure(description="Revenue for a region.")
-        def region_revenue(warehouse: Injected[Any]) -> int:
-            return 0
-    else:
+    return _as_measure(region_revenue)
 
-        @measure(description="Revenue for a region.")
-        def region_revenue(warehouse: Injected[Any] = default) -> int:
-            return 0
+
+def _region_revenue_with_default() -> Measure:
+    @measure(description="Revenue for a region.")
+    def region_revenue(warehouse: Injected[Any] = "fallback") -> int:
+        return 0
 
     return _as_measure(region_revenue)
 
@@ -1005,7 +1006,7 @@ def test_resolve_injections_binds_a_matching_source() -> None:
 
 def test_resolve_injections_prefers_a_source_over_a_default() -> None:
     connection = object()
-    layer = semantic_layer(_region_revenue(default="fallback"))
+    layer = semantic_layer(_region_revenue_with_default())
 
     resolved = resolve_injections(layer.measures, {"warehouse": connection})
 
@@ -1013,7 +1014,7 @@ def test_resolve_injections_prefers_a_source_over_a_default() -> None:
 
 
 def test_resolve_injections_leaves_an_unmatched_default_alone() -> None:
-    layer = semantic_layer(_region_revenue(default="fallback"))
+    layer = semantic_layer(_region_revenue_with_default())
 
     resolved = resolve_injections(layer.measures, {"finance": object()})
 
@@ -1060,16 +1061,45 @@ def test_resolve_injections_returns_an_entry_for_every_measure() -> None:
     assert resolve_injections(layer.measures, {}) == {"order_count": {}}
 
 
+def test_resolve_injections_resolves_every_measure_independently() -> None:
+    connection = object()
+    layer = semantic_layer(_region_revenue(), _count_measure())
+
+    resolved = resolve_injections(layer.measures, {"warehouse": connection})
+
+    assert resolved == {
+        "region_revenue": {"warehouse": connection},
+        "order_count": {},
+    }
+
+
+def test_resolve_injections_names_the_failing_measure() -> None:
+    layer = semantic_layer(_count_measure(), _region_revenue())
+
+    with pytest.raises(ValueError) as excinfo:
+        resolve_injections(layer.measures, {})
+
+    message = str(excinfo.value)
+    assert "region_revenue" in message
+    assert "order_count" not in message
+
+
 def test_public_api_exposes_the_semantic_layer() -> None:
     import commons
 
-    assert set(commons.__all__) >= {
+    assert set(commons.__all__) == {
+        "DataSource",
         "Injected",
         "Measure",
         "SemanticLayer",
+        "data_source",
+        "list_tables",
         "measure",
         "semantic_layer",
     }
+    assert commons.Injected is Injected
+    assert commons.Measure is Measure
+    assert commons.SemanticLayer is SemanticLayer
     assert commons.measure is measure
     assert commons.semantic_layer is semantic_layer
 

--- a/pkg-py/tests/test_measures.py
+++ b/pkg-py/tests/test_measures.py
@@ -2,6 +2,7 @@
 
 import enum
 import importlib
+import inspect
 import os
 import py_compile
 import sys
@@ -26,6 +27,7 @@ from commons._measures import (
     as_measure,
     measure,
     measure_schema_text,
+    resolve_injections,
     semantic_layer,
 )
 
@@ -975,6 +977,87 @@ def test_a_same_named_module_without_a_spec_is_a_construction_error(
             semantic_layer(tmp_path / "planted.py")
     finally:
         sys.modules.pop("planted", None)
+
+
+def _region_revenue(default: Any = inspect.Parameter.empty) -> Measure:
+    if default is inspect.Parameter.empty:
+
+        @measure(description="Revenue for a region.")
+        def region_revenue(warehouse: Injected[Any]) -> int:
+            return 0
+    else:
+
+        @measure(description="Revenue for a region.")
+        def region_revenue(warehouse: Injected[Any] = default) -> int:
+            return 0
+
+    return _as_measure(region_revenue)
+
+
+def test_resolve_injections_binds_a_matching_source() -> None:
+    connection = object()
+    layer = semantic_layer(_region_revenue())
+
+    resolved = resolve_injections(layer.measures, {"warehouse": connection})
+
+    assert resolved == {"region_revenue": {"warehouse": connection}}
+
+
+def test_resolve_injections_prefers_a_source_over_a_default() -> None:
+    connection = object()
+    layer = semantic_layer(_region_revenue(default="fallback"))
+
+    resolved = resolve_injections(layer.measures, {"warehouse": connection})
+
+    assert resolved["region_revenue"]["warehouse"] is connection
+
+
+def test_resolve_injections_leaves_an_unmatched_default_alone() -> None:
+    layer = semantic_layer(_region_revenue(default="fallback"))
+
+    resolved = resolve_injections(layer.measures, {"finance": object()})
+
+    assert resolved == {"region_revenue": {}}
+
+
+def test_resolve_injections_errors_on_an_unmatched_argument() -> None:
+    layer = semantic_layer(_region_revenue())
+
+    with pytest.raises(ValueError) as excinfo:
+        resolve_injections(layer.measures, {"finance": object()})
+
+    message = str(excinfo.value)
+    assert "region_revenue" in message
+    assert "warehouse" in message
+    assert "finance" in message
+
+
+def test_resolve_injections_says_when_there_are_no_named_sources() -> None:
+    layer = semantic_layer(_region_revenue())
+
+    with pytest.raises(ValueError, match="no named data sources"):
+        resolve_injections(layer.measures, {})
+
+
+def test_resolve_injections_lists_every_unmatched_argument_at_once() -> None:
+    @measure(description="Joins two warehouses.")
+    def joined(left: Injected[Any], right: Injected[Any]) -> int:
+        return 0
+
+    layer = semantic_layer(joined)
+
+    with pytest.raises(ValueError) as excinfo:
+        resolve_injections(layer.measures, {})
+
+    message = str(excinfo.value)
+    assert "left" in message
+    assert "right" in message
+
+
+def test_resolve_injections_returns_an_entry_for_every_measure() -> None:
+    layer = semantic_layer(_count_measure())
+
+    assert resolve_injections(layer.measures, {}) == {"order_count": {}}
 
 
 def test_semantic_layer_reenters_during_a_measure_files_import() -> None:

--- a/pkg-py/tests/test_measures.py
+++ b/pkg-py/tests/test_measures.py
@@ -1060,6 +1060,20 @@ def test_resolve_injections_returns_an_entry_for_every_measure() -> None:
     assert resolve_injections(layer.measures, {}) == {"order_count": {}}
 
 
+def test_public_api_exposes_the_semantic_layer() -> None:
+    import commons
+
+    assert set(commons.__all__) >= {
+        "Injected",
+        "Measure",
+        "SemanticLayer",
+        "measure",
+        "semantic_layer",
+    }
+    assert commons.measure is measure
+    assert commons.semantic_layer is semantic_layer
+
+
 def test_semantic_layer_reenters_during_a_measure_files_import() -> None:
     # A non-reentrant lock deadlocks here rather than raising, so this runs
     # on a daemon thread with a timeout: a regression fails the test instead


### PR DESCRIPTION
Last of four stacked PRs building the Python semantic layer (M3). Based on #249. Completes the milestone.

**The one-sentence version:** some measure arguments are not the model's to fill in — a database connection, say — so this PR adds the small function that matches each of those `Injected` arguments to a named data source, and it opens the public API: `measure`, `semantic_layer`, and their types are now importable from `commons` itself.

Carrying on the recipe-box analogy from #249: an `Injected` argument is an ingredient the kitchen supplies, not the chef. `resolve_injections()` is the stocking step that matches each kitchen-supplied ingredient to a named pantry, by name.

**The three rules.** For each injected argument of each measure: an argument named after a data source receives that source's connection, even when the argument has a default. One matching no source keeps its default. One matching no source *and* having no default is an error naming the measure, the arguments, and the sources that are available. The error is raised here, at construction, so a measure that can never run is caught before the agent starts a conversation, not in the middle of one.

**A deliberate boundary.** `resolve_injections(measures, injectables)` takes a plain `Mapping[str, Any]`, not a data-source type, and nothing in this milestone imports the data layer. That mirrors the R package's division of labor: `resolve_injections()` in `pkg-r/R/measures.R` also takes a plain named list, while `measure_injectables()`, the part that knows what a data source is, lives in `pkg-r/R/commons.R` with the agent. Nothing calls `resolve_injections()` yet for that reason — its caller is the agent constructor, which M5 adds, and which is where the error surfaces to a user.

**The public API.** `__all__` gains `Injected`, `Measure`, `SemanticLayer`, `measure`, and `semantic_layer`. `measure_schema_text()` and `resolve_injections()` stay private, matching the R package's export discipline: they are seams the agent layer imports, not API a measure author uses. The test fixture files move to the public import path (`from commons import Injected, measure`) in the same commit, which is what checks the surface is usable the way a measure author will use it.

Verified on both supported interpreters: 187 tests pass on 3.11 and 3.13.
