### PR TITLE
repair otelsdk envvars

### DIFF
--- a/pkg-r/R/tracing.R
+++ b/pkg-r/R/tracing.R
@@ -102,9 +102,31 @@ repair_connect_trace_routing <- function() {
     paste0("job.key=", job_key)
   )
   Sys.setenv(OTEL_RESOURCE_ATTRIBUTES = paste(pairs, collapse = ","))
+  repair_otelsdk_resource_attributes(guid, job_key)
   reset_otel_tracer_provider()
   refresh_ellmer_otel_cache()
   invisible(TRUE)
+}
+
+# otelsdk's C++ SDK statically caches its environment-derived resource when
+# ellmer first initializes OTel. Rebuilding the provider does not refresh it.
+repair_otelsdk_resource_attributes <- function(guid, job_key) {
+  if (!is_installed("otelsdk")) {
+    return(invisible(NULL))
+  }
+  tryCatch(
+    {
+      the <- asNamespace("otelsdk")$the
+      attributes <- the$default_resource_attributes
+      if (is.environment(the) && is.list(attributes)) {
+        attributes[["content.guid"]] <- guid
+        attributes[["job.key"]] <- job_key
+        the$default_resource_attributes <- attributes
+      }
+    },
+    error = function(err) NULL
+  )
+  invisible(NULL)
 }
 
 # Start and activate a span for the calling frame's lifetime, ending when it

--- a/pkg-r/tests/testthat/test-tracing.R
+++ b/pkg-r/tests/testthat/test-tracing.R
@@ -226,6 +226,39 @@ test_that("content capture is enabled when unset", {
   )
 })
 
+test_that("Connect routing repairs otelsdk's cached resource", {
+  skip_on_cran()
+  skip_if_not_installed("otelsdk")
+  withr::local_envvar(
+    POSIT_PRODUCT = "CONNECT",
+    CONNECT_CONTENT_GUID = "content-guid",
+    CONNECT_CONTENT_JOB_KEY = "job-key",
+    OTEL_RESOURCE_ATTRIBUTES = "k8s.namespace.name=test"
+  )
+  the <- asNamespace("otelsdk")$the
+  old_attributes <- the$default_resource_attributes
+  withr::defer(the$default_resource_attributes <- old_attributes)
+  local_mocked_bindings(
+    reset_otel_tracer_provider = function() NULL,
+    refresh_ellmer_otel_cache = function() NULL
+  )
+
+  expect_true(repair_connect_trace_routing())
+  expect_equal(
+    Sys.getenv("OTEL_RESOURCE_ATTRIBUTES"),
+    paste(
+      "k8s.namespace.name=test",
+      "content.guid=content-guid",
+      "job.key=job-key",
+      sep = ","
+    )
+  )
+  expect_equal(
+    the$default_resource_attributes[c("content.guid", "job.key")],
+    list("content.guid" = "content-guid", "job.key" = "job-key")
+  )
+})
+
 test_that("share_with grants wait for tracing to be live", {
   skip_if_not_installed("otel")
   withr::local_envvar(CONNECT_CONTENT_GUID = "guid")
@@ -255,6 +288,11 @@ test_that("the internals the tracing hacks rely on still exist", {
   the <- asNamespace("otel")[["the"]]
   expect_true(is.environment(the))
   expect_true(exists("tracer_provider", envir = the, inherits = FALSE))
+
+  skip_if_not_installed("otelsdk")
+  sdk_the <- asNamespace("otelsdk")[["the"]]
+  expect_true(is.environment(sdk_the))
+  expect_type(sdk_the$default_resource_attributes, "list")
 })
 
 test_that("local_commons_span is a no-op without otel", {


### PR DESCRIPTION
This fixes `trajectory_read()` on connect.posit.it. Reaches into private envs from otelsdk, so needs to fail gracefully.

For now, apps will need to be redeployed to get this fix. Once Connect itself includes PR #41837, apps should only need a restart.