### PR TITLE
Python context layer: fold source prose into retrieval

### DIFF
--- a/pkg-py/src/commons/_context_layer.py
+++ b/pkg-py/src/commons/_context_layer.py
@@ -20,6 +20,7 @@ from raghilda.store import DuckDBStore
 
 if TYPE_CHECKING:
     from ._data_dictionary import DataDictionary
+    from ._data_source import DataSource
 
 __all__ = ["ContextLayer", "context_layer"]
 
@@ -124,6 +125,32 @@ def _dictionary_chunks(dictionary: DataDictionary | None) -> list[str]:
     if dictionary is None:
         return []
     return dictionary.context_chunks()
+
+
+def augment_context_layer(
+    layer: ContextLayer | None, sources: Iterable[DataSource]
+) -> ContextLayer | None:
+    """Fold each source's prose into a layer the agent can retrieve from.
+
+    Returns a new layer, leaving the caller's untouched: source enrichment
+    belongs to the agent that owns the sources, so mutating the argument
+    would leak one agent's sources into the next agent built from the same
+    layer. With nothing to add, the argument comes back as it went in,
+    ``None`` included, so an agent with neither context nor a dictionary
+    has no layer rather than an empty one.
+    """
+    chunks: list[str] = []
+    for source in sources:
+        chunks.extend(_dictionary_chunks(source.dictionary))
+        # A warehouse's own semantic models contribute their retrieval prose
+        # here too, as they do in pkg-r/R/context-layer.R. This package has
+        # no semantic-model surface yet, so there is nothing to fold in.
+
+    if not chunks:
+        return layer
+
+    existing = layer.docs if layer is not None else ()
+    return ContextLayer([*existing, *chunks])
 
 
 def context_layer(

--- a/pkg-py/tests/test_context_layer.py
+++ b/pkg-py/tests/test_context_layer.py
@@ -315,17 +315,31 @@ def test_augment_gives_the_new_layer_a_fresh_store(tmp_path):
     assert "Orders" in augmented.search("orders retail")[0]
 
 
-def test_augment_folds_in_every_source():
-    first = a_source_with_dictionary({"details": "Orders from the retail system."})
-    second = a_source_with_dictionary({"glossary": {"AOV": "Average order value."}})
+# An empty case list would make the parametrized test below vacuously pass.
+def test_the_augment_fixture_is_not_empty():
+    assert SHARED["augment_context_layer"]["cases"]
 
-    augmented = augment_context_layer(None, [first, second])
 
-    assert augmented is not None
-    assert augmented.docs == (
-        "Orders from the retail system.",
-        "AOV: Average order value.",
-    )
+@pytest.mark.parametrize(
+    "case", SHARED["augment_context_layer"]["cases"], ids=lambda c: c["name"]
+)
+def test_augment_context_layer_shared_cases(case):
+    layer = None if case["docs"] is None else ContextLayer(case["docs"])
+    sources = [
+        data_source(
+            notes=pd.DataFrame({"n": [1]}),
+            dictionary=None if spec is None else DataDictionary.model_validate(spec),
+        )
+        for spec in case["dictionaries"]
+    ]
+
+    augmented = augment_context_layer(layer, sources)
+
+    if case["expected_docs"] is None:
+        assert augmented is None
+    else:
+        assert augmented is not None
+        assert list(augmented.docs) == case["expected_docs"]
 
 
 def test_a_dictionary_alone_is_searchable_context():

--- a/pkg-py/tests/test_context_layer.py
+++ b/pkg-py/tests/test_context_layer.py
@@ -1,11 +1,16 @@
 import time
 from concurrent.futures import ThreadPoolExecutor
 
+import pandas as pd
 import pytest
 from raghilda.store import DuckDBStore
 
-from commons import ContextLayer, context_layer
-from commons._context_layer import _dictionary_chunks, strip_frontmatter
+from commons import ContextLayer, context_layer, data_source
+from commons._context_layer import (
+    _dictionary_chunks,
+    augment_context_layer,
+    strip_frontmatter,
+)
 from commons._data_dictionary import DataDictionary
 
 from ._shared import load_shared_fixture
@@ -248,3 +253,93 @@ def test_dictionary_context_chunks_shared_cases(case):
     dictionary = None if spec is None else DataDictionary.model_validate(spec)
 
     assert _dictionary_chunks(dictionary) == case["expected"]
+
+
+def a_source_with_dictionary(spec):
+    """A real source over an in-memory DuckDB, carrying the given dictionary."""
+    return data_source(
+        notes=pd.DataFrame({"n": [1]}),
+        dictionary=DataDictionary.model_validate(spec),
+    )
+
+
+def test_augment_appends_dictionary_chunks_to_a_new_layer(tmp_path):
+    path = tmp_path / "notes.md"
+    path.write_text("# Revenue\nRevenue excludes tax.")
+    layer = context_layer(files=[path])
+    source = a_source_with_dictionary({"details": "Orders from the retail system."})
+
+    augmented = augment_context_layer(layer, [source])
+
+    assert augmented is not None
+    assert augmented is not layer
+    assert layer.docs == ("# Revenue\nRevenue excludes tax.",)
+    assert augmented.docs == (
+        "# Revenue\nRevenue excludes tax.",
+        "Orders from the retail system.",
+    )
+
+
+def test_augment_creates_a_layer_when_there_was_none():
+    source = a_source_with_dictionary({"details": "Orders from the retail system."})
+
+    augmented = augment_context_layer(None, [source])
+
+    assert augmented is not None
+    assert augmented.docs == ("Orders from the retail system.",)
+
+
+def test_augment_returns_the_argument_unchanged_when_there_is_nothing_to_add(tmp_path):
+    path = tmp_path / "notes.md"
+    path.write_text("# Revenue\nRevenue excludes tax.")
+    layer = context_layer(files=[path])
+    bare = data_source(notes=pd.DataFrame({"n": [1]}))
+
+    assert augment_context_layer(layer, [bare]) is layer
+    assert augment_context_layer(None, [bare]) is None
+    assert augment_context_layer(layer, []) is layer
+    assert augment_context_layer(None, []) is None
+
+
+def test_augment_gives_the_new_layer_a_fresh_store(tmp_path):
+    path = tmp_path / "notes.md"
+    path.write_text("# Revenue\nRevenue excludes tax.")
+    layer = context_layer(files=[path])
+    layer.prewarm()
+    source = a_source_with_dictionary({"details": "Orders from the retail system."})
+
+    augmented = augment_context_layer(layer, [source])
+
+    assert augmented is not None
+    assert augmented._store_cache is None
+    assert "Orders" in augmented.search("orders retail")[0]
+
+
+def test_augment_folds_in_every_source():
+    first = a_source_with_dictionary({"details": "Orders from the retail system."})
+    second = a_source_with_dictionary({"glossary": {"AOV": "Average order value."}})
+
+    augmented = augment_context_layer(None, [first, second])
+
+    assert augmented is not None
+    assert augmented.docs == (
+        "Orders from the retail system.",
+        "AOV: Average order value.",
+    )
+
+
+def test_a_dictionary_alone_is_searchable_context():
+    source = a_source_with_dictionary(
+        {
+            "details": None,
+            "tables": {},
+            "glossary": {"AOV": "Average order value, revenue divided by order count."},
+        }
+    )
+
+    layer = augment_context_layer(None, [source])
+
+    assert layer is not None
+    assert layer.search("average order value") == [
+        "AOV: Average order value, revenue divided by order count."
+    ]

--- a/pkg-r/tests/testthat/fixtures/shared/context_layer.json
+++ b/pkg-r/tests/testthat/fixtures/shared/context_layer.json
@@ -171,5 +171,102 @@
         ]
       }
     ]
+  },
+  "augment_context_layer": {
+    "description": "Folding each source's prose into an agent's context layer. The sources' chunks follow the caller's own documents and then each other in the order the sources were given, so the order a reader would expect is preserved. With no chunks to add, the layer is handed back as it was, absent included: an agent with neither context files nor dictionary prose has no layer rather than an empty one. `docs` and `expected_docs` are null for an absent layer and an empty list for a layer holding no documents; the two are not the same thing. Each entry in `dictionaries` is one source, null for a source carrying no dictionary. Whether the returned layer is a new object, and whether it carries a fresh index, is implementation detail and is not pinned here.",
+    "cases": [
+      {
+        "name": "source chunks follow the layer's own documents",
+        "docs": [
+          "Booked revenue excludes tax."
+        ],
+        "dictionaries": [
+          {
+            "details": "Orders from the retail system.",
+            "glossary": {
+              "AOV": "Average order value."
+            }
+          }
+        ],
+        "expected_docs": [
+          "Booked revenue excludes tax.",
+          "Orders from the retail system.",
+          "AOV: Average order value."
+        ]
+      },
+      {
+        "name": "a dictionary alone becomes the layer",
+        "docs": null,
+        "dictionaries": [
+          {
+            "details": "Orders from the retail system."
+          }
+        ],
+        "expected_docs": [
+          "Orders from the retail system."
+        ]
+      },
+      {
+        "name": "every source contributes, in the order given",
+        "docs": null,
+        "dictionaries": [
+          {
+            "details": "Orders from the retail system."
+          },
+          null,
+          {
+            "glossary": {
+              "AOV": "Average order value."
+            }
+          }
+        ],
+        "expected_docs": [
+          "Orders from the retail system.",
+          "AOV: Average order value."
+        ]
+      },
+      {
+        "name": "a source with no dictionary leaves the layer alone",
+        "docs": [
+          "Booked revenue excludes tax."
+        ],
+        "dictionaries": [
+          null
+        ],
+        "expected_docs": [
+          "Booked revenue excludes tax."
+        ]
+      },
+      {
+        "name": "a dictionary with no prose leaves the layer absent",
+        "docs": null,
+        "dictionaries": [
+          {
+            "details": null,
+            "tables": {
+              "orders": {
+                "description": null
+              }
+            },
+            "glossary": {}
+          }
+        ],
+        "expected_docs": null
+      },
+      {
+        "name": "an empty layer stays an empty layer",
+        "docs": [],
+        "dictionaries": [
+          null
+        ],
+        "expected_docs": []
+      },
+      {
+        "name": "no sources and no layer stays absent",
+        "docs": null,
+        "dictionaries": [],
+        "expected_docs": null
+      }
+    ]
   }
 }

--- a/pkg-r/tests/testthat/test-context-layer.R
+++ b/pkg-r/tests/testthat/test-context-layer.R
@@ -29,7 +29,6 @@ test_that("dictionary_context_chunks matches the shared cases", {
 
 test_that("augment_context_layer matches the shared cases", {
   cases <- shared_fixture("context_layer")$augment_context_layer$cases
-  # An empty list would make the loop below vacuously succeed.
   expect_gt(length(cases), 0)
 
   for (case in cases) {

--- a/pkg-r/tests/testthat/test-context-layer.R
+++ b/pkg-r/tests/testthat/test-context-layer.R
@@ -27,6 +27,36 @@ test_that("dictionary_context_chunks matches the shared cases", {
   }
 })
 
+test_that("augment_context_layer matches the shared cases", {
+  cases <- shared_fixture("context_layer")$augment_context_layer$cases
+  # An empty list would make the loop below vacuously succeed.
+  expect_gt(length(cases), 0)
+
+  for (case in cases) {
+    layer <- if (is.null(case$docs)) {
+      NULL
+    } else {
+      new_context_layer(as.character(unlist(case$docs)))
+    }
+    sources <- lapply(case$dictionaries, function(spec) {
+      dictionary <- if (is.null(spec)) NULL else new_data_dictionary(spec)
+      suppressMessages(data_source(sales = test_sales(), dictionary = dictionary))
+    })
+
+    augmented <- augment_context_layer(layer, sources)
+
+    if (is.null(case$expected_docs)) {
+      expect_null(augmented, info = case$name)
+    } else {
+      expect_identical(
+        context_layer_state(augmented)$docs,
+        as.character(unlist(case$expected_docs)),
+        info = case$name
+      )
+    }
+  }
+})
+
 test_that("context_layer indexes files and finds relevant chunks", {
   path <- withr::local_tempfile(fileext = ".md")
   writeLines(

--- a/pkg-r/tests/testthat/test-data-dictionary.R
+++ b/pkg-r/tests/testthat/test-data-dictionary.R
@@ -473,20 +473,9 @@ test_that("dictionary prose is searchable via the context layer", {
   )
 })
 
-test_that("augmenting keeps existing context docs", {
-  skip_if_not_installed("yaml")
-  path <- withr::local_tempfile(fileext = ".md")
-  writeLines("Booked revenue excludes tax.", path)
-  layer <- context_layer(files = path)
-  augmented <- augment_context_layer(layer, list(local_dict_source()))
-
-  expect_true("Booked revenue excludes tax." %in% context_layer_state(augmented)$docs)
-  expect_gt(length(context_layer_state(augmented)$docs), length(context_layer_state(layer)$docs))
-})
-
-test_that("augmenting without dictionaries is a no-op", {
-  expect_null(augment_context_layer(NULL, list(test_source())))
-})
+# Which documents augmenting produces, and that it is a no-op when there is
+# nothing to add, are pinned in tests/shared/context_layer.json and checked by
+# test-context-layer.R.
 
 test_that("agent tools share first-touch state", {
   skip_if_not_installed("yaml")

--- a/pkg-r/tests/testthat/test-data-dictionary.R
+++ b/pkg-r/tests/testthat/test-data-dictionary.R
@@ -473,9 +473,6 @@ test_that("dictionary prose is searchable via the context layer", {
   )
 })
 
-# Which documents augmenting produces, and that it is a no-op when there is
-# nothing to add, are pinned in tests/shared/context_layer.json and checked by
-# test-context-layer.R.
 
 test_that("agent tools share first-touch state", {
   skip_if_not_installed("yaml")

--- a/tests/shared/context_layer.json
+++ b/tests/shared/context_layer.json
@@ -171,5 +171,102 @@
         ]
       }
     ]
+  },
+  "augment_context_layer": {
+    "description": "Folding each source's prose into an agent's context layer. The sources' chunks follow the caller's own documents and then each other in the order the sources were given, so the order a reader would expect is preserved. With no chunks to add, the layer is handed back as it was, absent included: an agent with neither context files nor dictionary prose has no layer rather than an empty one. `docs` and `expected_docs` are null for an absent layer and an empty list for a layer holding no documents; the two are not the same thing. Each entry in `dictionaries` is one source, null for a source carrying no dictionary. Whether the returned layer is a new object, and whether it carries a fresh index, is implementation detail and is not pinned here.",
+    "cases": [
+      {
+        "name": "source chunks follow the layer's own documents",
+        "docs": [
+          "Booked revenue excludes tax."
+        ],
+        "dictionaries": [
+          {
+            "details": "Orders from the retail system.",
+            "glossary": {
+              "AOV": "Average order value."
+            }
+          }
+        ],
+        "expected_docs": [
+          "Booked revenue excludes tax.",
+          "Orders from the retail system.",
+          "AOV: Average order value."
+        ]
+      },
+      {
+        "name": "a dictionary alone becomes the layer",
+        "docs": null,
+        "dictionaries": [
+          {
+            "details": "Orders from the retail system."
+          }
+        ],
+        "expected_docs": [
+          "Orders from the retail system."
+        ]
+      },
+      {
+        "name": "every source contributes, in the order given",
+        "docs": null,
+        "dictionaries": [
+          {
+            "details": "Orders from the retail system."
+          },
+          null,
+          {
+            "glossary": {
+              "AOV": "Average order value."
+            }
+          }
+        ],
+        "expected_docs": [
+          "Orders from the retail system.",
+          "AOV: Average order value."
+        ]
+      },
+      {
+        "name": "a source with no dictionary leaves the layer alone",
+        "docs": [
+          "Booked revenue excludes tax."
+        ],
+        "dictionaries": [
+          null
+        ],
+        "expected_docs": [
+          "Booked revenue excludes tax."
+        ]
+      },
+      {
+        "name": "a dictionary with no prose leaves the layer absent",
+        "docs": null,
+        "dictionaries": [
+          {
+            "details": null,
+            "tables": {
+              "orders": {
+                "description": null
+              }
+            },
+            "glossary": {}
+          }
+        ],
+        "expected_docs": null
+      },
+      {
+        "name": "an empty layer stays an empty layer",
+        "docs": [],
+        "dictionaries": [
+          null
+        ],
+        "expected_docs": []
+      },
+      {
+        "name": "no sources and no layer stays absent",
+        "docs": null,
+        "dictionaries": [],
+        "expected_docs": null
+      }
+    ]
   }
 }


### PR DESCRIPTION
Last of four PRs for M4, the Python context layer (kata [`c8a0`](https://www.katatracker.com/)). Stacked on [#284](https://github.com/posit-dev/commons/pull/284), which adds the chunks this folds in.

`augment_context_layer(layer, sources)` appends each source's dictionary chunks and returns a new layer, so a dictionary alone is searchable context even when the caller passed no context files. It is internal, as it is in `pkg-r`; the agent constructor in M5 is what calls it.

The returned layer is always a new object with a fresh index. Source enrichment belongs to the agent that owns the sources, so mutating the caller's layer would leak one agent's sources into the next agent built from the same layer. With nothing to add the argument comes back unchanged, `None` included, so an agent with neither context files nor dictionary prose gets no layer rather than an empty one.

One deliberate gap. `pkg-r` also folds in each source's warehouse semantic models here, the Snowflake semantic views and Databricks metric views. The python side package has no surface for those yet (tracked locally as kata `gcgj`, and notes that porting the reader alone would produce records nothing consumes), so that half is a comment at the point where it will go rather than code.

## R changes

@simonpcouch 

Tests-only.

The behaviour this PR adds in Python already existed in R, and each package was testing it separately. `tests/shared/context_layer.json` gains an `augment_context_layer` section and `test-context-layer.R` gains a runner for it. The cases cover where source chunks land relative to the caller's documents, source ordering, skipping a dictionary-less source, and the distinct outcomes for an absent layer, an empty layer, and all-empty prose.

The runner replaces two hand-written tests in `test-data-dictionary.R`, with a comment at the deletion site pointing at the fixture. "dictionary prose is searchable via the context layer" stays, because it exercises BM25 ranking, which is engine-specific. The fresh-index assertion is Python-only, as the fixture notes: R holds documents in an R6 object, where the equivalent would be object identity rather than behaviour.

The runner is guarded against being vacuous (`expect_gt(length(cases), 0)`), and I verified the three-source case really builds three sources with the dictionary-less middle one skipped. `test-context-layer.R` passes at 33; `test-data-dictionary.R`, `test-definitions.R`, and `test-citations.R` also pass. Not the full R suite, for the [#268](https://github.com/posit-dev/commons/pull/268) hang. `pkg-r/tests/testthat/fixtures/shared/context_layer.json` is generated by `scripts/sync-shared-fixtures.sh` and needs no review.
