### PR TITLE
accept more Connect content URL types in `trajectory_read()`

### DIFF
--- a/pkg-r/DESCRIPTION
+++ b/pkg-r/DESCRIPTION
@@ -61,6 +61,7 @@ Suggests:
     ragg,
     readr,
     rmarkdown,
+    rsconnect,
     shiny (>= 1.11.1),
     shinytest2,
     testthat (>= 3.0.0),

--- a/pkg-r/R/connect.R
+++ b/pkg-r/R/connect.R
@@ -42,6 +42,59 @@ connect_req <- function(client, ...) {
     httr2::req_headers_redacted(Authorization = paste("Key", client$api_key))
 }
 
+# Search exposes vanity URLs to content viewers without requiring the
+# administrator-only endpoint that lists every vanity URL on the server.
+connect_vanity_guid <- function(
+  client,
+  url,
+  query,
+  call = rlang::caller_env()
+) {
+  page_number <- 1L
+  repeat {
+    body <- connect_req(client, "search", "content") |>
+      httr2::req_url_query(
+        q = query,
+        include = "vanity_url",
+        page_number = page_number,
+        page_size = 100
+      ) |>
+      httr2::req_perform() |>
+      httr2::resp_body_json(simplifyVector = TRUE)
+    results <- body$results
+    if (
+      is.data.frame(results) &&
+        all(c("guid", "vanity_url") %in% names(results))
+    ) {
+      expected <- paste0(client$server, "/", sub("^/+", "", query))
+      matches <- !is.na(results$vanity_url) &
+        normalize_connect_url(results$vanity_url) ==
+          normalize_connect_url(expected)
+      if (any(matches)) {
+        return(results$guid[which(matches)[[1]]])
+      }
+    }
+    if (is.null(body$total) || page_number >= body$total) {
+      break
+    }
+    page_number <- page_number + 1L
+  }
+
+  cli::cli_abort(
+    c(
+      "Can't find content for the Connect vanity URL {.url {url}}.",
+      i = "Check that the URL is correct and that your API key can access the
+           content."
+    ),
+    call = call
+  )
+}
+
+normalize_connect_url <- function(x) {
+  x <- sub("[?#].*$", "", x)
+  utils::URLdecode(sub("/+$", "", x))
+}
+
 # Fetch trace rows for a content item as raw OTLP NDJSON lines, paging until
 # the X-Total-Count header is exhausted. On servers with a single trace store,
 # `enough(lines)` can stop paging early.

--- a/pkg-r/R/trajectory-read.R
+++ b/pkg-r/R/trajectory-read.R
@@ -13,8 +13,9 @@
 #'     content's own traces; in a project that has been deployed with
 #'     rsconnect, the deployed content's traces; otherwise, the local trace
 #'     directory that [commons()] writes to.
-#'   * A Connect content GUID, a content URL (`.../content/<guid>/`), or a
-#'     dashboard URL (`.../connect/#/apps/<guid>/`).
+#'   * A Connect content GUID, a content URL (`.../content/<guid>/`), a
+#'     vanity URL (`.../content/<name>/`), or a dashboard URL
+#'     (`.../connect/#/apps/<guid>/`).
 #'   * A directory of OTLP NDJSON trace files (`trace-*.jsonl`).
 #' @param ... These dots are for future extensions and must be empty.
 #' @param n Keep only the `n` most recent conversations, after `from`/`to`
@@ -29,9 +30,9 @@
 #' @details
 #' Reading traces from Connect requires the `CONNECT_API_KEY` environment
 #' variable (and `CONNECT_SERVER`, when the server can't be inferred from the
-#' project's deployment record), and editor-level access to the content: you
-#' must own it or be a collaborator. See the `share_with` argument of
-#' [commons()].
+#' URL, the project's deployment record, or the sole Connect server registered
+#' with rsconnect), and editor-level access to the content: you must own it or
+#' be a collaborator. See the `share_with` argument of [commons()].
 #'
 #' @return A list of conversations, named by conversation id and ordered
 #'   oldest-first. Each conversation is a list with a `turns` field containing
@@ -233,20 +234,25 @@ resolve_trajectory_source <- function(source, call = rlang::caller_env()) {
       return(list(
         kind = "connect",
         guid = source,
-        client = connect_client(call = call)
+        client = connect_client(
+          server = trajectory_guid_server(call),
+          call = call
+        )
       ))
     }
     if (grepl("^https?://", source)) {
       url_guid <- content_url_guid(source)
       if (is.null(url_guid)) {
-        cli::cli_abort(
-          c(
-            "Can't find a content GUID in {.url {source}}.",
-            i = "Supported URLs contain {.code /content/<guid>} (a content
-                 URL) or {.code #/apps/<guid>} (a dashboard URL)."
-          ),
-          call = call
-        )
+        vanity <- content_vanity_url(source)
+        if (!is.null(vanity)) {
+          client <- connect_client(server = vanity$server, call = call)
+          return(list(
+            kind = "connect",
+            guid = connect_vanity_guid(client, source, vanity$query, call),
+            client = client
+          ))
+        }
+        trajectory_url_abort(source, call)
       }
       return(list(
         kind = "connect",
@@ -262,6 +268,69 @@ resolve_trajectory_source <- function(source, call = rlang::caller_env()) {
      GUID, or a Connect content URL.",
     call = call
   )
+}
+
+trajectory_url_abort <- function(source, call) {
+  cli::cli_abort(
+    c(
+      "Can't identify Connect content from {.url {source}}.",
+      i = "Supported URLs contain {.code /content/<guid>},
+           {.code /content/<name>}, or {.code #/apps/<guid>}."
+    ),
+    call = call
+  )
+}
+
+trajectory_guid_server <- function(call = rlang::caller_env()) {
+  server <- Sys.getenv("CONNECT_SERVER")
+  if (nzchar(server)) {
+    return(server)
+  }
+
+  deployment <- find_rsconnect_deployment()
+  if (!is.null(deployment)) {
+    return(deployment$server)
+  }
+
+  servers <- registered_connect_servers()
+  if (length(servers) == 1) {
+    return(servers)
+  }
+
+  message <- c(
+    "Can't determine which Posit Connect server contains this GUID.",
+    i = "Set {.envvar CONNECT_SERVER} or pass a full content URL."
+  )
+  if (length(servers) > 1) {
+    message <- c(
+      message,
+      i = "Registered Connect servers: {.url {servers}}."
+    )
+  }
+  cli::cli_abort(message, call = call)
+}
+
+registered_connect_servers <- function() {
+  if (!requireNamespace("rsconnect", quietly = TRUE)) {
+    return(character())
+  }
+  accounts <- tryCatch(rsconnect::accounts(), error = function(err) NULL)
+  if (is.null(accounts) || nrow(accounts) == 0) {
+    return(character())
+  }
+
+  names <- unique(accounts$server)
+  names <- setdiff(names, c("shinyapps.io", "connect.posit.cloud"))
+  servers <- vapply(
+    names,
+    function(name) {
+      info <- tryCatch(rsconnect::serverInfo(name), error = function(err) NULL)
+      if (is.null(info$url)) "" else info$url
+    },
+    character(1)
+  )
+  servers <- sub("/__api__/?$", "", servers)
+  unique(servers[nzchar(servers)])
 }
 
 resolve_default_source <- function(call = rlang::caller_env()) {
@@ -321,6 +390,18 @@ content_url_guid <- function(x) {
     return(list(server = match[2], guid = match[3]))
   }
   NULL
+}
+
+content_vanity_url <- function(x) {
+  if (!grepl("^https?://", x)) {
+    return(NULL)
+  }
+  x <- sub("[?#].*$", "", x)
+  match <- regmatches(x, regexec("^(.*?)/content/(.+?)/?$", x))[[1]]
+  if (length(match) == 0) {
+    return(NULL)
+  }
+  list(server = match[2], query = utils::URLdecode(match[3]))
 }
 
 # Find the project's Connect deployment record (written by rsconnect under

--- a/pkg-r/man/trajectory_read.Rd
+++ b/pkg-r/man/trajectory_read.Rd
@@ -13,8 +13,9 @@ trajectory_read(source = NULL, ..., n = NULL, from = NULL, to = NULL)
 content's own traces; in a project that has been deployed with
 rsconnect, the deployed content's traces; otherwise, the local trace
 directory that \code{\link[=commons]{commons()}} writes to.
-\item A Connect content GUID, a content URL (\verb{.../content/<guid>/}), or a
-dashboard URL (\verb{.../connect/#/apps/<guid>/}).
+\item A Connect content GUID, a content URL (\verb{.../content/<guid>/}), a
+vanity URL (\verb{.../content/<name>/}), or a dashboard URL
+(\verb{.../connect/#/apps/<guid>/}).
 \item A directory of OTLP NDJSON trace files (\verb{trace-*.jsonl}).
 }}
 
@@ -46,9 +47,9 @@ from local trace files.
 \details{
 Reading traces from Connect requires the \code{CONNECT_API_KEY} environment
 variable (and \code{CONNECT_SERVER}, when the server can't be inferred from the
-project's deployment record), and editor-level access to the content: you
-must own it or be a collaborator. See the \code{share_with} argument of
-\code{\link[=commons]{commons()}}.
+URL, the project's deployment record, or the sole Connect server registered
+with rsconnect), and editor-level access to the content: you must own it or
+be a collaborator. See the \code{share_with} argument of \code{\link[=commons]{commons()}}.
 }
 \examples{
 \dontrun{

--- a/pkg-r/tests/testthat/_snaps/connect.md
+++ b/pkg-r/tests/testthat/_snaps/connect.md
@@ -14,6 +14,16 @@
       Error:
       ! Set the `CONNECT_API_KEY` environment variable to a Posit Connect API key.
 
+# connect_vanity_guid explains an inaccessible URL
+
+    Code
+      connect_vanity_guid(list(server = "https://connect.example.com", api_key = "key"),
+      "https://connect.example.com/content/missing", "missing")
+    Condition
+      Error:
+      ! Can't find content for the Connect vanity URL <https://connect.example.com/content/missing>.
+      i Check that the URL is correct and that your API key can access the content.
+
 # connect_trace_lines explains auth failures on the traces endpoint
 
     Code

--- a/pkg-r/tests/testthat/_snaps/trajectories.md
+++ b/pkg-r/tests/testthat/_snaps/trajectories.md
@@ -71,6 +71,6 @@
       resolve_trajectory_source("https://connect.example.com/other")
     Condition
       Error:
-      ! Can't find a content GUID in <https://connect.example.com/other>.
-      i Supported URLs contain `/content/<guid>` (a content URL) or `#/apps/<guid>` (a dashboard URL).
+      ! Can't identify Connect content from <https://connect.example.com/other>.
+      i Supported URLs contain `/content/<guid>`, `/content/<name>`, or `#/apps/<guid>`.
 

--- a/pkg-r/tests/testthat/_snaps/trajectories.md
+++ b/pkg-r/tests/testthat/_snaps/trajectories.md
@@ -65,6 +65,16 @@
       Error in `trajectory_read()`:
       ! `source` must be `NULL`, a directory path, a Connect content GUID, or a Connect content URL.
 
+# a GUID source requires an unambiguous server
+
+    Code
+      resolve_trajectory_source("ea3c1445-cb71-42df-a2f2-bdb18874ef41")
+    Condition
+      Error:
+      ! Can't determine which Posit Connect server contains this GUID.
+      i Set `CONNECT_SERVER` or pass a full content URL.
+      i Registered Connect servers: <https://one.example.com> and <https://two.example.com>.
+
 # a URL without a recognizable GUID errors rather than reading locally
 
     Code

--- a/pkg-r/tests/testthat/test-connect.R
+++ b/pkg-r/tests/testthat/test-connect.R
@@ -29,26 +29,35 @@ test_that("is_connect_runtime detects Connect env vars", {
 })
 
 test_that("connect_vanity_guid matches the full vanity URL", {
-  local_mocked_bindings(
-    connect_req = function(client, ...) structure(list(), class = "fake_req")
-  )
-  local_mocked_bindings(
-    req_url_query = function(req, ...) req,
-    req_perform = function(req, ...) req,
-    resp_body_json = function(resp, ...) {
-      list(
-        results = data.frame(
-          guid = c("wrong-guid", "right-guid"),
-          vanity_url = c(
-            "https://connect.example.com/my-agent-test/",
-            "https://connect.example.com/my-agent/"
-          )
+  httr2::local_mocked_responses(function(req) {
+    url <- httr2::url_parse(req$url)
+    expect_equal(url$path, "/__api__/v1/search/content")
+    expect_equal(url$query$q, "my-agent")
+    expect_equal(url$query$include, "vanity_url")
+    httr2::new_response(
+      "GET",
+      req$url,
+      200L,
+      list(`Content-Type` = "application/json"),
+      charToRaw(jsonlite::toJSON(
+        list(
+          results = list(
+            list(
+              guid = "wrong-guid",
+              vanity_url = "https://connect.example.com/my-agent-test/"
+            ),
+            list(
+              guid = "right-guid",
+              vanity_url = "https://connect.example.com/my-agent/"
+            )
+          ),
+          total = 1L
         ),
-        total = 1L
-      )
-    },
-    .package = "httr2"
-  )
+        auto_unbox = TRUE
+      )),
+      request = req
+    )
+  })
 
   guid <- connect_vanity_guid(
     list(server = "https://connect.example.com", api_key = "key"),
@@ -60,25 +69,30 @@ test_that("connect_vanity_guid matches the full vanity URL", {
 })
 
 test_that("connect_vanity_guid explains an inaccessible URL", {
-  local_mocked_bindings(
-    connect_req = function(client, ...) structure(list(), class = "fake_req")
-  )
-  local_mocked_bindings(
-    req_url_query = function(req, ...) req,
-    req_perform = function(req, ...) req,
-    resp_body_json = function(resp, ...) {
-      list(results = data.frame(), total = 1L)
-    },
-    .package = "httr2"
-  )
+  httr2::local_mocked_responses(function(req) {
+    httr2::new_response(
+      "GET",
+      req$url,
+      200L,
+      list(`Content-Type` = "application/json"),
+      charToRaw(jsonlite::toJSON(
+        list(
+          results = list(),
+          total = 1L
+        ),
+        auto_unbox = TRUE
+      )),
+      request = req
+    )
+  })
 
-  expect_error(
+  expect_snapshot(
     connect_vanity_guid(
       list(server = "https://connect.example.com", api_key = "key"),
       "https://connect.example.com/content/missing",
       "missing"
     ),
-    "Can't find content for the Connect vanity URL"
+    error = TRUE
   )
 })
 

--- a/pkg-r/tests/testthat/test-connect.R
+++ b/pkg-r/tests/testthat/test-connect.R
@@ -28,6 +28,60 @@ test_that("is_connect_runtime detects Connect env vars", {
   expect_true(is_connect_runtime())
 })
 
+test_that("connect_vanity_guid matches the full vanity URL", {
+  local_mocked_bindings(
+    connect_req = function(client, ...) structure(list(), class = "fake_req")
+  )
+  local_mocked_bindings(
+    req_url_query = function(req, ...) req,
+    req_perform = function(req, ...) req,
+    resp_body_json = function(resp, ...) {
+      list(
+        results = data.frame(
+          guid = c("wrong-guid", "right-guid"),
+          vanity_url = c(
+            "https://connect.example.com/my-agent-test/",
+            "https://connect.example.com/my-agent/"
+          )
+        ),
+        total = 1L
+      )
+    },
+    .package = "httr2"
+  )
+
+  guid <- connect_vanity_guid(
+    list(server = "https://connect.example.com", api_key = "key"),
+    "https://connect.example.com/content/my-agent",
+    "my-agent"
+  )
+
+  expect_equal(guid, "right-guid")
+})
+
+test_that("connect_vanity_guid explains an inaccessible URL", {
+  local_mocked_bindings(
+    connect_req = function(client, ...) structure(list(), class = "fake_req")
+  )
+  local_mocked_bindings(
+    req_url_query = function(req, ...) req,
+    req_perform = function(req, ...) req,
+    resp_body_json = function(resp, ...) {
+      list(results = data.frame(), total = 1L)
+    },
+    .package = "httr2"
+  )
+
+  expect_error(
+    connect_vanity_guid(
+      list(server = "https://connect.example.com", api_key = "key"),
+      "https://connect.example.com/content/missing",
+      "missing"
+    ),
+    "Can't find content for the Connect vanity URL"
+  )
+})
+
 test_that("connect_trace_lines pages until the total is exhausted", {
   pages <- list(
     c("line1", "line2"),

--- a/pkg-r/tests/testthat/test-trajectories.R
+++ b/pkg-r/tests/testthat/test-trajectories.R
@@ -1154,6 +1154,56 @@ test_that("a GUID source resolves to a Connect read", {
   expect_equal(resolved$client$server, "https://connect.example.com")
 })
 
+test_that("a GUID source infers its server from rsconnect", {
+  withr::local_envvar(CONNECT_SERVER = NA, CONNECT_API_KEY = "key")
+  withr::local_dir(withr::local_tempdir())
+  local_mocked_bindings(
+    registered_connect_servers = function() "https://connect.example.com"
+  )
+
+  resolved <- resolve_trajectory_source(
+    "ea3c1445-cb71-42df-a2f2-bdb18874ef41"
+  )
+
+  expect_equal(resolved$client$server, "https://connect.example.com")
+})
+
+test_that("a GUID source prefers its environment and project deployment", {
+  withr::local_envvar(CONNECT_SERVER = "https://env.example.com")
+  expect_equal(trajectory_guid_server(), "https://env.example.com")
+
+  withr::local_envvar(CONNECT_SERVER = NA)
+  dir <- withr::local_tempdir()
+  record_dir <- file.path(dir, "rsconnect", "documents", "app.R", "server")
+  dir.create(record_dir, recursive = TRUE)
+  writeLines(
+    c(
+      "name: my-agent",
+      "hostUrl: https://project.example.com/__api__",
+      "url: https://project.example.com/content/ea3c1445-cb71-42df-a2f2-bdb18874ef41/"
+    ),
+    file.path(record_dir, "my-agent.dcf")
+  )
+  withr::local_dir(dir)
+
+  expect_equal(trajectory_guid_server(), "https://project.example.com")
+})
+
+test_that("a GUID source requires an unambiguous server", {
+  withr::local_envvar(CONNECT_SERVER = NA, CONNECT_API_KEY = "key")
+  withr::local_dir(withr::local_tempdir())
+  local_mocked_bindings(
+    registered_connect_servers = function() {
+      c("https://one.example.com", "https://two.example.com")
+    }
+  )
+
+  expect_error(
+    resolve_trajectory_source("ea3c1445-cb71-42df-a2f2-bdb18874ef41"),
+    "Can't determine which Posit Connect server"
+  )
+})
+
 test_that("a content URL source carries its own server", {
   withr::local_envvar(CONNECT_SERVER = NA, CONNECT_API_KEY = "key")
 
@@ -1176,6 +1226,27 @@ test_that("a dashboard URL source carries its own server", {
   expect_equal(resolved$kind, "connect")
   expect_equal(resolved$guid, "ea3c1445-cb71-42df-a2f2-bdb18874ef41")
   expect_equal(resolved$client$server, "https://connect.example.com")
+})
+
+test_that("a vanity URL is resolved through Connect", {
+  withr::local_envvar(CONNECT_SERVER = NA, CONNECT_API_KEY = "key")
+  state <- new.env()
+  local_mocked_bindings(
+    connect_vanity_guid = function(client, url, query, ...) {
+      state$client <- client
+      state$url <- url
+      state$query <- query
+      "ea3c1445-cb71-42df-a2f2-bdb18874ef41"
+    }
+  )
+
+  url <- "https://connect.example.com/content/my-agent"
+  resolved <- resolve_trajectory_source(url)
+
+  expect_equal(resolved$guid, "ea3c1445-cb71-42df-a2f2-bdb18874ef41")
+  expect_equal(state$client$server, "https://connect.example.com")
+  expect_equal(state$url, url)
+  expect_equal(state$query, "my-agent")
 })
 
 test_that("a URL without a recognizable GUID errors rather than reading locally", {
@@ -1273,6 +1344,18 @@ test_that("content_url_guid extracts the server and GUID", {
 
   expect_null(content_url_guid("https://connect.example.com/other"))
   expect_null(content_url_guid("plain-string"))
+})
+
+test_that("content_vanity_url extracts the server and search query", {
+  expect_equal(
+    content_vanity_url("https://connect.example.com/content/my-agent/"),
+    list(server = "https://connect.example.com", query = "my-agent")
+  )
+  expect_equal(
+    content_vanity_url("https://connect.example.com/rsc/content/my%20agent"),
+    list(server = "https://connect.example.com/rsc", query = "my agent")
+  )
+  expect_null(content_vanity_url("https://connect.example.com/other"))
 })
 
 test_that("deployment records are found in project subdirectories", {

--- a/pkg-r/tests/testthat/test-trajectories.R
+++ b/pkg-r/tests/testthat/test-trajectories.R
@@ -1198,9 +1198,9 @@ test_that("a GUID source requires an unambiguous server", {
     }
   )
 
-  expect_error(
+  expect_snapshot(
     resolve_trajectory_source("ea3c1445-cb71-42df-a2f2-bdb18874ef41"),
-    "Can't determine which Posit Connect server"
+    error = TRUE
   )
 })
 
@@ -1247,6 +1247,21 @@ test_that("a vanity URL is resolved through Connect", {
   expect_equal(state$client$server, "https://connect.example.com")
   expect_equal(state$url, url)
   expect_equal(state$query, "my-agent")
+})
+
+test_that("a vanity URL resolves against a configured Connect server", {
+  url <- Sys.getenv("COMMONS_TEST_CONNECT_VANITY_URL")
+  guid <- Sys.getenv("COMMONS_TEST_CONNECT_GUID")
+  skip_if(!nzchar(url), "COMMONS_TEST_CONNECT_VANITY_URL is not set")
+  skip_if(!nzchar(guid), "COMMONS_TEST_CONNECT_GUID is not set")
+  skip_if(
+    !nzchar(Sys.getenv("CONNECT_API_KEY")),
+    "CONNECT_API_KEY is not set"
+  )
+
+  resolved <- resolve_trajectory_source(url)
+
+  expect_equal(resolved$guid, guid)
 })
 
 test_that("a URL without a recognizable GUID errors rather than reading locally", {


### PR DESCRIPTION
Closes #235. Newly accepts vanity URLs and, if given only a GUID, will try it against a registered Connect server (if there is only one).