### PR TITLE
Cancel run_r's later callbacks so the loop drains

### DIFF
--- a/pkg-r/R/run-r.R
+++ b/pkg-r/R/run-r.R
@@ -279,6 +279,7 @@ new_r_worker <- function(network = "none", protection = "sandbox") {
   worker$synced <- 0L
   worker$tail <- NULL
   worker$pending <- 0L
+  worker$reap <- NULL
   worker$last_used <- Sys.time()
   worker$runtime <- worker_runtime()
   # Close the child process when the agent is garbage-collected, so a session
@@ -369,6 +370,7 @@ commons_dll_path <- function() {
 }
 
 worker_close <- function(worker) {
+  cancel_worker_reap(worker)
   if (!is.null(worker$rs)) {
     try(worker$rs$close(), silent = TRUE)
     worker$rs <- NULL
@@ -424,14 +426,18 @@ worker_call <- function(runtime, name, args) {
 }
 
 # Close the worker after a quiet stretch; it respawns lazily on the next
-# call. Stray timers are harmless: they check recency before acting.
+# call. One timer per worker, not one per call: shiny::testServer() reads its
+# outputs through shiny:::wait_for_it(), which spins until the whole later
+# queue drains, so a stray timer stalls the reader for its full delay.
 schedule_worker_reap <- function(
   worker,
   idle = getOption("commons.run_r_idle_timeout", 600)
 ) {
   worker$last_used <- Sys.time()
-  later::later(
+  cancel_worker_reap(worker)
+  worker$reap <- later::later(
     function() {
+      worker$reap <- NULL
       quiet <- difftime(Sys.time(), worker$last_used, units = "secs") >= idle
       if (worker$pending == 0L && quiet) {
         worker_close(worker)
@@ -439,6 +445,15 @@ schedule_worker_reap <- function(
     },
     delay = idle + 1
   )
+  invisible(worker)
+}
+
+cancel_worker_reap <- function(worker) {
+  if (!is.null(worker$reap)) {
+    worker$reap()
+    worker$reap <- NULL
+  }
+  invisible(worker)
 }
 
 # Resolve when the in-flight $call() completes, without blocking: later_fd
@@ -453,9 +468,29 @@ worker_await <- function(
   promises::promise(function(resolve, reject) {
     settled <- FALSE
     timed_out <- FALSE
+    cancel_timeout <- NULL
+    cancel_kill <- NULL
+    cancel_watch <- NULL
+
+    # later::later() and later::later_fd() each return their own canceller.
+    # Hand every one of them back once the call settles, so a caller that
+    # waits on later::loop_empty() is not held up by a timer for a call that
+    # already finished.
+    release <- function() {
+      for (cancel in list(cancel_timeout, cancel_kill, cancel_watch)) {
+        if (!is.null(cancel)) {
+          cancel()
+        }
+      }
+      cancel_timeout <<- NULL
+      cancel_kill <<- NULL
+      cancel_watch <<- NULL
+    }
+
     settle <- function(value) {
       if (!settled) {
         settled <<- TRUE
+        release()
         resolve(value)
       }
     }
@@ -468,15 +503,17 @@ worker_await <- function(
       settle(list(failure = reason))
     }
 
-    later::later(
+    cancel_timeout <- later::later(
       function() {
+        cancel_timeout <<- NULL
         if (settled) {
           return()
         }
         timed_out <<- TRUE
         try(rs$interrupt(), silent = TRUE)
-        later::later(
+        cancel_kill <<- later::later(
           function() {
+            cancel_kill <<- NULL
             if (!settled) {
               kill_worker(sprintf(
                 "the code exceeded the %d-second time limit and the R session did not respond to an interrupt, so it was restarted. Session variables were reset.",
@@ -492,8 +529,9 @@ worker_await <- function(
 
     fd <- processx::conn_get_fileno(rs$get_poll_connection())
     poll <- function() {
-      later::later_fd(
+      cancel_watch <<- later::later_fd(
         function(ready) {
+          cancel_watch <<- NULL
           if (settled) {
             return()
           }

--- a/pkg-r/R/run-r.R
+++ b/pkg-r/R/run-r.R
@@ -437,7 +437,6 @@ schedule_worker_reap <- function(
   cancel_worker_reap(worker)
   worker$reap <- later::later(
     function() {
-      worker$reap <- NULL
       quiet <- difftime(Sys.time(), worker$last_used, units = "secs") >= idle
       if (worker$pending == 0L && quiet) {
         worker_close(worker)
@@ -468,23 +467,18 @@ worker_await <- function(
   promises::promise(function(resolve, reject) {
     settled <- FALSE
     timed_out <- FALSE
-    cancel_timeout <- NULL
     cancel_kill <- NULL
-    cancel_watch <- NULL
 
     # later::later() and later::later_fd() each return their own canceller.
     # Hand every one of them back once the call settles, so a caller that
     # waits on later::loop_empty() is not held up by a timer for a call that
-    # already finished.
+    # already finished. Calling one after its callback ran is a safe no-op.
     release <- function() {
       for (cancel in list(cancel_timeout, cancel_kill, cancel_watch)) {
         if (!is.null(cancel)) {
           cancel()
         }
       }
-      cancel_timeout <<- NULL
-      cancel_kill <<- NULL
-      cancel_watch <<- NULL
     }
 
     settle <- function(value) {
@@ -505,7 +499,6 @@ worker_await <- function(
 
     cancel_timeout <- later::later(
       function() {
-        cancel_timeout <<- NULL
         if (settled) {
           return()
         }
@@ -513,7 +506,6 @@ worker_await <- function(
         try(rs$interrupt(), silent = TRUE)
         cancel_kill <<- later::later(
           function() {
-            cancel_kill <<- NULL
             if (!settled) {
               kill_worker(sprintf(
                 "the code exceeded the %d-second time limit and the R session did not respond to an interrupt, so it was restarted. Session variables were reset.",
@@ -529,15 +521,14 @@ worker_await <- function(
 
     fd <- processx::conn_get_fileno(rs$get_poll_connection())
     poll <- function() {
-      cancel_watch <<- later::later_fd(
+      later::later_fd(
         function(ready) {
-          cancel_watch <<- NULL
           if (settled) {
             return()
           }
           msg <- tryCatch(rs$read(), error = function(e) NULL)
           if (is.null(msg)) {
-            poll()
+            cancel_watch <<- poll()
           } else if (msg$code == 200) {
             if (timed_out) {
               settle(list(failure = sprintf(
@@ -554,12 +545,12 @@ worker_await <- function(
               "the R session crashed and was restarted. Session variables were reset."
             )
           } else {
-            poll()
+            cancel_watch <<- poll()
           }
         },
         readfds = fd
       )
     }
-    poll()
+    cancel_watch <- poll()
   })
 }

--- a/pkg-r/tests/testthat/test-run-r.R
+++ b/pkg-r/tests/testthat/test-run-r.R
@@ -471,3 +471,19 @@ test_that("guardrails restore bindings after success and model errors", {
     "available after restoration"
   )
 })
+
+test_that("a settled call and a closed worker leave the later loop empty", {
+  # shiny::testServer() reads outputs through shiny:::wait_for_it(), which
+  # spins until later::loop_empty(). A callback left behind here stalls the
+  # next testServer() block for the callback's full delay.
+  worker <- local_worker()
+  store <- new_handle_store()
+  register_handle(store, test_sales())
+
+  sync_promise(run_r_tool(worker, store, "sum(r1$revenue)"))
+  expect_false(later::loop_empty())
+
+  worker_close(worker)
+  later::run_now()
+  expect_true(later::loop_empty())
+})

--- a/pkg-r/tests/testthat/test-run-r.R
+++ b/pkg-r/tests/testthat/test-run-r.R
@@ -473,17 +473,24 @@ test_that("guardrails restore bindings after success and model errors", {
 })
 
 test_that("a settled call and a closed worker leave the later loop empty", {
-  # shiny::testServer() reads outputs through shiny:::wait_for_it(), which
-  # spins until later::loop_empty(). A callback left behind here stalls the
-  # next testServer() block for the callback's full delay.
-  worker <- local_worker()
-  store <- new_handle_store()
-  register_handle(store, test_sales())
+  later::with_temp_loop({
+    # shiny::testServer() reads outputs through shiny:::wait_for_it(), which
+    # spins until later::loop_empty(). A callback left behind here stalls the
+    # next testServer() block for the callback's full delay.
+    worker <- new_r_worker()
+    store <- new_handle_store()
+    register_handle(store, test_sales())
 
-  sync_promise(run_r_tool(worker, store, "sum(r1$revenue)"))
-  expect_false(later::loop_empty())
+    tryCatch(
+      {
+        sync_promise(run_r_tool(worker, store, "sum(r1$revenue)"))
+        expect_false(later::loop_empty())
 
-  worker_close(worker)
-  later::run_now()
-  expect_true(later::loop_empty())
+        worker_close(worker)
+        later::run_now()
+        expect_true(later::loop_empty())
+      },
+      finally = worker_close(worker)
+    )
+  })
 })


### PR DESCRIPTION
Fixes #267.

> To be completely honest, this is touching R code and mechanics in a way I totally do not understand, so this fix is totally on Claude. @simonpcouch please take a look over the approach and double-check it makes sense? Thanks!

Every `run_r_tool()` call armed two `later` callbacks and cancelled neither, and `worker_close()` didn't either. `shiny::testServer()` spins until `later::loop_empty()`, so after `test-run-r.R` the loop held 70 callbacks, the farthest 601 seconds out, and the first `testServer()` block in `test-trajectory-review.R` blocked for 601.1s. That was most of the 15-minute CI job.

`later()` and `later_fd()` return canceller functions (there is no `later::cancel()`). The change, all in `pkg-r/R/run-r.R`:

- Keep cancellers for the call timeout, kill escalation, and `later_fd()` watcher in `worker_await()`, and release them all from `settle()`: a finished call leaves nothing on the loop.
- Hold one reap timer per worker instead of one per call, and cancel it in `worker_close()`. Reap timing and target selection are unchanged.
- Interrupt and kill paths are untouched: callbacks are cancelled only once `settled` is TRUE, at which point they would have returned early anyway.

Verification: the new test in `test-run-r.R` fails before the change and passes after; the viewer test went from 601.1s to 0.65s; `R CMD check` is 1m17s, `Status: OK`, no notes. Full suite passes locally in 52s (28 skips, all environmental). No tests deleted; one added.

The CI tests drop from about 15m for the "R CMD check" job to ~5m.

Worth your scrutiny:

- The ordering in `poll()`, where the callback clears `cancel_watch` and may re-arm it through a recursive `poll()` call. I am confident it is right but it is the fiddliest part.
- Whether cancelling the reap timer on every call, rather than letting redundant timers pile up and no-op, is the behaviour you want for a long-lived worker under steady load.
