### PR TITLE
Lower type-checked definitions to DuckDB SQL

### DIFF
--- a/pkg-py/src/commons/_definitions/_emit_duckdb.py
+++ b/pkg-py/src/commons/_definitions/_emit_duckdb.py
@@ -1,0 +1,345 @@
+"""Lowering a type-checked expression to DuckDB SQL.
+
+A port of data-dict's DuckDB emitter. Only DuckDB is ported, because commons
+does not consume data-dict's R targets, and conformance against the data-dict
+binary is the authority for what this must produce.
+
+The emitter also collects notes: places where DuckDB's semantics differ from
+data-dict's, which the model is told about rather than silently inheriting.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import Any
+
+from ._export import Ir
+
+__all__ = ["emit_duckdb"]
+
+NAN_NOTE = (
+    "DuckDB compares a NaN as equal to itself and greater than every number, "
+    "where data-dict answers false; a row holding one passes here and is "
+    "reported there."
+)
+MOD_NOTE = (
+    "DuckDB yields null for an integer modulus by zero, where data-dict yields a NaN."
+)
+SUM_NOTE = (
+    "DuckDB sums integers at 128 bits, so a total data-dict reports as an "
+    "overflow (D09) may succeed."
+)
+
+# Precedence levels, loosest first. A child binding less tightly than its
+# parent is parenthesised, and so is an equally tight child on the right,
+# because these operators are left-associative.
+_OR, _AND, _NOT, _COMPARE, _ADDITIVE, _MULTIPLICATIVE, _NEGATE, _ATOM = range(1, 9)
+
+_SIMPLE_FUNCTIONS = {
+    "length": "length",
+    "lower": "lower",
+    "upper": "upper",
+    "trim": "trim",
+    "starts_with": "starts_with",
+    "ends_with": "ends_with",
+    "abs": "abs",
+    "floor": "floor",
+    "ceil": "ceil",
+    "round": "round",
+    "is_finite": "isfinite",
+    "is_infinite": "isinf",
+    "is_nan": "isnan",
+    "min": "min",
+    "max": "max",
+    "avg": "avg",
+    "count": "count",
+    "any": "bool_or",
+    "all": "bool_and",
+}
+
+# Characters that must be escaped when a LIKE pattern becomes a regex.
+_LIKE_ESCAPES = set("\\.+*?()|[]{}^$#-&~")
+_LIKE_WILDCARD = re.compile(r"[%_]")
+
+
+class _State:
+    def __init__(self) -> None:
+        self.notes: list[str] = []
+
+    def note(self, note: str) -> None:
+        self.notes.append(note)
+
+
+def emit_duckdb(ir: Ir, selection: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Render a type-checked expression as DuckDB SQL, with its notes."""
+    state = _State()
+    if selection is None:
+        code = _child(ir, 0, "free", state)
+    else:
+        # A `COLUMNS(...)` filter is one copy of the expression per selected
+        # column, conjoined. Each copy binds at `AND` level, so anything
+        # looser inside it is parenthesised.
+        code = " AND ".join(
+            _child(ir, _AND, "free", state, _identifier(column["path"]))
+            for column in selection["columns"]
+        )
+    return {"code": code, "notes": sorted(set(state.notes))}
+
+
+def _write(node: Ir, state: _State, selected: str | None = None) -> str:
+    kind = node.kind
+    attrs = node.attrs
+    if kind == "number":
+        return _number(node)
+    if kind == "string":
+        return _string(attrs["value"])
+    if kind == "boolean":
+        return "TRUE" if attrs["value"] else "FALSE"
+    if kind == "null":
+        return "NULL"
+    if kind == "date":
+        return f"DATE '{attrs['value']}'"
+    if kind == "datetime":
+        return f"TIMESTAMP '{attrs['value']}'"
+    if kind == "now":
+        return "current_timestamp"
+    if kind == "column":
+        return _identifier(attrs["path"])
+    if kind == "selected":
+        # Substituted per column by the caller.
+        assert selected is not None
+        return selected
+    if kind == "negate":
+        return "-" + _child(attrs["operand"], _NEGATE, "right", state, selected)
+    if kind == "not":
+        return "NOT " + _child(attrs["operand"], _NOT, "right", state, selected)
+    if kind in ("and", "or"):
+        level = _AND if kind == "and" else _OR
+        return _infix(attrs["lhs"], attrs["rhs"], kind.upper(), level, state, selected)
+    if kind == "arithmetic":
+        op = attrs["op"]
+        level = _ADDITIVE if op in ("+", "-") else _MULTIPLICATIVE
+        return _infix(attrs["lhs"], attrs["rhs"], op, level, state, selected)
+    if kind == "compare":
+        if attrs["lhs"].type == "number" or attrs["rhs"].type == "number":
+            state.note(NAN_NOTE)
+        op = "<>" if attrs["op"] in ("!=", "<>") else attrs["op"]
+        return _infix(attrs["lhs"], attrs["rhs"], op, _COMPARE, state, selected)
+    if kind == "is_null":
+        operand = _child(attrs["operand"], _COMPARE, "left", state, selected)
+        return operand + (" IS NOT NULL" if attrs["negated"] else " IS NULL")
+    if kind == "between":
+        return _between(node, state, selected)
+    if kind == "in":
+        return _in(node, state, selected)
+    if kind == "like":
+        return _like(node, state, selected)
+    if kind == "similar":
+        operand = _child(attrs["operand"], 0, "free", state, selected)
+        pattern = _child(attrs["pattern"], 0, "free", state, selected)
+        prefix = "NOT " if attrs["negated"] else ""
+        return f"{prefix}regexp_full_match({operand}, {pattern})"
+    if kind == "interval":
+        return _interval(node, state, selected)
+    if kind == "case":
+        return _case(node, state, selected)
+    if kind == "function":
+        return _function(node, state, selected)
+    raise ValueError(f"No DuckDB translation for expression node {kind!r}.")
+
+
+def _between(node: Ir, state: _State, selected: str | None) -> str:
+    attrs = node.attrs
+    if any(
+        part.type == "number" for part in (attrs["operand"], attrs["lo"], attrs["hi"])
+    ):
+        state.note(NAN_NOTE)
+    operand = _child(attrs["operand"], _COMPARE, "left", state, selected)
+    lo = _child(attrs["lo"], _COMPARE, "right", state, selected)
+    hi = _child(attrs["hi"], _COMPARE, "right", state, selected)
+    op = " NOT BETWEEN " if attrs["negated"] else " BETWEEN "
+    return f"{operand}{op}{lo} AND {hi}"
+
+
+def _in(node: Ir, state: _State, selected: str | None) -> str:
+    attrs = node.attrs
+    if attrs["operand"].type == "number":
+        state.note(NAN_NOTE)
+    operand = _child(attrs["operand"], _COMPARE, "left", state, selected)
+    items = ", ".join(
+        _child(item, 0, "free", state, selected) for item in attrs["items"]
+    )
+    op = " NOT IN (" if attrs["negated"] else " IN ("
+    return f"{operand}{op}{items})"
+
+
+def _interval(node: Ir, state: _State, selected: str | None) -> str:
+    attrs = node.attrs
+    count = attrs["n"]
+    unit = attrs["unit"]
+    if count.kind == "number" and count.attrs.get("number_kind") == "integer":
+        return f"INTERVAL '{count.attrs['value']} {unit}'"
+    written = _child(count, 0, "free", state, selected)
+    return f"({written} * INTERVAL '1 {unit}')"
+
+
+def _case(node: Ir, state: _State, selected: str | None) -> str:
+    branches = "".join(
+        " WHEN {} THEN {}".format(
+            _child(branch["condition"], 0, "free", state, selected),
+            _child(branch["result"], 0, "free", state, selected),
+        )
+        for branch in node.attrs["whens"]
+    )
+    otherwise = node.attrs["otherwise"]
+    tail = (
+        f" ELSE {_child(otherwise, 0, 'free', state, selected)}"
+        if otherwise is not None
+        else ""
+    )
+    return f"CASE{branches}{tail} END"
+
+
+def _function(node: Ir, state: _State, selected: str | None) -> str:
+    name = node.attrs["name"]
+    args = [_child(arg, 0, "free", state, selected) for arg in node.attrs["args"]]
+    if name in _SIMPLE_FUNCTIONS:
+        return f"{_SIMPLE_FUNCTIONS[name]}({', '.join(args)})"
+    if name == "sum":
+        state.note(SUM_NOTE)
+        return f"sum({', '.join(args)})"
+    if name == "row_count":
+        return "count(*)"
+    if name == "count_distinct":
+        return f"count(DISTINCT {args[0]})"
+    if name == "mod":
+        # data-dict's modulus takes the sign of the divisor; DuckDB's takes the
+        # sign of the dividend, so the divisor is added back before the second
+        # mod. The divisor is written twice, once as an operand of `+`.
+        state.note(MOD_NOTE)
+        divisor = _child(node.attrs["args"][1], _ADDITIVE, "right", state, selected)
+        return f"mod(mod({args[0]}, {args[1]}) + {divisor}, {args[1]})"
+    raise ValueError(f"No DuckDB translation for function {name!r}.")
+
+
+def _like(node: Ir, state: _State, selected: str | None) -> str:
+    """Lower LIKE to the narrowest DuckDB form the pattern allows.
+
+    An authored pattern is known at compile time, so a wildcard-free one is an
+    equality and a single anchored wildcard is a prefix or suffix test. Only
+    the general case needs a regex. A pattern that is itself an expression
+    stays a LIKE, because none of that is knowable.
+    """
+    attrs = node.attrs
+    negated = attrs["negated"]
+    operand = _child(attrs["operand"], _COMPARE, "left", state, selected)
+    pattern_node = attrs["pattern"]
+    if pattern_node.kind != "string":
+        pattern = _child(pattern_node, _COMPARE, "right", state, selected)
+        op = " NOT LIKE " if negated else " LIKE "
+        return f"{operand}{op}{pattern}"
+
+    pattern = pattern_node.attrs["value"]
+    count = len(_LIKE_WILDCARD.findall(pattern))
+    if count == 0:
+        op = " <> " if negated else " = "
+        return f"{operand}{op}{_string(pattern)}"
+    prefix = "NOT " if negated else ""
+    bare = _child(attrs["operand"], 0, "free", state, selected)
+    if count == 1 and pattern.endswith("%"):
+        return f"{prefix}starts_with({bare}, {_string(pattern[:-1])})"
+    if count == 1 and pattern.startswith("%"):
+        return f"{prefix}ends_with({bare}, {_string(pattern[1:])})"
+    return f"{prefix}regexp_full_match({bare}, {_string(_like_regex(pattern))})"
+
+
+def _like_regex(pattern: str) -> str:
+    out = []
+    for char in pattern:
+        if char == "%":
+            out.append(".*")
+        elif char == "_":
+            out.append(".")
+        elif char in _LIKE_ESCAPES:
+            out.append("\\" + char)
+        else:
+            out.append(char)
+    return "^" + "".join(out) + "$"
+
+
+def _infix(
+    lhs: Ir, rhs: Ir, op: str, level: int, state: _State, selected: str | None
+) -> str:
+    left = _child(lhs, level, "left", state, selected)
+    right = _child(rhs, level, "right", state, selected)
+    return f"{left} {op} {right}"
+
+
+def _child(
+    node: Ir, parent: int, side: str, state: _State, selected: str | None = None
+) -> str:
+    own = _precedence(node)
+    code = _write(node, state, selected)
+    if own < parent or (own == parent and side == "right"):
+        return f"({code})"
+    return code
+
+
+def _precedence(node: Ir) -> int:
+    kind = node.kind
+    if kind == "or":
+        return _OR
+    if kind == "and":
+        return _AND
+    if kind == "not":
+        return _NOT
+    if kind in ("compare", "is_null", "between", "in", "like"):
+        return _COMPARE
+    if kind == "arithmetic":
+        return _ADDITIVE if node.attrs["op"] in ("+", "-") else _MULTIPLICATIVE
+    if kind == "negate":
+        return _NEGATE
+    return _ATOM
+
+
+def _identifier(path: Any) -> str:
+    segments = path if isinstance(path, list) else [path]
+    return ".".join('"{}"'.format(str(part).replace('"', '""')) for part in segments)
+
+
+def _string(value: str) -> str:
+    escaped = value.replace("'", "''")
+    return f"'{escaped}'"
+
+
+def _number(node: Ir) -> str:
+    value = node.attrs["value"]
+    if node.attrs.get("number_kind") == "integer":
+        return str(value)
+    if math.isnan(value):
+        return "CAST('NaN' AS DOUBLE)"
+    if math.isinf(value):
+        sign = "-" if value < 0 else ""
+        return f"CAST('{sign}Infinity' AS DOUBLE)"
+    text = _float(value)
+    return text if re.search(r"[.eE]", text) else text + ".0"
+
+
+def _float(value: float) -> str:
+    """The shortest fixed-point text that reads back as this exact double.
+
+    Not `repr`, which switches to exponent notation for large and small
+    magnitudes and would emit `1e+20` where data-dict emits the digits. The
+    width is widened a significant figure at a time until the text round-trips.
+    """
+    exponent = 0 if value == 0 else math.floor(math.log10(abs(value)))
+    for significant in range(1, 18):
+        places = max(0, significant - 1 - exponent)
+        candidate = f"{value:.{places}f}"
+        try:
+            if float(candidate) == value:
+                return candidate
+        except ValueError:  # pragma: no cover - a finite float always parses
+            continue
+    return f"{value:.17f}"

--- a/pkg-py/src/commons/_definitions/_emit_duckdb.py
+++ b/pkg-py/src/commons/_definitions/_emit_duckdb.py
@@ -12,9 +12,10 @@ from __future__ import annotations
 
 import math
 import re
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from ._export import Ir
+if TYPE_CHECKING:
+    from ._export import Ir
 
 __all__ = ["emit_duckdb"]
 

--- a/pkg-py/src/commons/_definitions/_export.py
+++ b/pkg-py/src/commons/_definitions/_export.py
@@ -8,7 +8,8 @@ A definition's `expr` is written in data-dict's typed expression language, not
 in the SQL dialect of the attached source, so it cannot be run as authored. It
 is parsed, type-checked against the dictionary, given an inferred kind and
 value type, and its direct column and sibling-definition references resolved.
-Lowering to a dialect happens later, against a source.
+The type-checked expression is then lowered to DuckDB SQL, with notes where
+DuckDB's semantics differ from data-dict's.
 
 Conformance against the data-dict binary is the authority here, not this code
 and not its R counterpart in `pkg-r/R/definition-export.R`.
@@ -23,6 +24,7 @@ from typing import Any
 
 import re2
 
+from ._emit_duckdb import emit_duckdb
 from ._expression import Node, parse_expression
 
 __all__ = ["DefinitionExport", "TableExport", "export_spec"]
@@ -64,7 +66,7 @@ class Ir:
 
 @dataclass
 class DefinitionExport:
-    """One definition's export record, before a source lowers it."""
+    """One definition's export record, with its DuckDB lowering."""
 
     name: str
     label: str | None
@@ -76,7 +78,7 @@ class DefinitionExport:
     type: str | None
     columns: list[str]
     definitions: list[str]
-    # Filled by the emitter once a source supplies a dialect.
+    # The DuckDB lowering and its conformance notes, filled during resolution.
     translations: list[dict[str, Any]] = field(default_factory=list)
     ir: Ir | None = None
     shape: str = "row"
@@ -259,8 +261,6 @@ def _resolve_one(
         raise ValueError(
             f"Definition {name!r} on table {table!r} has no inferred type."
         )
-
-    from ._emit_duckdb import emit_duckdb
 
     emitted = emit_duckdb(ir, state.selection)
     references = _direct_references(

--- a/pkg-py/src/commons/_definitions/_export.py
+++ b/pkg-py/src/commons/_definitions/_export.py
@@ -260,6 +260,9 @@ def _resolve_one(
             f"Definition {name!r} on table {table!r} has no inferred type."
         )
 
+    from ._emit_duckdb import emit_duckdb
+
+    emitted = emit_duckdb(ir, state.selection)
     references = _direct_references(
         definition["ast"], definition_names, set(columns), columns
     )
@@ -280,6 +283,14 @@ def _resolve_one(
         type=ir.type if ir.type in _EXPORTED_TYPES else None,
         columns=references.columns,
         definitions=references.definitions,
+        translations=[
+            {
+                "target": "SQL(duckdb)",
+                "code": emitted["code"],
+                "error": None,
+                "notes": emitted["notes"],
+            }
+        ],
         ir=ir,
         shape=ir.shape,
         selection=state.selection,

--- a/pkg-py/tests/test_definition_emit_duckdb.py
+++ b/pkg-py/tests/test_definition_emit_duckdb.py
@@ -1,0 +1,397 @@
+"""Lowering a type-checked expression to DuckDB SQL.
+
+`tests/shared/definitions.json` pins `translation.code` byte for byte and
+`notes` exactly, so this is where conformance with data-dict becomes
+complete. The unit tests below cover the parts a 42-definition corpus does
+not reach, in particular number formatting, where the failure mode is passing
+every corpus case and breaking on the next value.
+"""
+
+import json
+import shutil
+import subprocess
+
+import pytest
+import yaml
+
+from commons._definitions._export import export_spec
+from tests._shared import SHARED_DIR, load_shared_fixture
+
+DATA_DICT = shutil.which("data-dict")
+
+
+def spec(*definitions: dict, columns: list[dict] | None = None) -> dict:
+    return {
+        "tables": [
+            {
+                "name": "orders",
+                "columns": columns
+                if columns is not None
+                else [
+                    {"name": "amount", "type": "number(quantity)"},
+                    {"name": "region", "type": "string"},
+                    {"name": "created", "type": "date"},
+                    {"name": "shipped", "type": "datetime"},
+                    {"name": "paid", "type": "boolean"},
+                ],
+                "definitions": list(definitions),
+            }
+        ]
+    }
+
+
+def sql(expr: str, **columns) -> str:
+    record = export_spec(spec({"name": "d", "expr": expr}, **columns))[
+        "orders"
+    ].definitions["d"]
+    return record.translations[0]["code"]
+
+
+def notes(expr: str) -> list[str]:
+    record = export_spec(spec({"name": "d", "expr": expr}))["orders"].definitions["d"]
+    return record.translations[0]["notes"]
+
+
+# --- the record's translation ---------------------------------------------
+
+
+def test_the_translation_names_the_duckdb_target():
+    record = export_spec(spec({"name": "d", "expr": "amount > 0"}))[
+        "orders"
+    ].definitions["d"]
+    assert record.translations[0]["target"] == "SQL(duckdb)"
+    assert record.translations[0]["error"] is None
+
+
+# --- identifiers, literals, and quoting ------------------------------------
+
+
+def test_a_column_is_quoted():
+    assert sql("amount > 0") == '"amount" > 0'
+
+
+def test_a_quote_inside_an_identifier_is_doubled():
+    assert (
+        sql('`we"ird` > 0', columns=[{"name": 'we"ird', "type": "number"}])
+        == '"we""ird" > 0'
+    )
+
+
+def test_a_dotted_path_quotes_each_segment():
+    assert (
+        sql(
+            "payload.total > 0",
+            columns=[
+                {
+                    "name": "payload",
+                    "type": "struct",
+                    "fields": [{"name": "total", "type": "number"}],
+                }
+            ],
+        )
+        == '"payload"."total" > 0'
+    )
+
+
+def test_a_quote_inside_a_string_is_doubled():
+    assert sql("region = 'it''s'") == "\"region\" = 'it''s'"
+
+
+def test_booleans_and_null_are_written_in_caps():
+    assert sql("paid = true") == '"paid" = TRUE'
+    assert sql("paid = false") == '"paid" = FALSE'
+    assert sql("region is null") == '"region" IS NULL'
+    assert sql("region is not null") == '"region" IS NOT NULL'
+
+
+def test_a_date_literal_is_cast():
+    assert sql("created >= '2020-01-01'") == "\"created\" >= DATE '2020-01-01'"
+
+
+def test_a_datetime_literal_is_cast():
+    assert (
+        sql("shipped >= '2020-01-01T00:00:00Z'")
+        == "\"shipped\" >= TIMESTAMP '2020-01-01 00:00:00'"
+    )
+
+
+def test_now_becomes_current_timestamp():
+    assert sql("shipped >= now()") == '"shipped" >= current_timestamp'
+
+
+# --- numbers ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("literal", "expected"),
+    [
+        ("1", "1"),
+        ("007", "7"),
+        ("1.5", "1.5"),
+        ("0.1", "0.1"),
+        ("2.0", "2.0"),
+        ("0.12345678901234566", "0.12345678901234566"),
+    ],
+)
+def test_number_literals_are_written_exactly(literal: str, expected: str):
+    assert sql(f"amount > {literal}") == f'"amount" > {expected}'
+
+
+def test_a_float_is_written_in_fixed_notation_however_large():
+    # Python's repr would give `1e+20`, which is not what data-dict emits.
+    emitted = sql("amount > 100000000000000000000.0")
+    written = emitted.split(" > ")[1]
+    assert "e" not in written and "E" not in written
+    assert float(written) == 1e20
+
+
+def test_a_float_round_trips_to_the_value_it_came_from():
+    for literal in ["0.1", "1.5", "3.14159265358979", "0.000001"]:
+        written = sql(f"amount > {literal}").split(" > ")[1]
+        assert float(written) == float(literal), literal
+
+
+def test_a_written_float_always_looks_like_a_float():
+    assert sql("amount > 2.0").endswith("2.0")
+
+
+def test_non_finite_numbers_are_cast():
+    assert sql("amount > inf") == "\"amount\" > CAST('Infinity' AS DOUBLE)"
+    assert sql("amount > -inf") == "\"amount\" > -CAST('Infinity' AS DOUBLE)"
+    assert sql("amount > nan") == "\"amount\" > CAST('NaN' AS DOUBLE)"
+
+
+# --- precedence ------------------------------------------------------------
+
+
+def test_a_tighter_child_needs_no_parentheses():
+    assert sql("amount > 0 and paid") == '"amount" > 0 AND "paid"'
+
+
+def test_a_looser_child_is_parenthesised():
+    assert (
+        sql("(amount > 0 or paid) and region = 'x'")
+        == '("amount" > 0 OR "paid") AND "region" = \'x\''
+    )
+
+
+def test_a_right_hand_operand_of_equal_precedence_is_parenthesised():
+    assert sql("amount - (amount - amount) > 0") == (
+        '"amount" - ("amount" - "amount") > 0'
+    )
+
+
+def test_a_left_hand_operand_of_equal_precedence_is_not():
+    assert sql("amount - amount - amount > 0") == ('"amount" - "amount" - "amount" > 0')
+
+
+def test_multiplication_inside_addition_needs_no_parentheses():
+    assert sql("amount + amount * amount > 0") == ('"amount" + "amount" * "amount" > 0')
+
+
+def test_not_parenthesises_a_looser_operand():
+    assert sql("not (amount > 0 and paid)") == 'NOT ("amount" > 0 AND "paid")'
+
+
+# --- predicates ------------------------------------------------------------
+
+
+def test_between_and_its_negation():
+    assert sql("amount between 1 and 10") == '"amount" BETWEEN 1 AND 10'
+    assert sql("amount not between 1 and 10") == '"amount" NOT BETWEEN 1 AND 10'
+
+
+def test_in_and_its_negation():
+    assert sql("region in ('a', 'b')") == "\"region\" IN ('a', 'b')"
+    assert sql("region not in ('a')") == "\"region\" NOT IN ('a')"
+
+
+def test_inequality_is_written_with_one_spelling():
+    assert sql("amount != 1") == '"amount" <> 1'
+    assert sql("amount <> 1") == '"amount" <> 1'
+
+
+def test_similar_to_becomes_a_full_match():
+    assert sql("region similar to '^x'") == "regexp_full_match(\"region\", '^x')"
+
+
+def test_case_writes_each_branch():
+    assert sql("case when paid then 1 else 0 end") == (
+        'CASE WHEN "paid" THEN 1 ELSE 0 END'
+    )
+
+
+def test_case_without_an_else_omits_it():
+    assert sql("case when paid then 1 end") == 'CASE WHEN "paid" THEN 1 END'
+
+
+# --- LIKE lowering ---------------------------------------------------------
+
+
+def test_a_like_without_wildcards_becomes_equality():
+    assert sql("region like 'x'") == "\"region\" = 'x'"
+    assert sql("region not like 'x'") == "\"region\" <> 'x'"
+
+
+def test_a_trailing_wildcard_becomes_starts_with():
+    assert sql("region like 'x%'") == "starts_with(\"region\", 'x')"
+    assert sql("region not like 'x%'") == "NOT starts_with(\"region\", 'x')"
+
+
+def test_a_leading_wildcard_becomes_ends_with():
+    assert sql("region like '%x'") == "ends_with(\"region\", 'x')"
+
+
+def test_any_other_wildcard_shape_becomes_a_regex():
+    assert sql("region like '%x%'") == "regexp_full_match(\"region\", '^.*x.*$')"
+
+
+def test_a_single_character_wildcard_becomes_a_dot():
+    assert sql("region like 'a_b'") == "regexp_full_match(\"region\", '^a.b$')"
+
+
+def test_regex_metacharacters_in_a_like_pattern_are_escaped():
+    assert sql("region like 'a.b%c'") == ("regexp_full_match(\"region\", '^a\\.b.*c$')")
+
+
+def test_a_non_literal_like_pattern_stays_a_like():
+    assert sql("region like region") == '"region" LIKE "region"'
+
+
+# --- intervals -------------------------------------------------------------
+
+
+def test_an_integer_interval_is_written_as_a_literal():
+    assert sql("shipped > now() - interval(7, days)") == (
+        "\"shipped\" > current_timestamp - INTERVAL '7 days'"
+    )
+
+
+def test_a_computed_interval_is_multiplied_out():
+    assert sql("shipped > now() - interval(amount, days)") == (
+        '"shipped" > current_timestamp - ("amount" * INTERVAL \'1 days\')'
+    )
+
+
+# --- functions -------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("expr", "expected"),
+    [
+        ("lower(region)", 'lower("region")'),
+        ("upper(region)", 'upper("region")'),
+        ("trim(region)", 'trim("region")'),
+        ("length(region)", 'length("region")'),
+        ("abs(amount)", 'abs("amount")'),
+        ("is_finite(amount)", 'isfinite("amount")'),
+        ("is_infinite(amount)", 'isinf("amount")'),
+        ("is_nan(amount)", 'isnan("amount")'),
+        ("any(paid)", 'bool_or("paid")'),
+        ("all(paid)", 'bool_and("paid")'),
+        ("row_count()", "count(*)"),
+        ("count_distinct(region)", 'count(DISTINCT "region")'),
+    ],
+)
+def test_functions_map_to_their_duckdb_spelling(expr: str, expected: str):
+    assert sql(f"{expr} = {expr}").startswith(expected)
+
+
+def test_mod_is_rewritten_to_keep_the_sign_of_the_divisor():
+    assert sql("mod(amount, amount) > 0") == (
+        '"amount" > 0'.replace(
+            '"amount"',
+            'mod(mod("amount", "amount") + "amount", "amount")',
+            1,
+        )
+    )
+
+
+# --- notes -----------------------------------------------------------------
+
+
+def test_a_numeric_comparison_carries_the_nan_note():
+    assert any("NaN" in note for note in notes("amount > 0"))
+
+
+def test_a_string_comparison_carries_no_note():
+    assert notes("region = 'x'") == []
+
+
+def test_sum_carries_the_overflow_note():
+    assert any("128 bits" in note for note in notes("sum(amount)"))
+
+
+def test_mod_carries_the_modulus_note():
+    assert any("modulus by zero" in note for note in notes("mod(amount, 2) > 0"))
+
+
+def test_notes_are_sorted_and_deduplicated():
+    emitted = notes("amount > 0 and amount < 10")
+    assert emitted == sorted(set(emitted))
+
+
+# --- COLUMNS selections ----------------------------------------------------
+
+
+def test_a_selection_repeats_the_expression_for_each_column():
+    assert (
+        sql(
+            "columns([a, b]) = true",
+            columns=[
+                {"name": "a", "type": "boolean"},
+                {"name": "b", "type": "boolean"},
+            ],
+        )
+        == '"a" = TRUE AND "b" = TRUE'
+    )
+
+
+# --- conformance -----------------------------------------------------------
+
+
+def _corpus() -> list:
+    return sorted((SHARED_DIR / "definition-export" / "valid").glob("*.yaml"))
+
+
+def test_the_translation_matches_the_shared_contract():
+    fixture = load_shared_fixture("definitions")["export_records"]
+    paths = _corpus()
+    assert paths, "the shared corpus is empty"
+    checked = 0
+    for path in paths:
+        exported = export_spec(yaml.safe_load(path.read_text(encoding="utf-8")))
+        for key, case in fixture[path.name].items():
+            table, name = key.split("::")
+            translation = exported[table].definitions[name].translations[0]
+            assert translation["target"] == case["translation"]["target"], key
+            assert translation["code"] == case["translation"]["code"], key
+            assert translation["notes"] == case["translation"]["notes"], key
+            checked += 1
+    assert checked == 42
+
+
+@pytest.mark.skipif(DATA_DICT is None, reason="the data-dict CLI is not installed")
+def test_the_translation_agrees_with_an_installed_data_dict():
+    for path in _corpus():
+        result = subprocess.run(
+            [str(DATA_DICT), "export-spec", str(path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        exported = export_spec(yaml.safe_load(path.read_text(encoding="utf-8")))
+        for table in json.loads(result.stdout)["tables"]:
+            for definition in table.get("definitions") or []:
+                upstream = next(
+                    item
+                    for item in definition["translations"]
+                    if item["target"] == "SQL(duckdb)"
+                )
+                mine = (
+                    exported[table["name"]].definitions[definition["name"]]
+                ).translations[0]
+                key = f"{table['name']}::{definition['name']}"
+                assert mine["code"] == upstream["code"], key
+                assert mine["notes"] == (upstream.get("notes") or []), key

--- a/pkg-py/tests/test_definition_emit_duckdb.py
+++ b/pkg-py/tests/test_definition_emit_duckdb.py
@@ -145,6 +145,13 @@ def test_a_float_is_written_in_fixed_notation_however_large():
     assert float(written) == 1e20
 
 
+def test_a_float_is_written_in_fixed_notation_however_small():
+    # Python's repr would give `1e-06`, which is not what data-dict emits.
+    written = sql("amount > 0.000001").split(" > ")[1]
+    assert "e" not in written and "E" not in written
+    assert float(written) == 1e-6
+
+
 def test_a_float_round_trips_to_the_value_it_came_from():
     for literal in ["0.1", "1.5", "3.14159265358979", "0.000001"]:
         written = sql(f"amount > {literal}").split(" > ")[1]


### PR DESCRIPTION
Third of four PRs porting the data-dict definition compiler (kata f6hz, stage 1). Stacked on #270.

This is where conformance completes. `translation.code` is now asserted byte for byte and `notes` exactly, for all 42 corpus definitions, against the shared fixture and against an installed `data-dict` binary.

Numbers are formatted by widening the significant digits until the text reads back as the same double, which is the R algorithm rather than `repr()`. `repr()` switches to exponent notation and would emit `1e+20` where data-dict emits the digits. Perturbing the formatter to `repr()` fails only the dedicated boundary test and leaves the 42-definition corpus green, so that test earns its place: the corpus never reaches the case.

LIKE lowers to the narrowest form an authored pattern allows, so a wildcard-free pattern becomes an equality and a single anchored wildcard becomes a prefix or suffix test. A pattern that is itself an expression stays a LIKE, because none of that is knowable at compile time.

The notes are why the emitter is hand-written rather than generated through sqlglot: they are collected as the writer walks the IR, and sqlglot has no way to produce them.

`_export.py` imports the emitter inside `_resolve_one` rather than at module scope, because the emitter needs `Ir` from `_export`. Worth a look if you would rather the IR moved to its own module to break the cycle properly.

Verification: 545 tests pass, ruff and pyrefly clean.