### PR TITLE
Parse data-dict definition expressions

### DIFF
--- a/pkg-py/src/commons/_definitions/_expression.py
+++ b/pkg-py/src/commons/_definitions/_expression.py
@@ -1,0 +1,529 @@
+"""The definition expression parser: data-dict's expression language to an AST.
+
+Recursive descent over a character cursor, in the same shape as the R parser
+in `pkg-r/R/definition-expression.R`, so the two can be read against each
+other and against data-dict itself.
+
+Positions are 1-based because they are reported to the author as
+"at character N", which is data-dict's convention.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, NoReturn
+
+__all__ = ["Node", "parse_expression"]
+
+RESERVED_WORDS = frozenset(
+    {
+        "and",
+        "or",
+        "not",
+        "is",
+        "null",
+        "between",
+        "in",
+        "like",
+        "similar",
+        "to",
+        "when",
+        "then",
+        "else",
+        "end",
+        "true",
+        "false",
+        "inf",
+        "nan",
+        "case",
+        "columns",
+        "now",
+        "interval",
+    }
+)
+
+_WHITESPACE = frozenset(" \t\n\r\f\v")
+_COMPARISONS = (">=", "<=", "<>", "!=", "=", ">", "<")
+_INT64_MAX = "9223372036854775807"
+
+
+@dataclass(frozen=True)
+class Node:
+    """One AST node.
+
+    The per-kind payload lives in `attrs` rather than in subclasses. The type
+    checker dispatches on `kind` exactly as the R and Rust implementations do,
+    and a flat payload keeps that dispatch readable against them.
+    """
+
+    kind: str
+    start: int
+    end: int
+    attrs: dict[str, Any] = field(default_factory=dict)
+
+
+def parse_expression(text: Any) -> Node:
+    """Parse a definition expression, or raise `ValueError` saying where."""
+    if not isinstance(text, str) or not text.strip():
+        raise ValueError("A definition expression must be a non-empty string.")
+    parser = _Parser(text)
+    node = _parse_or(parser)
+    parser.skip_ws()
+    if not parser.eof():
+        parser.fail("unexpected text after the expression")
+    return node
+
+
+class _Parser:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.pos = 1
+
+    def eof(self) -> bool:
+        return self.pos > len(self.text)
+
+    def peek(self, offset: int = 0) -> str | None:
+        pos = self.pos + offset
+        if pos < 1 or pos > len(self.text):
+            return None
+        return self.text[pos - 1]
+
+    def slice(self, start: int, end: int) -> str:
+        return self.text[start - 1 : end]
+
+    def skip_ws(self) -> None:
+        while not self.eof() and self.text[self.pos - 1] in _WHITESPACE:
+            self.pos += 1
+
+    def try_char(self, char: str, skip_ws: bool = False) -> bool:
+        if skip_ws:
+            self.skip_ws()
+        if self.peek() != char:
+            return False
+        self.pos += 1
+        return True
+
+    def expect(self, char: str) -> None:
+        if not self.try_char(char):
+            self.fail(f"expected `{char}`")
+
+    def read_word(self) -> str:
+        start = self.pos
+        while not self.eof() and _identifier_part(self.peek()):
+            self.pos += 1
+        return self.slice(start, self.pos - 1)
+
+    def match_word(self, word: str) -> bool:
+        """Consume `word` when it stands alone, case-insensitively.
+
+        The saved position is restored on any failure, including a word that
+        only shares a prefix, so `interval_days` is not read as `interval`.
+        """
+        save = self.pos
+        self.skip_ws()
+        end = self.pos + len(word) - 1
+        if end > len(self.text):
+            self.pos = save
+            return False
+        candidate = self.slice(self.pos, end)
+        after = self.text[end] if end < len(self.text) else None
+        if candidate.lower() != word or _identifier_part(after):
+            self.pos = save
+            return False
+        self.pos = end + 1
+        return True
+
+    def expect_word(self, word: str) -> None:
+        if not self.match_word(word):
+            self.fail(f"expected `{word.upper()}`")
+
+    def comparison(self) -> str | None:
+        for op in _COMPARISONS:
+            end = self.pos + len(op) - 1
+            if end <= len(self.text) and self.slice(self.pos, end) == op:
+                self.pos = end + 1
+                return op
+        return None
+
+    def fail(self, message: str, at: int | None = None) -> NoReturn:
+        where = self.pos if at is None else at
+        raise ValueError(
+            f"Invalid definition expression at character {where}. {message}"
+        )
+
+
+def _identifier_start(char: str | None) -> bool:
+    return char is not None and (char.isascii() and (char.isalpha() or char == "_"))
+
+
+def _identifier_part(char: str | None) -> bool:
+    return char is not None and (char.isascii() and (char.isalnum() or char == "_"))
+
+
+def _node(kind: str, start: int, end: int, **attrs: Any) -> Node:
+    return Node(kind=kind, start=start, end=end, attrs=attrs)
+
+
+def _parse_or(parser: _Parser) -> Node:
+    lhs = _parse_and(parser)
+    while parser.match_word("or"):
+        rhs = _parse_and(parser)
+        lhs = _node("or", lhs.start, rhs.end, lhs=lhs, rhs=rhs)
+    return lhs
+
+
+def _parse_and(parser: _Parser) -> Node:
+    lhs = _parse_not(parser)
+    while parser.match_word("and"):
+        rhs = _parse_not(parser)
+        lhs = _node("and", lhs.start, rhs.end, lhs=lhs, rhs=rhs)
+    return lhs
+
+
+def _parse_not(parser: _Parser) -> Node:
+    parser.skip_ws()
+    start = parser.pos
+    if parser.match_word("not"):
+        operand = _parse_not(parser)
+        return _node("not", start, operand.end, operand=operand)
+    return _parse_predicate(parser)
+
+
+def _parse_predicate(parser: _Parser) -> Node:
+    operand = _parse_additive(parser)
+    parser.skip_ws()
+    op = parser.comparison()
+    if op is not None:
+        rhs = _parse_additive(parser)
+        return _node("compare", operand.start, rhs.end, op=op, lhs=operand, rhs=rhs)
+    if parser.match_word("is"):
+        negated = parser.match_word("not")
+        parser.expect_word("null")
+        return _node(
+            "is_null", operand.start, parser.pos - 1, operand=operand, negated=negated
+        )
+    negated = parser.match_word("not")
+    if parser.match_word("between"):
+        # The bounds are parsed at additive precedence, so the `AND` that
+        # separates them cannot be read as a conjunction.
+        lo = _parse_additive(parser)
+        parser.expect_word("and")
+        hi = _parse_additive(parser)
+        return _node(
+            "between",
+            operand.start,
+            hi.end,
+            operand=operand,
+            lo=lo,
+            hi=hi,
+            negated=negated,
+        )
+    if parser.match_word("in"):
+        parser.skip_ws()
+        parser.expect("(")
+        items = [_parse_or(parser)]
+        while parser.try_char(",", skip_ws=True):
+            items.append(_parse_or(parser))
+        parser.skip_ws()
+        parser.expect(")")
+        return _node(
+            "in",
+            operand.start,
+            parser.pos - 1,
+            operand=operand,
+            items=items,
+            negated=negated,
+        )
+    if parser.match_word("like"):
+        pattern = _parse_additive(parser)
+        return _node(
+            "like",
+            operand.start,
+            pattern.end,
+            operand=operand,
+            pattern=pattern,
+            negated=negated,
+        )
+    if parser.match_word("similar"):
+        parser.expect_word("to")
+        pattern = _parse_additive(parser)
+        return _node(
+            "similar",
+            operand.start,
+            pattern.end,
+            operand=operand,
+            pattern=pattern,
+            negated=negated,
+        )
+    if negated:
+        parser.fail("expected `BETWEEN`, `IN`, `LIKE`, or `SIMILAR TO` after `NOT`")
+    return operand
+
+
+def _parse_additive(parser: _Parser) -> Node:
+    lhs = _parse_multiplicative(parser)
+    while True:
+        parser.skip_ws()
+        op = parser.peek()
+        if op not in ("+", "-"):
+            return lhs
+        parser.pos += 1
+        rhs = _parse_multiplicative(parser)
+        lhs = _node("arithmetic", lhs.start, rhs.end, op=op, lhs=lhs, rhs=rhs)
+
+
+def _parse_multiplicative(parser: _Parser) -> Node:
+    lhs = _parse_unary(parser)
+    while True:
+        parser.skip_ws()
+        op = parser.peek()
+        if op not in ("*", "/"):
+            return lhs
+        parser.pos += 1
+        rhs = _parse_unary(parser)
+        lhs = _node("arithmetic", lhs.start, rhs.end, op=op, lhs=lhs, rhs=rhs)
+
+
+def _parse_unary(parser: _Parser) -> Node:
+    parser.skip_ws()
+    start = parser.pos
+    if parser.peek() == "-":
+        parser.pos += 1
+        operand = _parse_unary(parser)
+        return _node("negate", start, operand.end, operand=operand)
+    return _parse_primary(parser)
+
+
+def _parse_primary(parser: _Parser) -> Node:
+    parser.skip_ws()
+    start = parser.pos
+    char = parser.peek()
+    if char is None:
+        parser.fail("expected an expression")
+    if char == "(":
+        parser.pos += 1
+        inner = _parse_or(parser)
+        parser.skip_ws()
+        parser.expect(")")
+        # The parenthesised span replaces the inner one so error positions
+        # point at what the author wrote.
+        return Node(inner.kind, start, parser.pos - 1, inner.attrs)
+    if char == "'":
+        return _parse_string(parser)
+    if char == "`":
+        name = _parse_quoted_name(parser)
+        path = _parse_field_path(parser, name)
+        return _node("column", start, parser.pos - 1, path=path)
+    if char.isascii() and char.isdigit():
+        return _parse_number(parser)
+    if _identifier_start(char):
+        return _parse_word_primary(parser)
+    parser.fail("expected an expression")
+
+
+def _parse_string(parser: _Parser) -> Node:
+    start = parser.pos
+    parser.pos += 1
+    value: list[str] = []
+    while True:
+        char = parser.peek()
+        if char is None:
+            parser.fail("unterminated string literal")
+        if char == "'":
+            if parser.peek(1) == "'":
+                value.append("'")
+                parser.pos += 2
+                continue
+            parser.pos += 1
+            break
+        value.append(char)
+        parser.pos += 1
+    return _node("string", start, parser.pos - 1, value="".join(value))
+
+
+def _parse_number(parser: _Parser) -> Node:
+    start = parser.pos
+    while (char := parser.peek()) is not None and char.isascii() and char.isdigit():
+        parser.pos += 1
+    number_kind = "integer"
+    following = parser.peek(1)
+    if (
+        parser.peek() == "."
+        and following is not None
+        and following.isascii()
+        and following.isdigit()
+    ):
+        number_kind = "float"
+        parser.pos += 1
+        while (char := parser.peek()) is not None and char.isascii() and char.isdigit():
+            parser.pos += 1
+    text = parser.slice(start, parser.pos - 1)
+    if number_kind == "integer":
+        normalized = text.lstrip("0") or "0"
+        if len(normalized) > 19 or (len(normalized) == 19 and normalized > _INT64_MAX):
+            parser.fail(f"`{text}` is too large for a 64-bit integer", at=start)
+        value: Any = int(normalized)
+    else:
+        value = float(text)
+        if value in (float("inf"), float("-inf")):
+            parser.fail(f"`{text}` is too large for a number", at=start)
+    return _node("number", start, parser.pos - 1, number_kind=number_kind, value=value)
+
+
+def _parse_word_primary(parser: _Parser) -> Node:
+    start = parser.pos
+    word = parser.read_word()
+    lower = word.lower()
+    if lower in ("true", "false"):
+        return _node("boolean", start, parser.pos - 1, value=lower == "true")
+    if lower == "null":
+        return _node("null", start, parser.pos - 1)
+    if lower in ("inf", "nan"):
+        value = float("inf") if lower == "inf" else float("nan")
+        return _node("number", start, parser.pos - 1, number_kind="float", value=value)
+    if lower == "case":
+        return _parse_case(parser, start)
+    if lower == "columns":
+        return _parse_columns(parser, start)
+    if lower == "now":
+        parser.skip_ws()
+        parser.expect("(")
+        parser.skip_ws()
+        parser.expect(")")
+        return _node("now", start, parser.pos - 1)
+    if lower == "interval":
+        return _parse_interval(parser, start)
+    if lower in RESERVED_WORDS:
+        parser.fail(f"unexpected keyword `{word.upper()}`", at=start)
+    # Whitespace may sit between a function name and its arguments, so the
+    # cursor rewinds when no call turns up and the word is a column after all.
+    after = parser.pos
+    parser.skip_ws()
+    if parser.peek() == "(":
+        parser.pos += 1
+        args = _parse_arguments(parser)
+        return _node("function", start, parser.pos - 1, name=lower, args=args)
+    parser.pos = after
+    path = _parse_field_path(parser, word)
+    return _node("column", start, parser.pos - 1, path=path)
+
+
+def _parse_arguments(parser: _Parser) -> list[Node]:
+    parser.skip_ws()
+    if parser.try_char(")"):
+        return []
+    args = [_parse_or(parser)]
+    while parser.try_char(",", skip_ws=True):
+        args.append(_parse_or(parser))
+    parser.skip_ws()
+    parser.expect(")")
+    return args
+
+
+def _parse_interval(parser: _Parser, start: int) -> Node:
+    parser.skip_ws()
+    parser.expect("(")
+    n = _parse_or(parser)
+    parser.skip_ws()
+    parser.expect(",")
+    parser.skip_ws()
+    unit_start = parser.pos
+    if not _identifier_start(parser.peek()):
+        parser.fail("expected an interval unit")
+    unit = parser.read_word()
+    parser.skip_ws()
+    parser.expect(")")
+    return _node(
+        "interval",
+        start,
+        parser.pos - 1,
+        n=n,
+        unit=unit.lower(),
+        unit_start=unit_start,
+    )
+
+
+def _parse_columns(parser: _Parser, start: int) -> Node:
+    parser.skip_ws()
+    parser.expect("(")
+    parser.skip_ws()
+    char = parser.peek()
+    selector: dict[str, Any]
+    if char == "*":
+        parser.pos += 1
+        selector = {"kind": "all"}
+    elif char == "'":
+        selector = {"kind": "regex", "pattern": _parse_string(parser).attrs["value"]}
+    elif char == "[":
+        parser.pos += 1
+        names: list[str] = []
+        while True:
+            parser.skip_ws()
+            char = parser.peek()
+            if char == "`":
+                names.append(_parse_quoted_name(parser))
+            elif _identifier_start(char):
+                names.append(parser.read_word())
+            else:
+                parser.fail("expected a column name")
+            parser.skip_ws()
+            if parser.try_char(","):
+                continue
+            parser.expect("]")
+            break
+        selector = {"kind": "list", "names": names}
+    else:
+        parser.fail("expected `*`, a regex string, or `[names]`")
+    parser.skip_ws()
+    parser.expect(")")
+    return _node("columns", start, parser.pos - 1, selector=selector)
+
+
+def _parse_case(parser: _Parser, start: int) -> Node:
+    whens: list[dict[str, Node]] = []
+    while parser.match_word("when"):
+        condition = _parse_or(parser)
+        parser.expect_word("then")
+        result = _parse_or(parser)
+        whens.append({"condition": condition, "result": result})
+    if not whens:
+        parser.fail("`CASE` needs at least one `WHEN ... THEN ...`")
+    otherwise = _parse_or(parser) if parser.match_word("else") else None
+    parser.expect_word("end")
+    return _node("case", start, parser.pos - 1, whens=whens, otherwise=otherwise)
+
+
+def _parse_quoted_name(parser: _Parser) -> str:
+    parser.pos += 1
+    value: list[str] = []
+    while True:
+        char = parser.peek()
+        if char is None:
+            parser.fail("unterminated quoted name")
+        if char == "`":
+            if parser.peek(1) == "`":
+                value.append("`")
+                parser.pos += 2
+                continue
+            parser.pos += 1
+            break
+        value.append(char)
+        parser.pos += 1
+    name = "".join(value)
+    if not name:
+        parser.fail("a quoted name must not be empty")
+    return name
+
+
+def _parse_field_path(parser: _Parser, first: str) -> list[str]:
+    path = [first]
+    while parser.peek() == ".":
+        parser.pos += 1
+        char = parser.peek()
+        if char == "`":
+            path.append(_parse_quoted_name(parser))
+        elif _identifier_start(char):
+            path.append(parser.read_word())
+        else:
+            parser.fail("expected a field name after `.`")
+    return path

--- a/pkg-py/tests/test_definition_expression.py
+++ b/pkg-py/tests/test_definition_expression.py
@@ -1,0 +1,310 @@
+"""The definition expression parser: text in, AST out.
+
+These tests pin the AST shape, not just the fact that a parse succeeded. A
+parser that accepts everything and builds the wrong tree passes a
+"parses the corpus" check, and the type checker downstream would then be
+verified against the wrong input.
+"""
+
+import pytest
+
+from commons._definitions._expression import Node, parse_expression
+
+
+def test_a_bare_word_parses_as_a_single_segment_column():
+    node = parse_expression("revenue")
+    assert node.kind == "column"
+    assert node.attrs["path"] == ["revenue"]
+
+
+def test_a_dotted_word_parses_as_a_field_path():
+    path = parse_expression("payload.user.id").attrs["path"]
+    assert path == ["payload", "user", "id"]
+
+
+def test_a_backquoted_name_keeps_its_spaces():
+    assert parse_expression("`order total`").attrs["path"] == ["order total"]
+
+
+def test_a_doubled_backquote_is_one_literal_backquote():
+    assert parse_expression("`a``b`").attrs["path"] == ["a`b"]
+
+
+def test_a_doubled_quote_is_one_literal_quote_in_a_string():
+    node = parse_expression("'it''s'")
+    assert node.kind == "string"
+    assert node.attrs["value"] == "it's"
+
+
+def test_an_integer_literal_keeps_its_kind():
+    node = parse_expression("42")
+    assert node.kind == "number"
+    assert node.attrs["number_kind"] == "integer"
+    assert node.attrs["value"] == 42
+
+
+def test_a_float_literal_keeps_its_kind():
+    node = parse_expression("1.5")
+    assert node.attrs["number_kind"] == "float"
+    assert node.attrs["value"] == 1.5
+
+
+def test_leading_zeros_are_stripped_from_an_integer():
+    assert parse_expression("007").attrs["value"] == 7
+
+
+def test_a_trailing_dot_is_not_part_of_the_number():
+    # `1.` is a column field-path error, not the float 1.0: the dot only
+    # starts a fraction when a digit follows it.
+    with pytest.raises(ValueError):
+        parse_expression("1.")
+
+
+def test_an_integer_above_the_64_bit_range_is_refused():
+    with pytest.raises(ValueError, match="64-bit integer"):
+        parse_expression("9223372036854775808")
+
+
+def test_the_largest_64_bit_integer_is_accepted():
+    assert parse_expression("9223372036854775807").attrs["value"] == (2**63) - 1
+
+
+def test_booleans_and_null_are_case_insensitive():
+    assert parse_expression("TRUE").attrs["value"] is True
+    assert parse_expression("False").attrs["value"] is False
+    assert parse_expression("null").kind == "null"
+
+
+def test_addition_is_left_associative():
+    node = parse_expression("a + b + c")
+    assert node.kind == "arithmetic"
+    assert node.attrs["op"] == "+"
+    assert node.attrs["lhs"].kind == "arithmetic"
+    assert node.attrs["rhs"].attrs["path"] == ["c"]
+
+
+def test_multiplication_binds_tighter_than_addition():
+    node = parse_expression("a + b * c")
+    assert node.attrs["op"] == "+"
+    assert node.attrs["rhs"].attrs["op"] == "*"
+
+
+def test_parentheses_override_precedence():
+    node = parse_expression("(a + b) * c")
+    assert node.attrs["op"] == "*"
+    assert node.attrs["lhs"].attrs["op"] == "+"
+
+
+def test_or_binds_looser_than_and():
+    node = parse_expression("a and b or c")
+    assert node.kind == "or"
+    assert node.attrs["lhs"].kind == "and"
+
+
+def test_not_applies_to_the_predicate_that_follows_it():
+    node = parse_expression("not a = 1")
+    assert node.kind == "not"
+    assert node.attrs["operand"].kind == "compare"
+
+
+def test_unary_minus_negates_its_operand():
+    node = parse_expression("-a")
+    assert node.kind == "negate"
+    assert node.attrs["operand"].attrs["path"] == ["a"]
+
+
+@pytest.mark.parametrize("op", [">=", "<=", "<>", "!=", "=", ">", "<"])
+def test_every_comparison_operator_parses(op: str):
+    node = parse_expression(f"a {op} 1")
+    assert node.kind == "compare"
+    assert node.attrs["op"] == op
+
+
+def test_a_longer_comparison_operator_wins_over_its_prefix():
+    assert parse_expression("a >= 1").attrs["op"] == ">="
+
+
+def test_an_empty_expression_is_refused():
+    with pytest.raises(ValueError):
+        parse_expression("   ")
+
+
+def test_trailing_text_after_a_complete_expression_is_refused():
+    with pytest.raises(ValueError, match="unexpected text"):
+        parse_expression("a = 1 b")
+
+
+def test_a_node_carries_the_span_it_was_parsed_from():
+    node = parse_expression("  revenue")
+    assert isinstance(node, Node)
+    # 1-based, matching data-dict's "at character N" convention.
+    assert (node.start, node.end) == (3, 9)
+
+
+def test_is_null_parses_without_negation():
+    node = parse_expression("a is null")
+    assert node.kind == "is_null"
+    assert node.attrs["negated"] is False
+
+
+def test_is_not_null_parses_as_a_negated_is_null():
+    assert parse_expression("a is not null").attrs["negated"] is True
+
+
+def test_between_carries_both_bounds():
+    node = parse_expression("a between 1 and 10")
+    assert node.kind == "between"
+    assert node.attrs["lo"].attrs["value"] == 1
+    assert node.attrs["hi"].attrs["value"] == 10
+    assert node.attrs["negated"] is False
+
+
+def test_the_and_in_between_does_not_start_a_conjunction():
+    # `1 and 10` must be the bounds, not `a between 1` conjoined with `10`.
+    assert parse_expression("a between 1 and 10").kind == "between"
+
+
+def test_not_between_is_negated():
+    assert parse_expression("a not between 1 and 10").attrs["negated"] is True
+
+
+def test_in_collects_every_item():
+    node = parse_expression("a in ('x', 'y', 'z')")
+    assert node.kind == "in"
+    assert [item.attrs["value"] for item in node.attrs["items"]] == ["x", "y", "z"]
+
+
+def test_not_in_is_negated():
+    assert parse_expression("a not in ('x')").attrs["negated"] is True
+
+
+def test_like_carries_its_pattern():
+    node = parse_expression("a like 'x%'")
+    assert node.kind == "like"
+    assert node.attrs["pattern"].attrs["value"] == "x%"
+
+
+def test_similar_to_carries_its_pattern():
+    node = parse_expression("a similar to '^x'")
+    assert node.kind == "similar"
+    assert node.attrs["pattern"].attrs["value"] == "^x"
+
+
+def test_not_without_a_predicate_keyword_is_refused():
+    with pytest.raises(ValueError, match="BETWEEN"):
+        parse_expression("a not 'x'")
+
+
+def test_a_function_call_lowercases_its_name():
+    node = parse_expression("SUM(revenue)")
+    assert node.kind == "function"
+    assert node.attrs["name"] == "sum"
+    assert len(node.attrs["args"]) == 1
+
+
+def test_a_function_call_can_take_no_arguments():
+    assert parse_expression("count()").attrs["args"] == []
+
+
+def test_a_function_call_takes_several_arguments():
+    node = parse_expression("coalesce(a, b, 0)")
+    assert len(node.attrs["args"]) == 3
+
+
+def test_whitespace_before_the_parenthesis_still_makes_a_call():
+    assert parse_expression("sum (a)").kind == "function"
+
+
+def test_a_word_not_followed_by_a_parenthesis_is_a_column():
+    node = parse_expression("sum + 1")
+    assert node.attrs["lhs"].kind == "column"
+
+
+def test_now_takes_an_empty_argument_list():
+    assert parse_expression("now()").kind == "now"
+
+
+def test_interval_carries_its_count_and_unit():
+    node = parse_expression("interval(7, days)")
+    assert node.kind == "interval"
+    assert node.attrs["n"].attrs["value"] == 7
+    assert node.attrs["unit"] == "days"
+
+
+def test_an_interval_unit_is_lowercased():
+    assert parse_expression("interval(1, DAY)").attrs["unit"] == "day"
+
+
+def test_columns_star_selects_everything():
+    assert parse_expression("columns(*)").attrs["selector"] == {"kind": "all"}
+
+
+def test_columns_with_a_string_is_a_regex_selector():
+    selector = parse_expression("columns('^amount_')").attrs["selector"]
+    assert selector == {"kind": "regex", "pattern": "^amount_"}
+
+
+def test_columns_with_a_bracket_list_names_each_column():
+    selector = parse_expression("columns([a, `b c`])").attrs["selector"]
+    assert selector == {"kind": "list", "names": ["a", "b c"]}
+
+
+def test_columns_needs_a_recognised_selector():
+    with pytest.raises(ValueError, match="regex string"):
+        parse_expression("columns(1)")
+
+
+def test_case_collects_each_when_and_the_else():
+    node = parse_expression("case when a then 1 when b then 2 else 3 end")
+    assert node.kind == "case"
+    assert len(node.attrs["whens"]) == 2
+    assert node.attrs["otherwise"].attrs["value"] == 3
+
+
+def test_case_without_an_else_has_no_otherwise():
+    node = parse_expression("case when a then 1 end")
+    assert node.attrs["otherwise"] is None
+
+
+def test_case_needs_at_least_one_when():
+    with pytest.raises(ValueError, match="at least one"):
+        parse_expression("case end")
+
+
+def test_case_must_be_closed_with_end():
+    with pytest.raises(ValueError, match="END"):
+        parse_expression("case when a then 1")
+
+
+def _corpus_expressions(kind: str) -> list[tuple[str, str, str]]:
+    """Every authored expression in a shared corpus directory."""
+    import yaml
+
+    from tests._shared import SHARED_DIR
+
+    out: list[tuple[str, str, str]] = []
+    for path in sorted((SHARED_DIR / "definition-export" / kind).glob("*.yaml")):
+        spec = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        for table in spec.get("tables") or []:
+            for definition in table.get("definitions") or []:
+                out.append((path.name, definition["name"], definition.get("expr")))
+    return out
+
+
+def test_every_valid_corpus_expression_parses():
+    cases = _corpus_expressions("valid")
+    # An empty corpus would otherwise pass this test silently.
+    assert len(cases) == 42
+    for filename, name, expr in cases:
+        try:
+            parse_expression(expr)
+        except ValueError as error:  # pragma: no cover - only on a real failure
+            pytest.fail(f"{filename}::{name}: {expr!r} did not parse: {error}")
+
+
+def test_the_unparseable_corpus_fixture_is_refused():
+    cases = [case for case in _corpus_expressions("invalid") if case[0] == "parse.yaml"]
+    assert cases
+    for _, _, expr in cases:
+        with pytest.raises(ValueError):
+            parse_expression(expr)


### PR DESCRIPTION
First of four PRs porting the data-dict definition compiler to Python (kata f6hz, stage 1). Text in, AST out. No type checking, so nothing here produces an export record yet.

`_expression.py` follows `pkg-r/R/definition-expression.R` closely enough to diff against it, which is the only practical way to review a hand-port this size. The later PRs are `_export.py`, `_emit_duckdb.py`, then `_compile.py` and the wiring.

The tests assert the AST rather than only the absence of a parse error. A parser that accepts everything and builds the wrong tree passes a "the corpus parses" check and then silently misinforms the type checker built on top of it, so the constructs with dedicated parse functions get their own cases alongside the precedence and associativity rules.

Both shared-corpus tests passed on first run, so I confirmed they can fail: dropping `COLUMNS` support fails the valid corpus (42 expressions), and accepting a missing operand fails `parse.yaml`. A third perturbation, removing the trailing-text check, failed neither, because `amount +` is refused for its missing right operand instead. That is recorded in the commit message so the next reader does not repeat it.

One deliberate departure from R: integer literals are stored as `int` rather than as the normalized string R keeps to protect 64-bit precision. Python needs no such protection, and the range check against `9223372036854775807` is still there because data-dict's is a Rust `i64`.

Verification: 406 tests pass, ruff and pyrefly clean on `src` and `tests`.