### PR TITLE
nest trajectory turns in conversation records

### DIFF
--- a/pkg-r/R/trajectory-read.R
+++ b/pkg-r/R/trajectory-read.R
@@ -35,7 +35,7 @@
 #'
 #' @return A list of conversations, named by conversation id and ordered
 #'   oldest-first. Each conversation is a list with a `turns` field containing
-#'   a list of [ellmer::Turn]s. The turns carry a `last_active` attribute: a
+#'   a list of [ellmer::Turn]s and a `last_active` field containing a
 #'   `POSIXct` giving the time of the conversation's most recent chat activity.
 #'
 #' @examples
@@ -78,7 +78,11 @@ trajectory_read <- function(
   if (!is.null(n)) {
     trajectories <- utils::tail(trajectories, n)
   }
-  lapply(trajectories, function(turns) list(turns = turns))
+  lapply(trajectories, function(turns) {
+    last_active <- attr(turns, "last_active")
+    attr(turns, "last_active") <- NULL
+    list(turns = turns, last_active = last_active)
+  })
 }
 
 # Dates and date strings both resolve to local midnight; as.POSIXct() alone

--- a/pkg-r/R/trajectory-read.R
+++ b/pkg-r/R/trajectory-read.R
@@ -37,8 +37,6 @@
 #'   oldest-first. Each conversation is a list with a `turns` field containing
 #'   a list of [ellmer::Turn]s. The turns carry a `last_active` attribute: a
 #'   `POSIXct` giving the time of the conversation's most recent chat activity.
-#'   The outer list carries a `source` attribute identifying the local trace
-#'   directory or Connect content from which it was read.
 #'
 #' @examples
 #' \dontrun{
@@ -80,23 +78,7 @@ trajectory_read <- function(
   if (!is.null(n)) {
     trajectories <- utils::tail(trajectories, n)
   }
-  trajectories <- lapply(trajectories, function(turns) list(turns = turns))
-  attr(trajectories, "source") <- trajectory_source_record(resolved)
-  trajectories
-}
-
-trajectory_source_record <- function(resolved) {
-  if (identical(resolved$kind, "connect")) {
-    return(list(
-      kind = "connect",
-      server = resolved$client$server,
-      content_guid = resolved$guid
-    ))
-  }
-  list(
-    kind = "local",
-    path = normalizePath(resolved$path, mustWork = FALSE)
-  )
+  lapply(trajectories, function(turns) list(turns = turns))
 }
 
 # Dates and date strings both resolve to local midnight; as.POSIXct() alone

--- a/pkg-r/R/trajectory-read.R
+++ b/pkg-r/R/trajectory-read.R
@@ -34,11 +34,11 @@
 #' [commons()].
 #'
 #' @return A list of conversations, named by conversation id and ordered
-#'   oldest-first. Each conversation is a list of [ellmer::Turn]s and carries
-#'   a `last_active` attribute: a `POSIXct` giving the time of the
-#'   conversation's most recent chat activity. The list carries a `source`
-#'   attribute identifying the local trace directory or Connect content from
-#'   which it was read.
+#'   oldest-first. Each conversation is a list with a `turns` field containing
+#'   a list of [ellmer::Turn]s. The turns carry a `last_active` attribute: a
+#'   `POSIXct` giving the time of the conversation's most recent chat activity.
+#'   The outer list carries a `source` attribute identifying the local trace
+#'   directory or Connect content from which it was read.
 #'
 #' @examples
 #' \dontrun{
@@ -80,6 +80,7 @@ trajectory_read <- function(
   if (!is.null(n)) {
     trajectories <- utils::tail(trajectories, n)
   }
+  trajectories <- lapply(trajectories, function(turns) list(turns = turns))
   attr(trajectories, "source") <- trajectory_source_record(resolved)
   trajectories
 }

--- a/pkg-r/R/trajectory-read.R
+++ b/pkg-r/R/trajectory-read.R
@@ -78,11 +78,7 @@ trajectory_read <- function(
   if (!is.null(n)) {
     trajectories <- utils::tail(trajectories, n)
   }
-  lapply(trajectories, function(turns) {
-    last_active <- attr(turns, "last_active")
-    attr(turns, "last_active") <- NULL
-    list(turns = turns, last_active = last_active)
-  })
+  trajectories
 }
 
 # Dates and date strings both resolve to local midnight; as.POSIXct() alone
@@ -204,7 +200,11 @@ enough_trace_lines <- function(n, from, to) {
 # them as empty conversations reads like data loss, so drop them, pointing
 # at the likely cause when nothing at all carried content.
 drop_contentless <- function(trajectories) {
-  empty <- vapply(trajectories, function(turns) length(turns) == 0, logical(1))
+  empty <- vapply(
+    trajectories,
+    function(conversation) length(conversation$turns) == 0,
+    logical(1)
+  )
   if (length(trajectories) > 0 && all(empty)) {
     cli::cli_warn(c(
       "Found {length(trajectories)} conversation{?s} of spans, but none carry
@@ -657,13 +657,15 @@ build_trajectories <- function(spans) {
     function(span, id) {
       turns <- parsed[[exchange_key(span)]]
       exchanges <- split_exchanges(turns)
-      attr(turns, "last_active") <- nano_posixct(span_time(span))
       attr(turns, "provenance") <- associate_exchange_provenance(
         exchanges,
         candidates[[id]],
         id
       )
-      turns
+      list(
+        turns = turns,
+        last_active = nano_posixct(span_time(span))
+      )
     },
     latest,
     names(latest)

--- a/pkg-r/R/trajectory-review-log.R
+++ b/pkg-r/R/trajectory-review-log.R
@@ -45,10 +45,11 @@ write_conversation_review <- function(
   call = rlang::caller_env()
 ) {
   id <- names(trajectories)[[conversation]]
+  record <- trajectories[[conversation]]
   notes <- Filter(\(note) identical(note$conversation, id), notes)
   conversation_flags <- review_conversation_flags(
     id,
-    trajectories[[conversation]],
+    record$turns,
     flags
   )
   file <- review_document_path(review_dir, id)
@@ -79,7 +80,7 @@ write_conversation_review <- function(
 
   markdown <- review_document(
     id,
-    trajectories[[conversation]],
+    record,
     conversation_flags,
     notes
   )
@@ -163,19 +164,21 @@ review_user <- function(session) {
 
 review_document <- function(
   id,
-  turns,
+  conversation,
   flags,
   notes,
   updated_at = review_timestamp()
 ) {
-  last_active <- attr(turns, "last_active") %||% as.POSIXct(NA)
   metadata <- list(
     generated_by = "commons::trajectory_review",
     schema_version = 1L,
     conversation = id
   )
-  if (!is.na(last_active)) {
-    metadata$last_active <- format(last_active, "%Y-%m-%dT%H:%M:%S%z")
+  if (!is.na(conversation$last_active)) {
+    metadata$last_active <- format(
+      conversation$last_active,
+      "%Y-%m-%dT%H:%M:%S%z"
+    )
   }
   metadata <- c(
     metadata,
@@ -189,7 +192,7 @@ review_document <- function(
     )
   )
   frontmatter <- yaml::as.yaml(metadata, indent.mapping.sequence = TRUE)
-  body <- review_document_body(id, turns, flags, notes)
+  body <- review_document_body(id, conversation$turns, flags, notes)
 
   paste0("---\n", frontmatter, "---\n\n", body, "\n")
 }

--- a/pkg-r/R/trajectory-review.R
+++ b/pkg-r/R/trajectory-review.R
@@ -149,8 +149,7 @@ check_trajectories <- function(trajectories, call = rlang::caller_env()) {
   if (!ok) {
     cli::cli_abort(
       "{.arg trajectories} must be a named list of conversations as returned
-       by {.fn trajectory_read}: each with a {.code turns} list of
-       {.cls ellmer::Turn}s and a {.code last_active} {.cls POSIXct}.",
+       by {.fn trajectory_read}.",
       call = call
     )
   }

--- a/pkg-r/R/trajectory-review.R
+++ b/pkg-r/R/trajectory-review.R
@@ -95,6 +95,7 @@ trajectory_review <- function(
   check_viewer_packages()
   check_trajectories(trajectories)
   review_dir <- resolve_review_dir(review_dir)
+  trajectories <- lapply(trajectories, `[[`, "turns")
   trajectories <- drop_side_conversations(trajectories)
   trajectories[] <- lapply(trajectories, sanitize_trajectory_turns)
   summary <- summarize_trajectories(trajectories)
@@ -130,12 +131,21 @@ check_viewer_packages <- function(call = rlang::caller_env()) {
 check_trajectories <- function(trajectories, call = rlang::caller_env()) {
   ok <- is.list(trajectories) &&
     (length(trajectories) == 0 || !is.null(names(trajectories))) &&
-    all(vapply(trajectories, is.list, logical(1)))
+    all(vapply(
+      trajectories,
+      function(conversation) {
+        is.list(conversation) &&
+          "turns" %in% names(conversation) &&
+          is.list(conversation$turns)
+      },
+      logical(1)
+    ))
 
   if (!ok) {
     cli::cli_abort(
       "{.arg trajectories} must be a named list of conversations as returned
-       by {.fn trajectory_read}: each a list of {.cls ellmer::Turn}s.",
+       by {.fn trajectory_read}: each with a {.code turns} list of
+       {.cls ellmer::Turn}s.",
       call = call
     )
   }

--- a/pkg-r/R/trajectory-review.R
+++ b/pkg-r/R/trajectory-review.R
@@ -95,13 +95,11 @@ trajectory_review <- function(
   check_viewer_packages()
   check_trajectories(trajectories)
   review_dir <- resolve_review_dir(review_dir)
-  trajectories <- lapply(trajectories, function(conversation) {
-    turns <- conversation$turns
-    attr(turns, "last_active") <- conversation$last_active
-    turns
-  })
   trajectories <- drop_side_conversations(trajectories)
-  trajectories[] <- lapply(trajectories, sanitize_trajectory_turns)
+  trajectories[] <- lapply(trajectories, function(conversation) {
+    conversation$turns <- sanitize_trajectory_turns(conversation$turns)
+    conversation
+  })
   summary <- summarize_trajectories(trajectories)
   questions <- summarize_questions(trajectories)
   shiny::shinyApp(
@@ -159,7 +157,11 @@ check_trajectories <- function(trajectories, call = rlang::caller_env()) {
 }
 
 drop_side_conversations <- function(trajectories) {
-  side <- vapply(trajectories, is_side_conversation, logical(1))
+  side <- vapply(
+    trajectories,
+    function(conversation) is_side_conversation(conversation$turns),
+    logical(1)
+  )
   if (any(side)) {
     cli::cli_inform(
       "Excluding {sum(side)} logged call{?s} that {?isn't/aren't} part of the
@@ -186,7 +188,8 @@ summarize_trajectories <- function(trajectories) {
   unname(Map(conversation_record, names(trajectories), trajectories))
 }
 
-conversation_record <- function(id, turns) {
+conversation_record <- function(id, conversation) {
+  turns <- conversation$turns
   exchanges <- split_exchanges(turns)
   provenance <- attr(turns, "provenance") %||% list()
   list(
@@ -198,14 +201,15 @@ conversation_record <- function(id, turns) {
       \(record) record$provenance_tag %||% NA_character_,
       character(1)
     ),
-    last_active = attr(turns, "last_active") %||% as.POSIXct(NA)
+    last_active = conversation$last_active
   )
 }
 
 summarize_questions <- function(trajectories) {
   records <- list()
   for (i in rlang::seq2(1, length(trajectories))) {
-    turns <- trajectories[[i]]
+    conversation <- trajectories[[i]]
+    turns <- conversation$turns
     exchanges <- split_exchanges(turns)
     provenance <- attr(turns, "provenance") %||% list()
     for (j in rlang::seq2(1, length(exchanges))) {
@@ -220,7 +224,7 @@ summarize_questions <- function(trajectories) {
         } else {
           record$provenance_tag %||% NA_character_
         },
-        last_active = attr(turns, "last_active") %||% as.POSIXct(NA)
+        last_active = conversation$last_active
       )
     }
   }
@@ -563,7 +567,7 @@ viewer_server <- function(
       if (is.null(conversation)) {
         return(NULL)
       }
-      trajectory_messages(trajectories[[conversation]])
+      trajectory_messages(trajectories[[conversation]]$turns)
     })
     review_selection <- shiny::reactive({
       conversation <- selected_conversation()
@@ -746,7 +750,7 @@ viewer_server <- function(
       }
       if (
         !exchange %in%
-          seq_along(split_exchanges(trajectories[[conversation]]))
+          seq_along(split_exchanges(trajectories[[conversation]]$turns))
       ) {
         return()
       }

--- a/pkg-r/R/trajectory-review.R
+++ b/pkg-r/R/trajectory-review.R
@@ -95,7 +95,11 @@ trajectory_review <- function(
   check_viewer_packages()
   check_trajectories(trajectories)
   review_dir <- resolve_review_dir(review_dir)
-  trajectories <- lapply(trajectories, `[[`, "turns")
+  trajectories <- lapply(trajectories, function(conversation) {
+    turns <- conversation$turns
+    attr(turns, "last_active") <- conversation$last_active
+    turns
+  })
   trajectories <- drop_side_conversations(trajectories)
   trajectories[] <- lapply(trajectories, sanitize_trajectory_turns)
   summary <- summarize_trajectories(trajectories)
@@ -136,7 +140,10 @@ check_trajectories <- function(trajectories, call = rlang::caller_env()) {
       function(conversation) {
         is.list(conversation) &&
           "turns" %in% names(conversation) &&
-          is.list(conversation$turns)
+          is.list(conversation$turns) &&
+          "last_active" %in% names(conversation) &&
+          inherits(conversation$last_active, "POSIXct") &&
+          length(conversation$last_active) == 1
       },
       logical(1)
     ))
@@ -145,7 +152,7 @@ check_trajectories <- function(trajectories, call = rlang::caller_env()) {
     cli::cli_abort(
       "{.arg trajectories} must be a named list of conversations as returned
        by {.fn trajectory_read}: each with a {.code turns} list of
-       {.cls ellmer::Turn}s.",
+       {.cls ellmer::Turn}s and a {.code last_active} {.cls POSIXct}.",
       call = call
     )
   }

--- a/pkg-r/inst/skills/commons/references/iterating-from-trajectories.md
+++ b/pkg-r/inst/skills/commons/references/iterating-from-trajectories.md
@@ -46,7 +46,7 @@ trajectories <- commons::trajectory_read(
   from = Sys.Date() - 7
 )
 
-turns <- trajectories[[1]]
+turns <- trajectories[[1]][["turns"]]
 print(turns)
 ```
 

--- a/pkg-r/man/trajectory_read.Rd
+++ b/pkg-r/man/trajectory_read.Rd
@@ -35,8 +35,6 @@ A list of conversations, named by conversation id and ordered
 oldest-first. Each conversation is a list with a \code{turns} field containing
 a list of \link[ellmer:Turn]{ellmer::Turn}s. The turns carry a \code{last_active} attribute: a
 \code{POSIXct} giving the time of the conversation's most recent chat activity.
-The outer list carries a \code{source} attribute identifying the local trace
-directory or Connect content from which it was read.
 }
 \description{
 \code{trajectory_read()} reads conversation trajectories captured by

--- a/pkg-r/man/trajectory_read.Rd
+++ b/pkg-r/man/trajectory_read.Rd
@@ -32,11 +32,11 @@ history as of \code{to}.}
 }
 \value{
 A list of conversations, named by conversation id and ordered
-oldest-first. Each conversation is a list of \link[ellmer:Turn]{ellmer::Turn}s and carries
-a \code{last_active} attribute: a \code{POSIXct} giving the time of the
-conversation's most recent chat activity. The list carries a \code{source}
-attribute identifying the local trace directory or Connect content from
-which it was read.
+oldest-first. Each conversation is a list with a \code{turns} field containing
+a list of \link[ellmer:Turn]{ellmer::Turn}s. The turns carry a \code{last_active} attribute: a
+\code{POSIXct} giving the time of the conversation's most recent chat activity.
+The outer list carries a \code{source} attribute identifying the local trace
+directory or Connect content from which it was read.
 }
 \description{
 \code{trajectory_read()} reads conversation trajectories captured by

--- a/pkg-r/man/trajectory_read.Rd
+++ b/pkg-r/man/trajectory_read.Rd
@@ -33,7 +33,7 @@ history as of \code{to}.}
 \value{
 A list of conversations, named by conversation id and ordered
 oldest-first. Each conversation is a list with a \code{turns} field containing
-a list of \link[ellmer:Turn]{ellmer::Turn}s. The turns carry a \code{last_active} attribute: a
+a list of \link[ellmer:Turn]{ellmer::Turn}s and a \code{last_active} field containing a
 \code{POSIXct} giving the time of the conversation's most recent chat activity.
 }
 \description{

--- a/pkg-r/tests/testthat/_snaps/trajectory-review.md
+++ b/pkg-r/tests/testthat/_snaps/trajectory-review.md
@@ -4,5 +4,5 @@
       check_trajectories("nope")
     Condition
       Error:
-      ! `trajectories` must be a named list of conversations as returned by `trajectory_read()`: each a list of <ellmer::Turn>s.
+      ! `trajectories` must be a named list of conversations as returned by `trajectory_read()`: each with a `turns` list of <ellmer::Turn>s.
 

--- a/pkg-r/tests/testthat/_snaps/trajectory-review.md
+++ b/pkg-r/tests/testthat/_snaps/trajectory-review.md
@@ -4,5 +4,5 @@
       check_trajectories("nope")
     Condition
       Error:
-      ! `trajectories` must be a named list of conversations as returned by `trajectory_read()`: each with a `turns` list of <ellmer::Turn>s.
+      ! `trajectories` must be a named list of conversations as returned by `trajectory_read()`: each with a `turns` list of <ellmer::Turn>s and a `last_active` <POSIXct>.
 

--- a/pkg-r/tests/testthat/_snaps/trajectory-review.md
+++ b/pkg-r/tests/testthat/_snaps/trajectory-review.md
@@ -4,5 +4,5 @@
       check_trajectories("nope")
     Condition
       Error:
-      ! `trajectories` must be a named list of conversations as returned by `trajectory_read()`: each with a `turns` list of <ellmer::Turn>s and a `last_active` <POSIXct>.
+      ! `trajectories` must be a named list of conversations as returned by `trajectory_read()`.
 

--- a/pkg-r/tests/testthat/test-trajectories.R
+++ b/pkg-r/tests/testthat/test-trajectories.R
@@ -764,10 +764,6 @@ test_that("trajectory_read reads OTLP files from a directory", {
   expect_length(read_local_spans(path), 1)
   expect_named(trajectories[[1]], "turns")
   expect_s7_class(trajectories[[1]]$turns[[1]], ellmer::UserTurn)
-  expect_equal(
-    attr(trajectories, "source"),
-    list(kind = "local", path = normalizePath(path))
-  )
 })
 
 test_that("local trace files can follow a custom exporter template", {
@@ -1114,14 +1110,6 @@ test_that("trajectory_read stops Connect paging after n conversations", {
 
   expect_equal(state$served, 1)
   expect_named(trajectories, "t300")
-  expect_equal(
-    attr(trajectories, "source"),
-    list(
-      kind = "connect",
-      server = "https://connect.example.com",
-      content_guid = "ea3c1445-cb71-42df-a2f2-bdb18874ef41"
-    )
-  )
 })
 
 test_that("trajectory_read returns an empty list for a missing directory", {

--- a/pkg-r/tests/testthat/test-trajectories.R
+++ b/pkg-r/tests/testthat/test-trajectories.R
@@ -762,8 +762,9 @@ test_that("trajectory_read reads OTLP files from a directory", {
 
   expect_length(trajectories, 1)
   expect_length(read_local_spans(path), 1)
-  expect_named(trajectories[[1]], "turns")
+  expect_named(trajectories[[1]], c("turns", "last_active"))
   expect_s7_class(trajectories[[1]]$turns[[1]], ellmer::UserTurn)
+  expect_s3_class(trajectories[[1]]$last_active, "POSIXct")
 })
 
 test_that("local trace files can follow a custom exporter template", {

--- a/pkg-r/tests/testthat/test-trajectories.R
+++ b/pkg-r/tests/testthat/test-trajectories.R
@@ -762,7 +762,8 @@ test_that("trajectory_read reads OTLP files from a directory", {
 
   expect_length(trajectories, 1)
   expect_length(read_local_spans(path), 1)
-  expect_s7_class(trajectories[[1]][[1]], ellmer::UserTurn)
+  expect_named(trajectories[[1]], "turns")
+  expect_s7_class(trajectories[[1]]$turns[[1]], ellmer::UserTurn)
   expect_equal(
     attr(trajectories, "source"),
     list(kind = "local", path = normalizePath(path))
@@ -834,7 +835,7 @@ test_that("trajectory_read drops content-less conversations, keeping the rest", 
 
   expect_snapshot(.res <- trajectory_read(path))
   expect_length(.res, 1)
-  expect_s7_class(.res[[1]][[1]], ellmer::UserTurn)
+  expect_s7_class(.res[[1]]$turns[[1]], ellmer::UserTurn)
 })
 
 test_that("from/to filter conversations by chat-span start time", {
@@ -886,8 +887,11 @@ test_that("a conversation continuing past `to` returns history as of `to`", {
   full <- trajectory_read(path)
   as_of <- trajectory_read(path, to = .POSIXct(200, tz = "UTC"))
 
-  expect_s7_class(full[[1]][[length(full[[1]])]], ellmer::AssistantTurn)
-  expect_length(as_of[[1]], length(full[[1]]) - 1)
+  expect_s7_class(
+    full[[1]]$turns[[length(full[[1]]$turns)]],
+    ellmer::AssistantTurn
+  )
+  expect_length(as_of[[1]]$turns, length(full[[1]]$turns) - 1)
 })
 
 test_that("n keeps the most recent conversations", {

--- a/pkg-r/tests/testthat/test-trajectories.R
+++ b/pkg-r/tests/testthat/test-trajectories.R
@@ -45,7 +45,7 @@ test_that("trajectories rebuild ellmer turns from semconv messages", {
   trajectories <- build_trajectories(spans)
 
   expect_length(trajectories, 1)
-  turns <- trajectories[[1]]
+  turns <- trajectories[[1]]$turns
   expect_length(turns, 5)
   expect_s7_class(turns[[1]], ellmer::SystemTurn)
   expect_equal(turns[[1]]@text, "Be helpful.")
@@ -165,7 +165,7 @@ test_that("only a completed final assistant response is attachable", {
 test_that("conversations carry their last chat activity time", {
   trajectories <- build_trajectories(parse_otlp_lines(staggered_test_line()))
 
-  last_active <- attr(trajectories[[1]], "last_active")
+  last_active <- trajectories[[1]]$last_active
   expect_s3_class(last_active, "POSIXct")
   expect_equal(as.numeric(last_active), 101)
 })
@@ -176,7 +176,7 @@ test_that("rebuilt turns can be set on an ellmer chat", {
     chat_test_span("t1", "s1", input_messages = json$input)
   )))
 
-  turns <- build_trajectories(spans)[[1]]
+  turns <- build_trajectories(spans)[[1]]$turns
   chat <- test_client()
   expect_no_error(chat$set_turns(turns))
 })
@@ -207,8 +207,8 @@ test_that("chat spans group by their conversation id across traces", {
   trajectories <- build_trajectories(parse_otlp_lines(lines))
 
   expect_named(trajectories, "conv-a")
-  expect_length(trajectories[[1]], 3)
-  expect_equal(trajectories[[1]][[1]]@text, "Roll a die.")
+  expect_length(trajectories[[1]]$turns, 3)
+  expect_equal(trajectories[[1]]$turns[[1]]@text, "Roll a die.")
 })
 
 text_semconv_message <- function(role, text) {
@@ -292,7 +292,10 @@ test_that("linear calls attach records to their own final exchanges", {
     )
   )))
 
-  provenance <- attr(build_trajectories(spans)[["conv-a"]], "provenance")
+  provenance <- attr(
+    build_trajectories(spans)[["conv-a"]]$turns,
+    "provenance"
+  )
 
   expect_identical(
     vapply(provenance, `[[`, character(1), "provenance_tag"),
@@ -313,7 +316,10 @@ test_that("restored context stays unannotated when only the new call was recorde
     recorded_call_test_spans("t3", "conv-a", messages, "C", "30")
   ))
 
-  provenance <- attr(build_trajectories(spans)[["conv-a"]], "provenance")
+  provenance <- attr(
+    build_trajectories(spans)[["conv-a"]]$turns,
+    "provenance"
+  )
 
   expect_length(provenance, 3)
   expect_true(all(is.na(vapply(
@@ -351,7 +357,10 @@ test_that("calls after restore attach to their respective new exchanges", {
     recorded_call_test_spans("t4", "conv-a", q4a4, "C", "40")
   )))
 
-  provenance <- attr(build_trajectories(spans)[["conv-a"]], "provenance")
+  provenance <- attr(
+    build_trajectories(spans)[["conv-a"]]$turns,
+    "provenance"
+  )
 
   expect_true(is.na(provenance[[1]]$provenance_tag))
   expect_true(is.na(provenance[[2]]$provenance_tag))
@@ -373,7 +382,7 @@ test_that("switched conversations do not donate audit records", {
     recorded_call_test_spans("new", "conv-a", latest_path, "C", "20")
   )))
 
-  turns <- build_trajectories(spans)[["conv-a"]]
+  turns <- build_trajectories(spans)[["conv-a"]]$turns
   provenance <- attr(turns, "provenance")
 
   expect_identical(split_exchanges(turns)[[1]][[1]]@text, "New question")
@@ -402,7 +411,10 @@ test_that("edited paths retain shared-prefix records and drop abandoned records"
     recorded_call_test_spans("t3", "conv-a", edited, "C", "30")
   )))
 
-  provenance <- attr(build_trajectories(spans)[["conv-a"]], "provenance")
+  provenance <- attr(
+    build_trajectories(spans)[["conv-a"]]$turns,
+    "provenance"
+  )
 
   expect_identical(provenance[[1]]$provenance_tag, "A")
   expect_identical(provenance[[2]]$provenance_tag, "C")
@@ -518,7 +530,7 @@ test_that("the latest descendant tool-loop span contributes one call record", {
   )
 
   trajectories <- build_trajectories(parse_otlp_lines(lines))
-  turns <- trajectories[["conv-a"]]
+  turns <- trajectories[["conv-a"]]$turns
 
   exchanges <- split_exchanges(turns)
   provenance <- attr(turns, "provenance")
@@ -548,9 +560,10 @@ test_that("conflicting records fail closed with one conversation warning", {
   )))
 
   expect_warning(
-    turns <- build_trajectories(spans)[["conv-a"]],
+    conversation <- build_trajectories(spans)[["conv-a"]],
     "conflicting audit records"
   )
+  turns <- conversation$turns
   expect_true(is.na(attr(turns, "provenance")[[1]]$provenance_tag))
 })
 
@@ -564,7 +577,8 @@ test_that("identical duplicate records collapse to one claim", {
     recorded_call_test_spans("t2", "conv-a", messages, "A", "20")
   )))
 
-  expect_no_warning(turns <- build_trajectories(spans)[["conv-a"]])
+  expect_no_warning(conversation <- build_trajectories(spans)[["conv-a"]])
+  turns <- conversation$turns
   expect_identical(attr(turns, "provenance")[[1]]$provenance_tag, "A")
 })
 
@@ -583,7 +597,10 @@ test_that("an incomplete tool call does not receive provenance", {
     recorded_call_test_spans("t1", "conv-a", messages, "A", "10")
   ))
 
-  provenance <- attr(build_trajectories(spans)[["conv-a"]], "provenance")
+  provenance <- attr(
+    build_trajectories(spans)[["conv-a"]]$turns,
+    "provenance"
+  )
 
   expect_length(provenance, 1)
   expect_true(is.na(provenance[[1]]$provenance_tag))
@@ -657,7 +674,7 @@ test_that("trajectory reconstruction classifies spans a linear number of times",
   )
 
   trajectories <- build_trajectories(spans)
-  provenance <- lapply(trajectories, attr, "provenance")
+  provenance <- lapply(trajectories, function(x) attr(x$turns, "provenance"))
 
   expect_length(trajectories, 40)
   expect_lte(chat_checks, length(spans) * 3L)
@@ -712,7 +729,7 @@ test_that("provenance defaults to NA/empty with no commons_conversation_turn anc
 
   trajectories <- build_trajectories(spans)
 
-  provenance <- attr(trajectories[["lonetrace"]], "provenance")
+  provenance <- attr(trajectories[["lonetrace"]]$turns, "provenance")
   expect_length(provenance, 1)
   expect_identical(
     provenance[[1]],
@@ -743,7 +760,7 @@ test_that("generic parts and empty messages are dropped", {
     chat_test_span("t1", "s1", input_messages = input)
   )))
 
-  turns <- build_trajectories(spans)[[1]]
+  turns <- build_trajectories(spans)[[1]]$turns
 
   expect_length(turns, 1)
   expect_equal(turns[[1]]@text, "Kept.")
@@ -802,7 +819,8 @@ test_that("the latest chat span wins across timestamp digit counts", {
   trajectories <- build_trajectories(spans)
 
   expect_length(trajectories, 1)
-  final <- trajectories[[1]][[length(trajectories[[1]])]]
+  turns <- trajectories[[1]]$turns
+  final <- turns[[length(turns)]]
   expect_s7_class(final, ellmer::AssistantTurn)
   expect_equal(final@text, "You rolled a 4.")
 })

--- a/pkg-r/tests/testthat/test-trajectory-review-log.R
+++ b/pkg-r/tests/testthat/test-trajectory-review-log.R
@@ -22,10 +22,6 @@ review_test_turns <- function() {
       )
     )
   )
-  attr(turns, "last_active") <- as.POSIXct(
-    "2026-08-11 09:30:00",
-    tz = "UTC"
-  )
   attr(turns, "provenance") <- list(list(
     provenance_tag = "B",
     citation_decisions = list(list(
@@ -36,6 +32,13 @@ review_test_turns <- function() {
     ))
   ))
   turns
+}
+
+review_test_conversation <- function() {
+  list(
+    turns = review_test_turns(),
+    last_active = as.POSIXct("2026-08-11 09:30:00", tz = "UTC")
+  )
 }
 
 review_test_notes <- function(id = "conv/1") {
@@ -60,7 +63,7 @@ review_test_notes <- function(id = "conv/1") {
 test_that("review_document renders a self-contained trajectory review", {
   markdown <- review_document(
     "conv/1",
-    review_test_turns(),
+    review_test_conversation(),
     list(conversation = TRUE, exchanges = 1L),
     review_test_notes(),
     updated_at = "2026-08-12T16:10:00Z"
@@ -151,7 +154,7 @@ test_that("review state round trips through YAML frontmatter", {
   writeLines(
     review_document(
       id,
-      review_test_turns(),
+      review_test_conversation(),
       list(conversation = TRUE, exchanges = 1L),
       review_test_notes(id),
       updated_at = "2026-08-12T16:10:00Z"
@@ -219,7 +222,7 @@ test_that("review state ignores unrelated Markdown and rejects malformed reviews
 test_that("conversation reviews are created, replaced, and removed", {
   parent <- withr::local_tempdir()
   review_dir <- file.path(parent, "reviews")
-  trajectories <- list(`conv/1` = review_test_turns())
+  trajectories <- list(`conv/1` = review_test_conversation())
 
   write_conversation_review(
     review_dir,
@@ -247,7 +250,7 @@ test_that("conversation reviews are created, replaced, and removed", {
   writeLines(
     review_document(
       "unknown",
-      review_test_turns(),
+      review_test_conversation(),
       list(conversation = TRUE, exchanges = integer()),
       list(),
       updated_at = "2026-08-12T16:10:00Z"
@@ -274,7 +277,7 @@ test_that("conversation reviews are created, replaced, and removed", {
 
 test_that("conversation reviews with notes remain after their final unflag", {
   review_dir <- withr::local_tempdir()
-  trajectories <- list(conv1 = review_test_turns())
+  trajectories <- list(conv1 = review_test_conversation())
   notes <- review_test_notes("conv1")[1]
 
   write_conversation_review(

--- a/pkg-r/tests/testthat/test-trajectory-review.R
+++ b/pkg-r/tests/testthat/test-trajectory-review.R
@@ -65,7 +65,6 @@ test_that("summarize_trajectories describes each conversation", {
     test_tool_turns("run_sql", id = "c2"),
     list(ellmer::AssistantTurn("5650."))
   )
-  attr(active, "last_active") <- as.POSIXct("2026-07-22 14:30:00")
   attr(active, "provenance") <- list(
     provenance_record("A"),
     provenance_record("C")
@@ -75,7 +74,13 @@ test_that("summarize_trajectories describes each conversation", {
     ellmer::AssistantTurn("Revenue excludes tax.")
   )
   attr(conv2, "provenance") <- list(provenance_record(NA_character_))
-  trajectories <- list(conv1 = active, conv2 = conv2)
+  trajectories <- list(
+    conv1 = list(
+      turns = active,
+      last_active = as.POSIXct("2026-07-22 14:30:00")
+    ),
+    conv2 = list(turns = conv2, last_active = as.POSIXct(NA))
+  )
 
   summary <- summarize_trajectories(trajectories)
 
@@ -210,7 +215,10 @@ test_that("side calls are excluded from the viewer", {
   expect_true(is_side_conversation(promptless))
   expect_false(is_side_conversation(real))
 
-  trajectories <- list(t = title_call, p = promptless, r = real)
+  trajectories <- lapply(
+    list(t = title_call, p = promptless, r = real),
+    function(turns) list(turns = turns, last_active = as.POSIXct(NA))
+  )
   expect_message(
     kept <- drop_side_conversations(trajectories),
     "Excluding 2 logged calls"
@@ -229,14 +237,19 @@ test_that("summarize_questions flattens exchanges across conversations", {
     test_tool_turns("run_sql", id = "c2"),
     list(ellmer::AssistantTurn("5650."))
   )
-  attr(first, "last_active") <- as.POSIXct("2026-07-22 14:30:00")
   attr(first, "provenance") <- list(
     provenance_record("A"),
     provenance_record("C")
   )
   conv2 <- list(ellmer::UserTurn("What does revenue mean?"))
   attr(conv2, "provenance") <- list(provenance_record(NA_character_))
-  trajectories <- list(conv1 = first, conv2 = conv2)
+  trajectories <- list(
+    conv1 = list(
+      turns = first,
+      last_active = as.POSIXct("2026-07-22 14:30:00")
+    ),
+    conv2 = list(turns = conv2, last_active = as.POSIXct(NA))
+  )
 
   questions <- summarize_questions(trajectories)
 
@@ -269,16 +282,23 @@ test_that("the viewer filters conversations and follows selection", {
     test_tool_turns("call_measure"),
     list(ellmer::AssistantTurn("1."))
   )
-  attr(early, "last_active") <- as.POSIXct("2026-07-01 09:00:00")
   attr(early, "provenance") <- list(provenance_record("A"))
   late <- c(
     list(ellmer::UserTurn("Two?")),
     test_tool_turns("run_sql"),
     list(ellmer::AssistantTurn("2."))
   )
-  attr(late, "last_active") <- as.POSIXct("2026-07-20 09:00:00")
   attr(late, "provenance") <- list(provenance_record("C"))
-  trajectories <- list(conv1 = early, conv2 = late)
+  trajectories <- list(
+    conv1 = list(
+      turns = early,
+      last_active = as.POSIXct("2026-07-01 09:00:00")
+    ),
+    conv2 = list(
+      turns = late,
+      last_active = as.POSIXct("2026-07-20 09:00:00")
+    )
+  )
   summary <- summarize_trajectories(trajectories)
   questions <- summarize_questions(trajectories)
   review_dir <- withr::local_tempdir()
@@ -363,7 +383,9 @@ test_that("flags and notes write to and restore from review documents", {
   skip_if_not_installed("htmltools")
 
   turns <- list(ellmer::UserTurn("One?"), ellmer::AssistantTurn("1."))
-  trajectories <- list(conv1 = turns)
+  trajectories <- list(
+    conv1 = list(turns = turns, last_active = as.POSIXct(NA))
+  )
   summary <- summarize_trajectories(trajectories)
   questions <- summarize_questions(trajectories)
   review_dir <- withr::local_tempdir()

--- a/pkg-r/tests/testthat/test-trajectory-review.R
+++ b/pkg-r/tests/testthat/test-trajectory-review.R
@@ -251,8 +251,9 @@ test_that("summarize_questions flattens exchanges across conversations", {
 
 test_that("trajectory reviewer accepts empty trajectories and rejects other shapes", {
   expect_no_error(check_trajectories(list()))
+  expect_no_error(check_trajectories(list(conv1 = list(turns = list()))))
   expect_snapshot(check_trajectories("nope"), error = TRUE)
-  expect_error(check_trajectories(list(list())))
+  expect_error(check_trajectories(list(conv1 = list())))
 })
 
 test_that("the viewer filters conversations and follows selection", {

--- a/pkg-r/tests/testthat/test-trajectory-review.R
+++ b/pkg-r/tests/testthat/test-trajectory-review.R
@@ -251,7 +251,9 @@ test_that("summarize_questions flattens exchanges across conversations", {
 
 test_that("trajectory reviewer accepts empty trajectories and rejects other shapes", {
   expect_no_error(check_trajectories(list()))
-  expect_no_error(check_trajectories(list(conv1 = list(turns = list()))))
+  expect_no_error(check_trajectories(list(
+    conv1 = list(turns = list(), last_active = as.POSIXct(NA))
+  )))
   expect_snapshot(check_trajectories("nope"), error = TRUE)
   expect_error(check_trajectories(list(conv1 = list())))
 })


### PR DESCRIPTION
Closes #223.

Moves `trajectory_read()[[i]]` into `trajectory_read()[[i]][["turns"]]` so that we can add other conversation-level metadata about the conversation into other entries. As part of this, removes the `last_active` attribute from the turn lists into a list field `last_active`. I can imagine in the future, we might also add a user field into each list as well, once we can get that information from Connect. 