### PR TITLE
Show "information" icon (leading to modal) inline

### DIFF
--- a/pkg-r/R/provenance.R
+++ b/pkg-r/R/provenance.R
@@ -50,7 +50,7 @@ provenance_aside <- function(tag, include_cited = FALSE) {
     '<shiny-aside label="%s"%s>%s</shiny-aside>',
     escape_attr(entry$label),
     if (is.null(icon)) "" else sprintf(' icon="%s"', escape_attr(icon)),
-    paste(entry$body, as.character(provenance_info_control()), sep = "\n\n")
+    paste(entry$body, as.character(provenance_info_control()))
   )
 }
 

--- a/pkg-r/inst/www/commons-chat/commons-chat.css
+++ b/pkg-r/inst/www/commons-chat/commons-chat.css
@@ -120,7 +120,7 @@ shiny-chat-container .shiny-chat-thinking[data-streaming] {
 .commons-provenance-info {
   display: inline-flex;
   margin-left: 0.2rem;
-  vertical-align: -0.1em;
+  vertical-align: 0.1em;
 }
 
 .commons-provenance-info-trigger {
@@ -131,15 +131,15 @@ shiny-chat-container .shiny-chat-thinking[data-streaming] {
   color: var(--bs-secondary-color, #6c757d);
   display: inline-flex;
   font-family: inherit;
-  font-size: 0.625rem;
+  font-size: 0.55rem;
   font-style: normal;
   font-weight: 600;
-  height: 0.9rem;
+  height: 0.8rem;
   justify-content: center;
   line-height: 1;
   padding: 0;
   text-decoration: none;
-  width: 0.9rem;
+  width: 0.8rem;
 }
 
 .commons-provenance-info-trigger:hover {

--- a/pkg-r/inst/www/commons-chat/commons-chat.css
+++ b/pkg-r/inst/www/commons-chat/commons-chat.css
@@ -118,28 +118,28 @@ shiny-chat-container .shiny-chat-thinking[data-streaming] {
 }
 
 .commons-provenance-info {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 0.5rem;
+  display: inline-flex;
+  margin-left: 0.2rem;
+  vertical-align: -0.1em;
 }
 
 .commons-provenance-info-trigger {
   align-items: center;
   background: transparent;
-  border: 1.5px solid currentcolor;
+  border: 1px solid currentcolor;
   border-radius: 50%;
   color: var(--bs-secondary-color, #6c757d);
   display: inline-flex;
   font-family: inherit;
-  font-size: 0.75rem;
+  font-size: 0.625rem;
   font-style: normal;
   font-weight: 600;
-  height: 1.125rem;
+  height: 0.9rem;
   justify-content: center;
   line-height: 1;
   padding: 0;
   text-decoration: none;
-  width: 1.125rem;
+  width: 0.9rem;
 }
 
 .commons-provenance-info-trigger:hover {

--- a/pkg-r/tests/testthat/test-citation-browser.R
+++ b/pkg-r/tests/testthat/test-citation-browser.R
@@ -275,6 +275,17 @@ test_that("Shiny Chat distinguishes verified, cited, and untrusted asides", {
     ),
     timeout = 30 * 1000
   )
+  expect_true(
+    app$get_js(
+      paste0(
+        "(() => { const control = document.querySelector('",
+        verified_dialog,
+        " .commons-provenance-info'); return ",
+        "control.previousSibling.textContent.endsWith('data team. ') && ",
+        "getComputedStyle(control).display === 'inline-flex'; })()"
+      )
+    )
+  )
   app$get_js(
     paste0(
       "document.querySelector('",


### PR DESCRIPTION
Closes #264. Now:

> <img width="259" height="38" alt="provenance-icon-inline" src="https://github.com/user-attachments/assets/911a54e4-9b85-43e9-a6f7-6de7b2049da5" />
