### PR TITLE
feat(py): the Commons class, its assembly order, chat() and stream_async()

### DIFF
--- a/pkg-py/src/commons/_agent.py
+++ b/pkg-py/src/commons/_agent.py
@@ -1,0 +1,388 @@
+"""The agent: its layers, the tools they earn, and the rules a turn follows.
+
+`pkg-r/R/commons.R` assembles the same agent for R, in the order this follows.
+A `chatlas.Chat` is composed rather than subclassed (decision D1 in the port
+plan), so the public surface is a choice R never had to make: what an agent
+needs, plus the chatlas methods the two turn rules have to hook.
+"""
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import AsyncGenerator, Mapping, Sequence
+from typing import Any, Literal
+
+from chatlas import Chat, StreamController, Tool, Turn, UserTurn
+from chatlas.types import ChatResponse, Content, SubmitInputArgsT
+
+from ._backends import DuckDBBackend, EngineBackend
+from ._citation_scan import CitationScanner
+from ._citations import (
+    CitationRequest,
+    CorpusEntry,
+    build_citation_corpus,
+    turn_has_user_message,
+)
+from ._context_layer import ContextLayer, augment_context_layer
+from ._data_source import DataSource
+from ._definitions import Registry, build_registry
+from ._handles import HandleStore
+from ._measures import SemanticLayer, resolve_injections, semantic_layer
+from ._prompt import (
+    check_instructions,
+    read_instructions,
+    render_system_prompt,
+    system_prompt_data,
+    system_prompt_template,
+)
+from ._provenance import collect_appended_tags, derive_provenance_tag, provenance_aside
+from ._reminders import append_restored_conversation_reminder, append_turn_reminder
+from ._tools import FirstTouch, ToolContext, build_commons_tools
+
+__all__ = ["Commons"]
+
+EchoOptions = Literal["output", "all", "none", "text"]
+
+# The label a lone source is filed under. An agent with one source never shows
+# the model a `source` argument and never labels its prompt sections, so this
+# is only what the agent's own bookkeeping keys on.
+SOLE_SOURCE = "data"
+
+# Frozen and empty, so every agent built without a semantic layer can share it.
+_NO_MEASURES = semantic_layer()
+
+
+class Commons:
+    """An agent that answers questions about its data.
+
+    Give it a `chatlas.Chat` for the provider and model, the data sources it
+    can query, and optionally a semantic layer of trusted calculations and a
+    context layer of prose. It registers the tools its composition earns and
+    sets its own system prompt, so an answer can be classified by how it was
+    produced.
+
+    `client` is taken over rather than copied: its tools become the agent's
+    tools and its system prompt becomes commons' own. A system prompt already
+    set on it is discarded with a warning; use `instructions` to add to
+    commons' prompt instead.
+
+    Parameters
+    ----------
+    client
+        A `chatlas.Chat` giving the provider and model to use. For best
+        results, enable thinking where the provider and model support it.
+    data_sources
+        A `DataSource`, or a mapping of name to `DataSource`. A measure can
+        take a named source's connection as an argument named after it.
+    semantic_layer
+        An optional `SemanticLayer` of measures.
+    context_layer
+        An optional `ContextLayer` of prose.
+    instructions
+        Extra instructions placed under an `## Additional instructions`
+        heading at the end of commons' built-in system prompt, as a string or
+        the path to a text or Markdown file.
+    """
+
+    def __init__(
+        self,
+        client: Chat,
+        data_sources: DataSource | Mapping[str, DataSource],
+        semantic_layer: SemanticLayer | None = None,
+        context_layer: ContextLayer | None = None,
+        *,
+        instructions: str | None = None,
+    ) -> None:
+        if not isinstance(client, Chat):
+            raise TypeError(
+                "client must be a chatlas.Chat, e.g. from chatlas.ChatAnthropic(), "
+                f"not {type(client).__name__}."
+            )
+        _warn_about_discarded_state(client)
+
+        sources = _as_data_sources(data_sources)
+        if context_layer is not None and not isinstance(context_layer, ContextLayer):
+            raise TypeError(
+                "context_layer must be a ContextLayer from commons.context_layer(), "
+                f"or None, not {type(context_layer).__name__}."
+            )
+        if semantic_layer is None:
+            semantic_layer = _NO_MEASURES
+        if not isinstance(semantic_layer, SemanticLayer):
+            raise TypeError(
+                "semantic_layer must be a SemanticLayer from "
+                f"commons.semantic_layer(), or None, not "
+                f"{type(semantic_layer).__name__}."
+            )
+        check_instructions(instructions)
+
+        self._client = client
+        self._sources = sources
+        self._context_layer = augment_context_layer(context_layer, sources.values())
+        self._definitions = build_registry(sources)
+        self._measures = semantic_layer.measures
+        # The injectables side stays here because it is the only part that
+        # knows what a DataSource is: a measure asks for a source by name and
+        # receives whatever that source is queried through.
+        self._injections = resolve_injections(
+            self._measures, _measure_injectables(data_sources, sources)
+        )
+        self._first_touch = FirstTouch()
+        self._handles = HandleStore()
+        self._citation_request = CitationRequest()
+        self._corpus = build_citation_corpus(
+            self._context_layer, self._measures.values(), sources
+        )
+        self._restore_reminder_pending = False
+
+        tools = build_commons_tools(
+            ToolContext(
+                sources=sources,
+                measures=self._measures,
+                definitions=self._definitions,
+                context_layer=self._context_layer,
+                handles=self._handles,
+                citation_request=self._citation_request,
+                injections=self._injections,
+                first_touch=self._first_touch,
+            )
+        )
+        client.set_tools(list(tools))
+        client.system_prompt = _system_prompt(
+            sources,
+            self._definitions,
+            instructions=instructions,
+            tools=tools,
+            model=client.model,
+        )
+
+    def __repr__(self) -> str:
+        count = len(self._sources)
+        plural = "" if count == 1 else "s"
+        return f"A commons agent over {count} data source{plural}."
+
+    # ---- asking it something ---------------------------------------------
+
+    def chat(
+        self,
+        *args: Content | str,
+        echo: EchoOptions = "output",
+        stream: bool = True,
+        kwargs: SubmitInputArgsT | None = None,
+    ) -> ChatResponse:
+        """Ask a question and wait for the whole answer."""
+        was_pending = self._restore_reminder_pending
+        inputs = self._prepare_turn_inputs(args)
+        self._citation_request.reset()
+        response = self._client.chat(*inputs, echo=echo, stream=stream, kwargs=kwargs)
+        self._consume_restore_reminder(was_pending)
+        return response
+
+    async def stream_async(
+        self,
+        *args: Content | str,
+        content: Literal["text", "all"] = "text",
+        echo: EchoOptions = "none",
+        kwargs: SubmitInputArgsT | None = None,
+        controller: StreamController | None = None,
+    ) -> AsyncGenerator[str | Content, None]:
+        """Ask a question and stream the answer as it arrives.
+
+        The signature is chatlas's, less `data_model`, so a chat UI can drive
+        this agent directly: shinychat calls
+        `stream_async(input, *contents, content="all", controller=controller)`
+        and needs the attachment content, the mode, and the controller its
+        stop button cancels through.
+
+        Structured output is left out rather than passed through: its chunks
+        are JSON to be parsed whole, and the provenance marker this appends
+        would make that JSON unparseable.
+        """
+        from_index = len(self._client.get_turns())
+        was_pending = self._restore_reminder_pending
+        inputs = self._prepare_turn_inputs(args)
+        self._citation_request.reset()
+        raw = await self._client.stream_async(
+            *inputs,
+            content=content,
+            echo=echo,
+            kwargs=kwargs,
+            controller=controller,
+        )
+        return self._projected(raw, from_index, was_pending)
+
+    # Citations are always projected, so reserved model markup cannot reach
+    # the browser whatever the display layer does with the stream.
+    async def _projected(
+        self,
+        raw: AsyncGenerator[Any, None],
+        from_index: int,
+        was_pending: bool,
+    ) -> AsyncGenerator[str | Content, None]:
+        scanner = CitationScanner(self._corpus)
+        async for chunk in raw:
+            # A provider's structured content passes through untouched; only
+            # the model's own text can carry the reserved dialect.
+            if not isinstance(chunk, str):
+                yield chunk
+                continue
+            projected = scanner.feed(chunk)
+            if projected:
+                yield projected
+
+        self._consume_restore_reminder(was_pending)
+
+        tail = scanner.finish()
+        if tail:
+            yield tail
+
+        tag = derive_provenance_tag(
+            collect_appended_tags(self._client.get_turns(), from_index),
+            scanner.any_verified,
+        )
+        aside = provenance_aside(tag)
+        if aside:
+            yield aside
+
+    # ---- what the agent knows --------------------------------------------
+
+    def citation_corpus(self) -> list[CorpusEntry]:
+        """The trusted text this agent's citations are verified against."""
+        return list(self._corpus)
+
+    def prewarm(self) -> None:
+        """Build the caches the first question would otherwise pay for.
+
+        Failures propagate: a direct call is typically warming caches ahead
+        of a deployment, so a cold cache should fail the deploy.
+        """
+        if self._context_layer is not None:
+            self._context_layer.prewarm()
+        for source in self._sources.values():
+            source.ensure_loaded()
+
+    # ---- the turn rules ---------------------------------------------------
+
+    def add_turn(self, turn: Turn) -> None:
+        """Add a turn, restarting the citation request if a person spoke.
+
+        A user turn of nothing but tool results is the same question still
+        running, and an assistant turn is nobody asking anything.
+        """
+        if isinstance(turn, UserTurn) and turn_has_user_message(turn):
+            self._citation_request.reset()
+        self._client.add_turn(turn)
+
+    def get_turns(self) -> list[Turn]:
+        """The conversation so far."""
+        return self._client.get_turns()
+
+    def set_turns(self, turns: Sequence[Turn]) -> None:
+        """Replace the conversation, dropping any reminder queued for it."""
+        self._restore_reminder_pending = False
+        self._client.set_turns(turns)
+
+    def queue_restore_reminder(self) -> None:
+        """Tell the next turn that the session behind its history is gone."""
+        self._restore_reminder_pending = True
+
+    def _prepare_turn_inputs(
+        self, inputs: Sequence[Content | str]
+    ) -> list[Content | str]:
+        prepared = append_turn_reminder(inputs, self._client.model)
+        if self._restore_reminder_pending:
+            prepared = append_restored_conversation_reminder(prepared)
+        return prepared
+
+    # Only a reminder that was pending when the turn started is spent, so a
+    # turn that failed, or one whose stream was never consumed, leaves the
+    # next turn to deliver it.
+    def _consume_restore_reminder(self, was_pending: bool) -> None:
+        if was_pending:
+            self._restore_reminder_pending = False
+
+
+def _warn_about_discarded_state(client: Chat) -> None:
+    discarded = []
+    if client.system_prompt is not None:
+        discarded.append("system prompt")
+    if client.get_tools():
+        discarded.append("tools")
+    if not discarded:
+        return
+    warnings.warn(
+        f"The {' and '.join(discarded)} set on client "
+        f"{'is' if len(discarded) == 1 else 'are'} discarded; commons builds "
+        "its own. Use `instructions` to add to commons' prompt.",
+        stacklevel=3,
+    )
+
+
+def _as_data_sources(
+    data_sources: DataSource | Mapping[str, DataSource],
+) -> dict[str, DataSource]:
+    if isinstance(data_sources, DataSource):
+        return {SOLE_SOURCE: data_sources}
+    if not isinstance(data_sources, Mapping):
+        raise TypeError(
+            "data_sources must be a DataSource from commons.data_source(), or a "
+            f"mapping of name to DataSource, not {type(data_sources).__name__}."
+        )
+    if not data_sources:
+        raise ValueError("data_sources must name at least one DataSource.")
+    wrong = [
+        name
+        for name, source in data_sources.items()
+        if not isinstance(source, DataSource)
+    ]
+    if wrong:
+        raise TypeError(
+            f"Every entry in data_sources must be a DataSource from "
+            f"commons.data_source(); {', '.join(sorted(wrong))} "
+            f"{'is' if len(wrong) == 1 else 'are'} not."
+        )
+    return dict(data_sources)
+
+
+# A measure can take a named source's connection as an argument named after
+# the source. A lone source passed on its own has no name to be asked for, so
+# it offers nothing to inject, as in pkg-r/R/commons.R.
+def _measure_injectables(
+    data_sources: DataSource | Mapping[str, DataSource],
+    sources: Mapping[str, DataSource],
+) -> dict[str, Any]:
+    if isinstance(data_sources, DataSource):
+        return {}
+    return {name: _connection(source) for name, source in sources.items()}
+
+
+def _connection(source: DataSource) -> Any:
+    """What a measure queries a source through.
+
+    The engine for a caller's database and the DuckDB connection for the
+    in-process one commons builds, which is what each was queried through
+    before it reached the measure.
+    """
+    backend = source.backend
+    if isinstance(backend, EngineBackend):
+        return backend.engine
+    if isinstance(backend, DuckDBBackend):
+        return backend.connection
+    raise TypeError(f"No connection to inject for a {type(backend).__name__}.")
+
+
+def _system_prompt(
+    sources: Mapping[str, DataSource],
+    definitions: Registry,
+    instructions: str | None,
+    tools: Sequence[Tool],
+    model: str | None,
+) -> str:
+    data = system_prompt_data(
+        sources,
+        definitions,
+        instructions=read_instructions(instructions),
+        tools=[tool.name for tool in tools],
+        model=model,
+    )
+    return render_system_prompt(system_prompt_template(), data)

--- a/pkg-py/src/commons/_agent.py
+++ b/pkg-py/src/commons/_agent.py
@@ -61,9 +61,10 @@ class Commons:
     sets its own system prompt, so an answer can be classified by how it was
     produced.
 
-    `client` is taken over rather than copied: its tools become the agent's
-    tools and its system prompt becomes commons' own. A system prompt already
-    set on it is discarded with a warning; use `instructions` to add to
+    The provider and the model come from `client`; the agent builds its own
+    chat from them, so nothing it does reaches an object the caller still
+    holds, and nothing already on that object reaches the agent. A system
+    prompt set on it is ignored with a warning; use `instructions` to add to
     commons' prompt instead.
 
     Parameters
@@ -98,8 +99,6 @@ class Commons:
                 "client must be a chatlas.Chat, e.g. from chatlas.ChatAnthropic(), "
                 f"not {type(client).__name__}."
             )
-        _warn_about_discarded_state(client)
-
         sources = _as_data_sources(data_sources)
         if context_layer is not None and not isinstance(context_layer, ContextLayer):
             raise TypeError(
@@ -116,7 +115,7 @@ class Commons:
             )
         check_instructions(instructions)
 
-        self._client = client
+        self._client = _agent_client(client)
         self._sources = sources
         self._context_layer = augment_context_layer(context_layer, sources.values())
         self._definitions = build_registry(sources)
@@ -147,13 +146,13 @@ class Commons:
                 first_touch=self._first_touch,
             )
         )
-        client.set_tools(list(tools))
-        client.system_prompt = _system_prompt(
+        self._client.set_tools(list(tools))
+        self._client.system_prompt = _system_prompt(
             sources,
             self._definitions,
             instructions=instructions,
             tools=tools,
-            model=client.model,
+            model=self._client.model,
         )
 
     def __repr__(self) -> str:
@@ -302,20 +301,53 @@ class Commons:
             self._restore_reminder_pending = False
 
 
-def _warn_about_discarded_state(client: Chat) -> None:
-    discarded = []
+# Called straight from __init__, so one stacklevel reaches whoever built the
+# agent from every warning below.
+_CALLER = 3
+
+
+def _agent_client(client: Chat) -> Chat:
+    """A chat of the caller's provider and model, holding none of its state.
+
+    The provider and the model come from `client`, and commons brings its own
+    system prompt and tools, as `pkg-r/R/commons.R` does when it initializes
+    from the client's provider. Building a chat rather than taking the given
+    one over means an agent never changes an object its caller still holds.
+    """
     if client.system_prompt is not None:
-        discarded.append("system prompt")
-    if client.get_tools():
-        discarded.append("tools")
-    if not discarded:
-        return
-    warnings.warn(
-        f"The {' and '.join(discarded)} set on client "
-        f"{'is' if len(discarded) == 1 else 'are'} discarded; commons builds "
-        "its own. Use `instructions` to add to commons' prompt.",
-        stacklevel=3,
-    )
+        warnings.warn(
+            "The system prompt set on client is ignored; commons builds its "
+            "own. Use `instructions` to add to commons' prompt.",
+            stacklevel=_CALLER,
+        )
+    if client.get_turns():
+        warnings.warn(
+            "An agent starts a new conversation, so the turns on client are "
+            "not carried over. Restore them with the agent's set_turns().",
+            stacklevel=_CALLER,
+        )
+
+    agent_client = Chat(provider=client.provider, kwargs_chat=client.kwargs_chat)
+    # chatlas never generates one, so an id the caller chose is theirs to keep.
+    agent_client.conversation_id = client.conversation_id
+
+    # chatlas has the setter for these and no getter, so they are read off the
+    # attribute behind it and written back through the public setter, which
+    # checks them against the provider again. An attribute that is missing, or
+    # no longer a mapping, has to be told apart from an empty one, which means
+    # nothing was set: dropping a temperature in silence is worse than saying
+    # that this chatlas does not show what was set.
+    params = getattr(client, "_standard_model_params", None)
+    if not isinstance(params, Mapping):
+        warnings.warn(
+            "Any model parameters set on client with set_model_params() are "
+            "not carried onto the agent: this version of chatlas does not "
+            "expose them.",
+            stacklevel=_CALLER,
+        )
+    elif params:
+        agent_client.set_model_params(**dict(params))
+    return agent_client
 
 
 def _as_data_sources(

--- a/pkg-py/src/commons/_agent.py
+++ b/pkg-py/src/commons/_agent.py
@@ -8,6 +8,7 @@ needs, plus the chatlas methods the two turn rules have to hook.
 
 from __future__ import annotations
 
+import copy
 import warnings
 from collections.abc import AsyncGenerator, Mapping, Sequence
 from typing import Any, Literal
@@ -327,7 +328,14 @@ def _agent_client(client: Chat) -> Chat:
             stacklevel=_CALLER,
         )
 
-    agent_client = Chat(provider=client.provider, kwargs_chat=client.kwargs_chat)
+    # The provider is shared rather than copied, because it is what carries
+    # the model the caller chose. Its arguments are copied one level deep, so
+    # adding or dropping one later does not cross between the two chats; a
+    # value inside one is left alone, since it can be anything a provider
+    # takes and copying it could fail.
+    agent_client = Chat(
+        provider=client.provider, kwargs_chat=copy.copy(client.kwargs_chat)
+    )
     # chatlas never generates one, so an id the caller chose is theirs to keep.
     agent_client.conversation_id = client.conversation_id
 

--- a/pkg-py/src/commons/_agent.py
+++ b/pkg-py/src/commons/_agent.py
@@ -1,9 +1,9 @@
 """The agent: its layers, the tools they earn, and the rules a turn follows.
 
 `pkg-r/R/commons.R` assembles the same agent for R, in the order this follows.
-A `chatlas.Chat` is composed rather than subclassed (decision D1 in the port
-plan), so the public surface is a choice R never had to make: what an agent
-needs, plus the chatlas methods the two turn rules have to hook.
+A `chatlas.Chat` is composed rather than subclassed (D1), so the public
+surface is a choice R never had to make: what an agent needs, plus the
+chatlas methods the two turn rules have to hook.
 """
 
 from __future__ import annotations
@@ -66,24 +66,20 @@ class Commons:
     chat from them, so nothing it does reaches an object the caller still
     holds, and nothing already on that object reaches the agent. A system
     prompt set on it is ignored with a warning; use `instructions` to add to
-    commons' prompt instead.
+    commons' prompt instead. For best results, enable thinking where the
+    provider and model support it.
 
-    Parameters
-    ----------
-    client
-        A `chatlas.Chat` giving the provider and model to use. For best
-        results, enable thinking where the provider and model support it.
-    data_sources
-        A `DataSource`, or a mapping of name to `DataSource`. A measure can
-        take a named source's connection as an argument named after it.
-    semantic_layer
-        An optional `SemanticLayer` of measures.
-    context_layer
-        An optional `ContextLayer` of prose.
-    instructions
-        Extra instructions placed under an `## Additional instructions`
-        heading at the end of commons' built-in system prompt, as a string or
-        the path to a text or Markdown file.
+    `data_sources` is a `DataSource`, or a mapping of name to `DataSource`;
+    a measure can take a named source's connection as an argument named
+    after it. `instructions` is extra text placed under an
+    `## Additional instructions` heading at the end of commons' built-in
+    system prompt, as a string or the path to a text or Markdown file.
+
+    Construction raises a TypeError if `client` is not a `chatlas.Chat`, if
+    an entry of `data_sources` is not a `DataSource`, or if a layer is not
+    the layer its argument claims; a ValueError if `data_sources` names no
+    source or a measure asks for an injection no named source can fill; and
+    a FileNotFoundError if `instructions` names a file that does not exist.
     """
 
     def __init__(
@@ -100,6 +96,10 @@ class Commons:
                 "client must be a chatlas.Chat, e.g. from chatlas.ChatAnthropic(), "
                 f"not {type(client).__name__}."
             )
+        # What the client carried is warned about before any other argument
+        # is checked, as pkg-r/R/commons.R does, so a bad later argument
+        # does not eat the warning.
+        _warn_ignored_client_state(client)
         sources = _as_data_sources(data_sources)
         if context_layer is not None and not isinstance(context_layer, ContextLayer):
             raise TypeError(
@@ -170,7 +170,11 @@ class Commons:
         stream: bool = True,
         kwargs: SubmitInputArgsT | None = None,
     ) -> ChatResponse:
-        """Ask a question and wait for the whole answer."""
+        """Ask a question and wait for the whole answer.
+
+        A reminder queued with `queue_restore_reminder()` rides this turn,
+        and a turn that fails leaves it queued for the next one.
+        """
         was_pending = self._restore_reminder_pending
         inputs = self._prepare_turn_inputs(args)
         self._citation_request.reset()
@@ -220,15 +224,20 @@ class Commons:
         was_pending: bool,
     ) -> AsyncGenerator[str | Content, None]:
         scanner = CitationScanner(self._corpus)
-        async for chunk in raw:
-            # A provider's structured content passes through untouched; only
-            # the model's own text can carry the reserved dialect.
-            if not isinstance(chunk, str):
-                yield chunk
-                continue
-            projected = scanner.feed(chunk)
-            if projected:
-                yield projected
+        try:
+            async for chunk in raw:
+                # A provider's structured content passes through untouched;
+                # only the model's own text can carry the reserved dialect.
+                if not isinstance(chunk, str):
+                    yield chunk
+                    continue
+                projected = scanner.feed(chunk)
+                if projected:
+                    yield projected
+        finally:
+            # A consumer that walks away early without cancelling still
+            # closes the provider's stream.
+            await raw.aclose()
 
         self._consume_restore_reminder(was_pending)
 
@@ -273,9 +282,17 @@ class Commons:
             self._citation_request.reset()
         self._client.add_turn(turn)
 
-    def get_turns(self) -> list[Turn]:
-        """The conversation so far."""
-        return self._client.get_turns()
+    def get_turns(
+        self,
+        *,
+        include_system_prompt: bool = False,
+        tool_result_role: Literal["assistant", "user"] = "user",
+    ) -> list[Turn]:
+        """The conversation so far, through chatlas's own view options."""
+        return self._client.get_turns(
+            include_system_prompt=include_system_prompt,
+            tool_result_role=tool_result_role,
+        )
 
     def set_turns(self, turns: Sequence[Turn]) -> None:
         """Replace the conversation, dropping any reminder queued for it."""
@@ -307,14 +324,8 @@ class Commons:
 _CALLER = 3
 
 
-def _agent_client(client: Chat) -> Chat:
-    """A chat of the caller's provider and model, holding none of its state.
-
-    The provider and the model come from `client`, and commons brings its own
-    system prompt and tools, as `pkg-r/R/commons.R` does when it initializes
-    from the client's provider. Building a chat rather than taking the given
-    one over means an agent never changes an object its caller still holds.
-    """
+def _warn_ignored_client_state(client: Chat) -> None:
+    """Warn about whatever the agent's own chat will not carry over."""
     if client.system_prompt is not None:
         warnings.warn(
             "The system prompt set on client is ignored; commons builds its "
@@ -328,6 +339,15 @@ def _agent_client(client: Chat) -> Chat:
             stacklevel=_CALLER,
         )
 
+
+def _agent_client(client: Chat) -> Chat:
+    """A chat of the caller's provider and model, holding none of its state.
+
+    The provider and the model come from `client`, and commons brings its own
+    system prompt and tools, as `pkg-r/R/commons.R` does when it initializes
+    from the client's provider. Building a chat rather than taking the given
+    one over means an agent never changes an object its caller still holds.
+    """
     # The provider is shared rather than copied, because it is what carries
     # the model the caller chose. Its arguments are copied one level deep, so
     # adding or dropping one later does not cross between the two chats; a

--- a/pkg-py/src/commons/_citations.py
+++ b/pkg-py/src/commons/_citations.py
@@ -244,7 +244,7 @@ def citation_aside_html(quote: str, explanation: str, label: str, kind: str) -> 
 
     ``kind`` selects the icon the UI layer draws beside the label. No icon is
     emitted yet: the URL comes from the served asset bundle, which arrives with
-    the Python UI (see decision D10 in the port plan).
+    the Python UI (D10).
     """
     reason = f"{explanation}\n\n" if explanation else ""
     blockquote = "> " + quote.strip().replace("\n", "\n> ")

--- a/pkg-py/tests/_provider.py
+++ b/pkg-py/tests/_provider.py
@@ -1,0 +1,121 @@
+"""A chatlas provider that replays a script, so the real chat loop runs offline.
+
+Every part of chatlas an agent leans on is real here: the tool loop, the turns
+it appends, the streamed chunk types, and the controller a stop button cancels
+through. Only the network call is scripted, which is what lets a test assert
+on what the agent does with a model's answer without having a model.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterable, Sequence
+from typing import Any
+
+from chatlas import Chat, Turn
+from chatlas._provider import Provider
+from chatlas._turn import AssistantTurn
+from chatlas.types import Content, ContentText, ModelInfo
+
+
+class ScriptedProvider(Provider):
+    """Answer each request with the next scripted list of content chunks."""
+
+    def __init__(
+        self,
+        responses: Iterable[Sequence[Content]] = (),
+        model: str = "claude-sonnet-4-5",
+    ) -> None:
+        super().__init__(name="scripted", model=model)
+        self.responses = [list(response) for response in responses]
+        self.requests: list[list[Turn]] = []
+
+    def _next_response(self) -> list[Content]:
+        if self.responses:
+            return self.responses.pop(0)
+        return [ContentText(text="Nothing more to say.")]
+
+    async def chat_perform_async(  # type: ignore[override]
+        self,
+        *,
+        stream: bool,
+        turns: list[Turn],
+        tools: Any,
+        data_model: Any,
+        kwargs: Any,
+    ) -> AsyncIterator[Content]:
+        self.requests.append(list(turns))
+        response = self._next_response()
+
+        async def chunks() -> AsyncIterator[Content]:
+            for chunk in response:
+                yield chunk
+
+        return chunks()
+
+    def chat_perform(  # type: ignore[override]
+        self,
+        *,
+        stream: bool,
+        turns: list[Turn],
+        tools: Any,
+        data_model: Any,
+        kwargs: Any,
+    ) -> Iterable[Content]:
+        self.requests.append(list(turns))
+        return self._next_response()
+
+    # A chunk is already the content it stands for, so merging is collecting.
+    def stream_merge_chunks(self, completion: Any, chunk: Any) -> list[Content]:
+        return [*(completion or []), chunk]
+
+    def stream_content(
+        self, chunk: Any, completion: Any, turns: Sequence[Turn] = ()
+    ) -> Sequence[Content]:
+        return [chunk]
+
+    def stream_turn(
+        self, completion: Any, has_data_model: bool, turns: Sequence[Turn] = ()
+    ) -> AssistantTurn[Any]:
+        return AssistantTurn(list(completion or []))
+
+    def value_turn(
+        self, completion: Any, has_data_model: bool, turns: Sequence[Turn] = ()
+    ) -> AssistantTurn[Any]:
+        return AssistantTurn(list(completion or []))
+
+    def value_tokens(self, completion: Any) -> tuple[int, int, int] | None:
+        return None
+
+    def token_count(self, turns: list[Turn], *, tools: Any, data_model: Any) -> int:
+        return 0
+
+    async def token_count_async(
+        self, turns: list[Turn], *, tools: Any, data_model: Any
+    ) -> int:
+        return 0
+
+    def translate_model_params(self, params: Any) -> Any:
+        return {}
+
+    def supported_model_params(self) -> set[Any]:
+        return set()
+
+    def list_models(self) -> list[ModelInfo]:
+        return []
+
+
+def scripted_chat(
+    responses: Iterable[Sequence[Content]] = (),
+    model: str = "claude-sonnet-4-5",
+) -> Chat:
+    """A real `chatlas.Chat` whose provider replays `responses`."""
+    return Chat(provider=ScriptedProvider(responses, model=model))
+
+
+def text(*chunks: str) -> list[Content]:
+    """One scripted response streaming `chunks` as separate text pieces."""
+    return [ContentText(text=chunk) for chunk in chunks]
+
+
+async def collect(stream: AsyncIterator[Any]) -> list[Any]:
+    return [chunk async for chunk in stream]

--- a/pkg-py/tests/_provider.py
+++ b/pkg-py/tests/_provider.py
@@ -97,8 +97,20 @@ class ScriptedProvider(Provider):
     def translate_model_params(self, params: Any) -> Any:
         return {}
 
+    # A real provider supports most of these, and chatlas drops any it does
+    # not, so declaring them is what lets set_model_params() be exercised.
     def supported_model_params(self) -> set[Any]:
-        return set()
+        return {
+            "temperature",
+            "top_p",
+            "top_k",
+            "frequency_penalty",
+            "presence_penalty",
+            "seed",
+            "max_tokens",
+            "log_probs",
+            "stop_sequences",
+        }
 
     def list_models(self) -> list[ModelInfo]:
         return []

--- a/pkg-py/tests/test_agent.py
+++ b/pkg-py/tests/test_agent.py
@@ -11,6 +11,7 @@ from pydantic import Field
 from commons import Injected, context_layer, data_source, measure, semantic_layer
 from commons._agent import Commons
 from commons._citations import CorpusEntry
+from commons._reminders import RESTORED_CONVERSATION_REMINDER, ContentTurnReminder
 
 from ._provider import ScriptedProvider, scripted_chat, text
 
@@ -129,6 +130,20 @@ def test_the_clients_history_warns_and_does_not_carry_over(
     assert len(client.get_turns()) == 1
 
 
+def test_ignored_client_state_warns_before_other_arguments_fail(
+    client: Chat,
+) -> None:
+    client.system_prompt = "You are a pirate."
+
+    # pkg-r/R/commons.R warns about the ignored prompt before it checks
+    # anything else, so a bad later argument does not eat the warning.
+    with (
+        pytest.warns(UserWarning, match="system prompt"),
+        pytest.raises(TypeError, match="commons.data_source"),
+    ):
+        Commons(client, "sales")  # type: ignore[arg-type]
+
+
 # ---- the agent's own chat -------------------------------------------------
 
 
@@ -180,6 +195,13 @@ def test_the_provider_arguments_and_conversation_id_carry_over(
     assert agent._client.conversation_id == "abc123"
     # The provider carries the model, so it is shared on purpose.
     assert agent._client.provider is client.provider
+
+
+def test_get_turns_offers_chatlas_own_views(client: Chat, source: Any) -> None:
+    agent = Commons(client, source)
+
+    assert agent.get_turns() == []
+    assert agent.get_turns(include_system_prompt=True)[0].text == prompt(agent)
 
 
 # ---- assembly -------------------------------------------------------------
@@ -460,3 +482,47 @@ def test_the_scripted_provider_answers_offline(client: Chat, source: Any) -> Non
     agent = Commons(scripted_chat([text("Two orders.")]), source)
 
     assert str(agent.chat("How many orders?", echo="none")) == "Two orders."
+
+
+# ---- the turn rules, asked over chat() -------------------------------------
+
+
+def test_a_chat_turn_carries_the_models_reminder(source: Any) -> None:
+    agent = Commons(scripted_chat([text("Answer.")], model="claude-opus-5"), source)
+
+    agent.chat("How many orders?", echo="none")
+
+    reminders = [
+        content
+        for content in agent.get_turns()[0].contents
+        if isinstance(content, ContentTurnReminder)
+    ]
+    assert len(reminders) == 1
+
+
+def test_a_successful_chat_spends_the_queued_restore_reminder(source: Any) -> None:
+    agent = Commons(scripted_chat([text("First."), text("Second.")]), source)
+    agent.queue_restore_reminder()
+
+    agent.chat("First question.", echo="none")
+
+    first = agent.get_turns()[0].contents
+    assert [
+        content.text for content in first if isinstance(content, ContentTurnReminder)
+    ] == [RESTORED_CONVERSATION_REMINDER]
+    assert not agent._restore_reminder_pending
+
+    agent.chat("Second question.", echo="none")
+    second = agent.get_turns()[2].contents
+    assert not [
+        content for content in second if isinstance(content, ContentTurnReminder)
+    ]
+
+
+def test_a_chat_starts_a_new_citation_request(source: Any) -> None:
+    agent = Commons(scripted_chat([text("Answer.")]), source)
+    agent._citation_request.requested = True
+
+    agent.chat("How many orders?", echo="none")
+
+    assert not agent._citation_request.requested

--- a/pkg-py/tests/test_agent.py
+++ b/pkg-py/tests/test_agent.py
@@ -148,6 +148,9 @@ def test_model_parameters_carry_onto_the_agents_chat(client: Chat, source: Any) 
 
     agent = Commons(client, source)
 
+    # Reading chatlas' own attribute is the only way to see these, and doing
+    # it here on purpose means a chatlas that renames it fails loudly rather
+    # than leaving the warning path as the only thing still exercised.
     assert agent._client._standard_model_params == {"temperature": 0.0, "seed": 7}
 
 
@@ -171,9 +174,12 @@ def test_the_provider_arguments_and_conversation_id_carry_over(
     client.conversation_id = "abc123"
 
     agent = Commons(client, source)
+    client.kwargs_chat["max_tokens"] = 8  # type: ignore[typeddict-unknown-key]
 
     assert agent._client.kwargs_chat == {"max_tokens": 2048}
     assert agent._client.conversation_id == "abc123"
+    # The provider carries the model, so it is shared on purpose.
+    assert agent._client.provider is client.provider
 
 
 # ---- assembly -------------------------------------------------------------

--- a/pkg-py/tests/test_agent.py
+++ b/pkg-py/tests/test_agent.py
@@ -5,7 +5,7 @@ from typing import Annotated, Any
 
 import pandas as pd
 import pytest
-from chatlas import Chat, ContentToolResult, Tool
+from chatlas import Chat, ContentToolResult, Tool, UserTurn
 from pydantic import Field
 
 from commons import Injected, context_layer, data_source, measure, semantic_layer
@@ -45,18 +45,26 @@ def client() -> Chat:
     return scripted_chat()
 
 
-def tool_names(client: Chat) -> list[str]:
-    return [tool.name for tool in client.get_tools()]
+# The agent builds its own chat, so what it registered and what it tells the
+# model are read off the agent rather than off the client it was given.
+def tool_names(agent: Commons) -> list[str]:
+    return [tool.name for tool in agent._client.get_tools()]
 
 
-def agent_tool(client: Chat, name: str) -> Tool:
-    tool = next(tool for tool in client.get_tools() if tool.name == name)
+def prompt(agent: Commons) -> str:
+    system_prompt = agent._client.system_prompt
+    assert system_prompt is not None
+    return system_prompt
+
+
+def agent_tool(agent: Commons, name: str) -> Tool:
+    tool = next(tool for tool in agent._client.get_tools() if tool.name == name)
     assert isinstance(tool, Tool)
     return tool
 
 
-def call_tool(client: Chat, tool: str, /, **arguments: Any) -> str:
-    result = agent_tool(client, tool).func(**arguments)
+def call_tool(agent: Commons, tool: str, /, **arguments: Any) -> str:
+    result = agent_tool(agent, tool).func(**arguments)
     assert isinstance(result, ContentToolResult)
     assert isinstance(result.value, str)
     return result.value
@@ -98,29 +106,74 @@ def test_instructions_naming_a_missing_file_fail_at_construction(
         Commons(client, source, instructions=str(tmp_path / "absent.md"))
 
 
-def test_a_system_prompt_on_the_client_warns_and_is_discarded(
+def test_a_system_prompt_on_the_client_warns_and_is_ignored(
     client: Chat, source: Any
 ) -> None:
     client.system_prompt = "You are a pirate."
 
     with pytest.warns(UserWarning, match="system prompt"):
+        agent = Commons(client, source)
+
+    assert "pirate" not in prompt(agent)
+
+
+def test_the_clients_history_warns_and_does_not_carry_over(
+    client: Chat, source: Any
+) -> None:
+    client.add_turn(UserTurn("An earlier question."))
+
+    with pytest.warns(UserWarning, match="set_turns"):
+        agent = Commons(client, source)
+
+    assert agent.get_turns() == []
+    assert len(client.get_turns()) == 1
+
+
+# ---- the agent's own chat -------------------------------------------------
+
+
+def test_the_client_it_was_given_is_left_alone(client: Chat, source: Any) -> None:
+    agent = Commons(client, source)
+
+    # The agent brings its own tools and prompt, and someone else may still be
+    # holding this object, so none of that reaches it.
+    assert client.get_tools() == []
+    assert client.system_prompt is None
+    assert tool_names(agent)
+    assert agent._client is not client
+
+
+def test_model_parameters_carry_onto_the_agents_chat(client: Chat, source: Any) -> None:
+    client.set_model_params(temperature=0.0, seed=7)
+
+    agent = Commons(client, source)
+
+    assert agent._client._standard_model_params == {"temperature": 0.0, "seed": 7}
+
+
+def test_model_parameters_that_cannot_be_read_are_reported(
+    client: Chat, source: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client.set_model_params(temperature=0.0)
+    # chatlas has a setter and no getter, so the values are read off the
+    # attribute behind it; a chatlas that renames it says so rather than
+    # dropping a temperature in silence.
+    monkeypatch.delattr(client, "_standard_model_params")
+
+    with pytest.warns(UserWarning, match="set_model_params"):
         Commons(client, source)
 
-    assert client.system_prompt is not None
-    assert "pirate" not in client.system_prompt
 
+def test_the_provider_arguments_and_conversation_id_carry_over(
+    client: Chat, source: Any
+) -> None:
+    client.kwargs_chat = {"max_tokens": 2048}  # type: ignore[typeddict-unknown-key]
+    client.conversation_id = "abc123"
 
-def test_tools_on_the_client_warn_and_are_discarded(client: Chat, source: Any) -> None:
-    def unrelated() -> str:
-        """Do something else."""
-        return "done"
+    agent = Commons(client, source)
 
-    client.register_tool(unrelated)
-
-    with pytest.warns(UserWarning, match="tools"):
-        Commons(client, source)
-
-    assert "unrelated" not in tool_names(client)
+    assert agent._client.kwargs_chat == {"max_tokens": 2048}
+    assert agent._client.conversation_id == "abc123"
 
 
 # ---- assembly -------------------------------------------------------------
@@ -129,12 +182,12 @@ def test_tools_on_the_client_warn_and_are_discarded(client: Chat, source: Any) -
 def test_an_agent_registers_the_tools_its_composition_earns(
     client: Chat, source: Any
 ) -> None:
-    Commons(client, source)
+    agent = Commons(client, source)
 
     # Which conditions earn which tool is pinned by
     # tests/shared/tool-registration.json; what matters here is that the
     # agent's own composition is what they were asked about.
-    assert tool_names(client) == ["search_context", "describe_table", "run_sql"]
+    assert tool_names(agent) == ["search_context", "describe_table", "run_sql"]
 
 
 def test_a_semantic_layer_earns_the_measure_tools(client: Chat, source: Any) -> None:
@@ -142,24 +195,20 @@ def test_a_semantic_layer_earns_the_measure_tools(client: Chat, source: Any) -> 
     def order_count() -> int:
         return 3
 
-    Commons(client, source, semantic_layer=semantic_layer(order_count))
+    agent = Commons(client, source, semantic_layer=semantic_layer(order_count))
 
-    assert "search_pool" in tool_names(client)
-    assert "call_measure" in tool_names(client)
+    assert "search_pool" in tool_names(agent)
+    assert "call_measure" in tool_names(agent)
 
 
 def test_the_system_prompt_names_the_tables(client: Chat, source: Any) -> None:
-    Commons(client, source)
-
-    assert client.system_prompt is not None
-    assert "- sales" in client.system_prompt
+    assert "- sales" in prompt(Commons(client, source))
 
 
 def test_instructions_are_appended_to_the_prompt(client: Chat, source: Any) -> None:
-    Commons(client, source, instructions="Use fiscal-year conventions.")
+    agent = Commons(client, source, instructions="Use fiscal-year conventions.")
 
-    assert client.system_prompt is not None
-    assert client.system_prompt.endswith("Use fiscal-year conventions.")
+    assert prompt(agent).endswith("Use fiscal-year conventions.")
 
 
 def test_instructions_can_be_read_from_a_file(
@@ -168,10 +217,9 @@ def test_instructions_can_be_read_from_a_file(
     path = tmp_path / "house-style.md"
     path.write_text("Round revenue to whole dollars.", encoding="utf-8")
 
-    Commons(client, source, instructions=str(path))
+    agent = Commons(client, source, instructions=str(path))
 
-    assert client.system_prompt is not None
-    assert client.system_prompt.endswith("Round revenue to whole dollars.")
+    assert prompt(agent).endswith("Round revenue to whole dollars.")
 
 
 def test_the_prompt_describes_the_tools_the_agent_actually_has(
@@ -181,24 +229,21 @@ def test_the_prompt_describes_the_tools_the_agent_actually_has(
     def order_count() -> int:
         return 3
 
-    Commons(client, source, semantic_layer=semantic_layer(order_count))
-    with_measures = client.system_prompt or ""
-
-    bare = scripted_chat()
-    Commons(bare, source)
+    with_measures = prompt(
+        Commons(client, source, semantic_layer=semantic_layer(order_count))
+    )
+    bare = prompt(Commons(scripted_chat(), source))
 
     assert "call_measure" in with_measures
-    assert "call_measure" not in (bare.system_prompt or "")
+    assert "call_measure" not in bare
 
 
 def test_the_model_decides_which_reminder_the_prompt_expects(source: Any) -> None:
-    five = scripted_chat(model="claude-opus-5")
-    Commons(five, source)
-    four = scripted_chat(model="claude-sonnet-4-5")
-    Commons(four, source)
+    five = prompt(Commons(scripted_chat(model="claude-opus-5"), source))
+    four = prompt(Commons(scripted_chat(model="claude-sonnet-4-5"), source))
 
     # is_claude_5_model() drives one prompt section, so the two differ.
-    assert five.system_prompt != four.system_prompt
+    assert five != four
 
 
 def test_the_context_layer_gains_the_sources_prose(
@@ -252,8 +297,8 @@ def test_the_conversation_state_is_the_agents_own(client: Chat, source: Any) -> 
 def test_one_handle_store_serves_every_tool_call(client: Chat, source: Any) -> None:
     agent = Commons(client, source)
 
-    call_tool(client, "run_sql", sql="SELECT revenue FROM sales")
-    call_tool(client, "run_sql", sql="SELECT region FROM sales")
+    call_tool(agent, "run_sql", sql="SELECT revenue FROM sales")
+    call_tool(agent, "run_sql", sql="SELECT region FROM sales")
 
     assert agent._handles.ids() == ["r1", "r2"]
 
@@ -263,10 +308,10 @@ def test_a_tables_dictionary_entry_is_delivered_once_per_conversation(
 ) -> None:
     path = tmp_path / "data-dict.yaml"
     path.write_text(DICTIONARY, encoding="utf-8")
-    Commons(client, data_source(sales=frame(), dictionary=path))
+    agent = Commons(client, data_source(sales=frame(), dictionary=path))
 
-    first = call_tool(client, "run_sql", sql="SELECT revenue FROM sales")
-    second = call_tool(client, "run_sql", sql="SELECT region FROM sales")
+    first = call_tool(agent, "run_sql", sql="SELECT revenue FROM sales")
+    second = call_tool(agent, "run_sql", sql="SELECT region FROM sales")
 
     assert "One row per order line." in first
     assert "One row per order line." not in second
@@ -281,12 +326,12 @@ def test_a_measure_receives_a_named_sources_connection(client: Chat) -> None:
         rows = warehouse.execute("SELECT count(*) AS n FROM sales").fetchall()
         return int(rows[0][0])
 
-    Commons(
+    agent = Commons(
         client,
         {"warehouse": data_source(sales=frame())},
         semantic_layer=semantic_layer(order_count),
     )
-    result = call_tool(client, "call_measure", name="order_count", arguments="{}")
+    result = call_tool(agent, "call_measure", name="order_count", arguments="{}")
 
     assert "3" in result
 
@@ -304,13 +349,13 @@ def test_a_measure_can_still_take_an_argument_the_model_supplies(
         ).fetchall()
         return float(rows[0][0])
 
-    Commons(
+    agent = Commons(
         client,
         {"warehouse": data_source(sales=frame())},
         semantic_layer=semantic_layer(region_revenue),
     )
     result = call_tool(
-        client, "call_measure", name="region_revenue", arguments='{"region": "EMEA"}'
+        agent, "call_measure", name="region_revenue", arguments='{"region": "EMEA"}'
     )
 
     assert "800" in result
@@ -388,10 +433,13 @@ def test_prewarm_propagates_a_failure(client: Chat, tmp_path: Path) -> None:
 # ---- the model the prompt was built for -----------------------------------
 
 
-def test_the_agent_keeps_the_clients_provider(client: Chat, source: Any) -> None:
-    Commons(client, source)
+def test_the_agent_asks_the_clients_own_provider(client: Chat, source: Any) -> None:
+    agent = Commons(client, source)
 
-    assert isinstance(client.provider, ScriptedProvider)
+    # The provider carries the model, so taking it is how the agent ends up
+    # talking to what the caller chose.
+    assert agent._client.provider is client.provider
+    assert isinstance(agent._client.provider, ScriptedProvider)
 
 
 def test_an_agent_says_how_many_sources_it_has(client: Chat, source: Any) -> None:

--- a/pkg-py/tests/test_agent.py
+++ b/pkg-py/tests/test_agent.py
@@ -1,0 +1,408 @@
+"""Building an agent: what it validates, what it assembles, and what it warms."""
+
+from pathlib import Path
+from typing import Annotated, Any
+
+import pandas as pd
+import pytest
+from chatlas import Chat, ContentToolResult, Tool
+from pydantic import Field
+
+from commons import Injected, context_layer, data_source, measure, semantic_layer
+from commons._agent import Commons
+from commons._citations import CorpusEntry
+
+from ._provider import ScriptedProvider, scripted_chat, text
+
+DICTIONARY = """
+name: sales
+description: What the shop sold.
+tables:
+  - name: sales
+    description: One row per order line.
+    columns:
+      - name: revenue
+        type: number
+        description: Line revenue.
+      - name: region
+        type: string
+"""
+
+
+def frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {"revenue": [500.0, 900.0, 300.0], "region": ["EMEA", "Americas", "EMEA"]}
+    )
+
+
+@pytest.fixture
+def source() -> Any:
+    return data_source(sales=frame())
+
+
+@pytest.fixture
+def client() -> Chat:
+    return scripted_chat()
+
+
+def tool_names(client: Chat) -> list[str]:
+    return [tool.name for tool in client.get_tools()]
+
+
+def agent_tool(client: Chat, name: str) -> Tool:
+    tool = next(tool for tool in client.get_tools() if tool.name == name)
+    assert isinstance(tool, Tool)
+    return tool
+
+
+def call_tool(client: Chat, tool: str, /, **arguments: Any) -> str:
+    result = agent_tool(client, tool).func(**arguments)
+    assert isinstance(result, ContentToolResult)
+    assert isinstance(result.value, str)
+    return result.value
+
+
+# ---- validation -----------------------------------------------------------
+
+
+def test_the_client_has_to_be_a_chat(source: Any) -> None:
+    with pytest.raises(TypeError, match="chatlas.Chat"):
+        Commons("not a chat", source)  # type: ignore[arg-type]
+
+
+def test_data_sources_has_to_hold_data_sources(client: Chat) -> None:
+    with pytest.raises(TypeError, match="commons.data_source"):
+        Commons(client, "sales")  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="warehouse is not"):
+        Commons(client, {"warehouse": frame()})  # type: ignore[dict-item]
+
+
+def test_an_agent_needs_at_least_one_data_source(client: Chat) -> None:
+    with pytest.raises(ValueError, match="at least one DataSource"):
+        Commons(client, {})
+
+
+def test_the_layers_have_to_be_layers(client: Chat, source: Any) -> None:
+    with pytest.raises(TypeError, match="commons.context_layer"):
+        Commons(client, source, context_layer="notes.md")  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="commons.semantic_layer"):
+        Commons(client, source, semantic_layer=[])  # type: ignore[arg-type]
+
+
+def test_instructions_naming_a_missing_file_fail_at_construction(
+    client: Chat, source: Any, tmp_path: Path
+) -> None:
+    with pytest.raises(FileNotFoundError):
+        Commons(client, source, instructions=str(tmp_path / "absent.md"))
+
+
+def test_a_system_prompt_on_the_client_warns_and_is_discarded(
+    client: Chat, source: Any
+) -> None:
+    client.system_prompt = "You are a pirate."
+
+    with pytest.warns(UserWarning, match="system prompt"):
+        Commons(client, source)
+
+    assert client.system_prompt is not None
+    assert "pirate" not in client.system_prompt
+
+
+def test_tools_on_the_client_warn_and_are_discarded(client: Chat, source: Any) -> None:
+    def unrelated() -> str:
+        """Do something else."""
+        return "done"
+
+    client.register_tool(unrelated)
+
+    with pytest.warns(UserWarning, match="tools"):
+        Commons(client, source)
+
+    assert "unrelated" not in tool_names(client)
+
+
+# ---- assembly -------------------------------------------------------------
+
+
+def test_an_agent_registers_the_tools_its_composition_earns(
+    client: Chat, source: Any
+) -> None:
+    Commons(client, source)
+
+    # Which conditions earn which tool is pinned by
+    # tests/shared/tool-registration.json; what matters here is that the
+    # agent's own composition is what they were asked about.
+    assert tool_names(client) == ["search_context", "describe_table", "run_sql"]
+
+
+def test_a_semantic_layer_earns_the_measure_tools(client: Chat, source: Any) -> None:
+    @measure(description="Count orders.")
+    def order_count() -> int:
+        return 3
+
+    Commons(client, source, semantic_layer=semantic_layer(order_count))
+
+    assert "search_pool" in tool_names(client)
+    assert "call_measure" in tool_names(client)
+
+
+def test_the_system_prompt_names_the_tables(client: Chat, source: Any) -> None:
+    Commons(client, source)
+
+    assert client.system_prompt is not None
+    assert "- sales" in client.system_prompt
+
+
+def test_instructions_are_appended_to_the_prompt(client: Chat, source: Any) -> None:
+    Commons(client, source, instructions="Use fiscal-year conventions.")
+
+    assert client.system_prompt is not None
+    assert client.system_prompt.endswith("Use fiscal-year conventions.")
+
+
+def test_instructions_can_be_read_from_a_file(
+    client: Chat, source: Any, tmp_path: Path
+) -> None:
+    path = tmp_path / "house-style.md"
+    path.write_text("Round revenue to whole dollars.", encoding="utf-8")
+
+    Commons(client, source, instructions=str(path))
+
+    assert client.system_prompt is not None
+    assert client.system_prompt.endswith("Round revenue to whole dollars.")
+
+
+def test_the_prompt_describes_the_tools_the_agent_actually_has(
+    client: Chat, source: Any
+) -> None:
+    @measure(description="Count orders.")
+    def order_count() -> int:
+        return 3
+
+    Commons(client, source, semantic_layer=semantic_layer(order_count))
+    with_measures = client.system_prompt or ""
+
+    bare = scripted_chat()
+    Commons(bare, source)
+
+    assert "call_measure" in with_measures
+    assert "call_measure" not in (bare.system_prompt or "")
+
+
+def test_the_model_decides_which_reminder_the_prompt_expects(source: Any) -> None:
+    five = scripted_chat(model="claude-opus-5")
+    Commons(five, source)
+    four = scripted_chat(model="claude-sonnet-4-5")
+    Commons(four, source)
+
+    # is_claude_5_model() drives one prompt section, so the two differ.
+    assert five.system_prompt != four.system_prompt
+
+
+def test_the_context_layer_gains_the_sources_prose(
+    client: Chat, source: Any, tmp_path: Path
+) -> None:
+    path = tmp_path / "data-dict.yaml"
+    path.write_text(DICTIONARY, encoding="utf-8")
+    documented = data_source(sales=frame(), dictionary=path)
+    notes = tmp_path / "notes.md"
+    notes.write_text("Revenue means booked revenue.", encoding="utf-8")
+    layer = context_layer(files=[notes])
+
+    agent = Commons(client, documented, context_layer=layer)
+
+    assert agent._context_layer is not None
+    assert agent._context_layer is not layer
+    assert len(agent._context_layer.docs) > len(layer.docs)
+    # The caller's layer is left as it was, so a second agent starts clean.
+    assert layer.docs == ("Revenue means booked revenue.",)
+
+
+def test_an_agent_with_nothing_to_retrieve_has_no_context_layer(
+    client: Chat, source: Any
+) -> None:
+    assert Commons(client, source)._context_layer is None
+
+
+def test_the_citation_corpus_holds_the_trusted_text(
+    client: Chat, source: Any, tmp_path: Path
+) -> None:
+    notes = tmp_path / "notes.md"
+    notes.write_text("Canopy cover is always acre-weighted.", encoding="utf-8")
+
+    agent = Commons(client, source, context_layer=context_layer(files=[notes]))
+
+    corpus = agent.citation_corpus()
+    assert all(isinstance(entry, CorpusEntry) for entry in corpus)
+    assert any("acre-weighted" in entry.text for entry in corpus)
+
+
+def test_the_conversation_state_is_the_agents_own(client: Chat, source: Any) -> None:
+    first = Commons(client, source)
+    second = Commons(scripted_chat(), source)
+
+    first._handles.register(frame())
+
+    assert first._handles.ids() == ["r1"]
+    assert second._handles.ids() == []
+
+
+def test_one_handle_store_serves_every_tool_call(client: Chat, source: Any) -> None:
+    agent = Commons(client, source)
+
+    call_tool(client, "run_sql", sql="SELECT revenue FROM sales")
+    call_tool(client, "run_sql", sql="SELECT region FROM sales")
+
+    assert agent._handles.ids() == ["r1", "r2"]
+
+
+def test_a_tables_dictionary_entry_is_delivered_once_per_conversation(
+    client: Chat, tmp_path: Path
+) -> None:
+    path = tmp_path / "data-dict.yaml"
+    path.write_text(DICTIONARY, encoding="utf-8")
+    Commons(client, data_source(sales=frame(), dictionary=path))
+
+    first = call_tool(client, "run_sql", sql="SELECT revenue FROM sales")
+    second = call_tool(client, "run_sql", sql="SELECT region FROM sales")
+
+    assert "One row per order line." in first
+    assert "One row per order line." not in second
+
+
+# ---- injected measure arguments -------------------------------------------
+
+
+def test_a_measure_receives_a_named_sources_connection(client: Chat) -> None:
+    @measure(description="Count orders.")
+    def order_count(warehouse: Injected[Any]) -> int:
+        rows = warehouse.execute("SELECT count(*) AS n FROM sales").fetchall()
+        return int(rows[0][0])
+
+    Commons(
+        client,
+        {"warehouse": data_source(sales=frame())},
+        semantic_layer=semantic_layer(order_count),
+    )
+    result = call_tool(client, "call_measure", name="order_count", arguments="{}")
+
+    assert "3" in result
+
+
+def test_a_measure_can_still_take_an_argument_the_model_supplies(
+    client: Chat,
+) -> None:
+    @measure(description="Revenue for a region.")
+    def region_revenue(
+        region: Annotated[str, Field(description="The sales region.")],
+        warehouse: Injected[Any],
+    ) -> float:
+        rows = warehouse.execute(
+            "SELECT sum(revenue) AS total FROM sales WHERE region = ?", [region]
+        ).fetchall()
+        return float(rows[0][0])
+
+    Commons(
+        client,
+        {"warehouse": data_source(sales=frame())},
+        semantic_layer=semantic_layer(region_revenue),
+    )
+    result = call_tool(
+        client, "call_measure", name="region_revenue", arguments='{"region": "EMEA"}'
+    )
+
+    assert "800" in result
+
+
+def test_an_injected_argument_matching_no_source_fails_at_construction(
+    client: Chat, source: Any
+) -> None:
+    @measure(description="Count orders.")
+    def order_count(warehouse: Injected[Any]) -> int:
+        return 0
+
+    with pytest.raises(ValueError, match="order_count"):
+        Commons(client, {"finance": source}, semantic_layer=semantic_layer(order_count))
+
+
+def test_a_lone_unnamed_source_has_no_name_to_inject_by(
+    client: Chat, source: Any
+) -> None:
+    @measure(description="Count orders.")
+    def order_count(sales: Injected[Any]) -> int:
+        return 0
+
+    with pytest.raises(ValueError, match="no named data sources"):
+        Commons(client, source, semantic_layer=semantic_layer(order_count))
+
+
+# ---- prewarming -----------------------------------------------------------
+
+
+def test_prewarm_builds_the_context_store_before_the_first_search(
+    client: Chat, source: Any, tmp_path: Path
+) -> None:
+    notes = tmp_path / "notes.md"
+    notes.write_text("# Revenue\n\nRevenue means booked revenue.", encoding="utf-8")
+    agent = Commons(client, source, context_layer=context_layer(files=[notes]))
+    layer = agent._context_layer
+    assert layer is not None
+    assert layer._store_cache is None
+
+    agent.prewarm()
+
+    assert layer._store_cache is not None
+    assert "booked" in layer.search("revenue")[0]
+
+
+def test_prewarm_without_a_context_layer_is_a_no_op(client: Chat, source: Any) -> None:
+    Commons(client, source).prewarm()
+
+
+def test_prewarm_reads_a_boards_pins(client: Chat, tmp_path: Path) -> None:
+    pins = pytest.importorskip("pins")
+    board = pins.board_folder(str(tmp_path))
+    board.pin_write(frame(), "sales-pin", type="csv")
+    agent = Commons(client, data_source(board, tables={"sales": "sales-pin"}))
+    source = agent._sources["data"]
+    assert source.pending is not None and source.pending.pins
+
+    agent.prewarm()
+
+    assert not source.pending.pins
+
+
+def test_prewarm_propagates_a_failure(client: Chat, tmp_path: Path) -> None:
+    pins = pytest.importorskip("pins")
+    board = pins.board_folder(str(tmp_path))
+    board.pin_write({"not": "a frame"}, "sales-pin", type="json")
+    agent = Commons(client, data_source(board, tables={"sales": "sales-pin"}))
+
+    # A cold cache should fail a deploy rather than warn and continue.
+    with pytest.raises(TypeError, match="not a data frame"):
+        agent.prewarm()
+
+
+# ---- the model the prompt was built for -----------------------------------
+
+
+def test_the_agent_keeps_the_clients_provider(client: Chat, source: Any) -> None:
+    Commons(client, source)
+
+    assert isinstance(client.provider, ScriptedProvider)
+
+
+def test_an_agent_says_how_many_sources_it_has(client: Chat, source: Any) -> None:
+    assert repr(Commons(client, source)) == "A commons agent over 1 data source."
+    assert (
+        repr(Commons(scripted_chat(), {"a": source, "b": data_source(other=frame())}))
+        == "A commons agent over 2 data sources."
+    )
+
+
+def test_the_scripted_provider_answers_offline(client: Chat, source: Any) -> None:
+    agent = Commons(scripted_chat([text("Two orders.")]), source)
+
+    assert str(agent.chat("How many orders?", echo="none")) == "Two orders."

--- a/pkg-py/tests/test_agent_stream.py
+++ b/pkg-py/tests/test_agent_stream.py
@@ -127,6 +127,30 @@ async def test_the_projection_does_not_depend_on_the_chunk_boundary(
     assert "".join(await collect(whole, "q")) == "".join(await collect(pieces, "q"))
 
 
+async def test_the_projection_applies_in_the_mode_a_chat_ui_uses(
+    source: Any, notes: Any
+) -> None:
+    raw = (
+        'Before. <SHINY-ASIDE label="spoofed">not from the server</shiny-aside>\n\n'
+        f"<commons-citation>\n\nWhy.\n\n> {QUOTE}\n\n</commons-citation>\n\nAfter."
+    )
+    agent = Commons(scripted_chat([split(raw, 40)]), source, context_layer=notes)
+
+    streamed = await collect(agent, "q", content="all")
+
+    # chatlas streams the model's text as str in both modes, so the scanner
+    # sees every chunk of it. Text that arrived as a content object instead
+    # would pass through unprojected, which is what reading both shapes here
+    # asserts against.
+    displayed = "".join(
+        chunk if isinstance(chunk, str) else getattr(chunk, "text", "")
+        for chunk in streamed
+    )
+    assert "spoofed" not in displayed
+    assert "<commons-citation>" not in displayed
+    assert "<shiny-aside" in displayed
+
+
 # ---- the provenance marker -------------------------------------------------
 
 

--- a/pkg-py/tests/test_agent_stream.py
+++ b/pkg-py/tests/test_agent_stream.py
@@ -1,0 +1,411 @@
+"""Asking an agent something: the streamed projection, the marker, the reminders."""
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+from chatlas import (
+    AssistantTurn,
+    ContentToolRequest,
+    ContentToolResult,
+    StreamController,
+    UserTurn,
+)
+from chatlas.types import ContentText
+
+from commons import context_layer, data_source, measure, semantic_layer
+from commons._agent import Commons
+from commons._provenance import Tag, provenance_aside
+from commons._reminders import (
+    RESTORED_CONVERSATION_REMINDER,
+    ContentTurnReminder,
+)
+
+from ._provider import scripted_chat, text
+
+QUOTE = "Canopy cover is always acre-weighted for reporting."
+
+
+def frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {"revenue": [500.0, 900.0, 300.0], "region": ["EMEA", "Americas", "EMEA"]}
+    )
+
+
+@pytest.fixture
+def source() -> Any:
+    return data_source(sales=frame())
+
+
+@pytest.fixture
+def notes(tmp_path: Path) -> Any:
+    path = tmp_path / "notes.md"
+    path.write_text(QUOTE, encoding="utf-8")
+    return context_layer(files=[path])
+
+
+def split(raw: str, at: int) -> list[Any]:
+    """The same text streamed as two chunks, so a tag straddles the boundary."""
+    return [ContentText(text=raw[:at]), ContentText(text=raw[at:])]
+
+
+async def collect(agent: Commons, *args: Any, **kwargs: Any) -> list[Any]:
+    return [chunk async for chunk in await agent.stream_async(*args, **kwargs)]
+
+
+def tool_request(tool: str, /, **arguments: Any) -> list[Any]:
+    return [ContentToolRequest(id=f"call-{tool}", name=tool, arguments=arguments)]
+
+
+def order_count_layer() -> Any:
+    @measure(description="Count orders.")
+    def order_count() -> int:
+        return 3
+
+    return semantic_layer(order_count)
+
+
+# ---- projecting the model's text -------------------------------------------
+
+
+async def test_a_verified_citation_becomes_an_aside(source: Any, notes: Any) -> None:
+    raw = (
+        "Answer sentence.\n\n"
+        "<commons-citation>\n\nFollows the weighting rule.\n\n"
+        f"> {QUOTE}\n\n"
+        "</commons-citation>\n\nMore text."
+    )
+    agent = Commons(scripted_chat([split(raw, 30)]), source, context_layer=notes)
+
+    streamed = "".join(await collect(agent, "What does canopy cover mean?"))
+
+    assert "<commons-citation>" not in streamed
+    assert "<shiny-aside" in streamed
+    assert QUOTE in streamed
+    assert streamed.startswith("Answer sentence.")
+    assert streamed.endswith("More text.")
+
+
+async def test_a_model_authored_aside_never_reaches_the_consumer(
+    source: Any, notes: Any
+) -> None:
+    raw = (
+        'Before. <SHINY-ASIDE label="spoofed">not from the server</shiny-aside> After.'
+    )
+    agent = Commons(scripted_chat([split(raw, 25)]), source, context_layer=notes)
+
+    streamed = "".join(await collect(agent, "Anything."))
+
+    assert "spoofed" not in streamed
+    assert streamed == "Before.  After."
+
+
+async def test_the_stored_turn_keeps_the_models_own_words(
+    source: Any, notes: Any
+) -> None:
+    raw = f"Answer.\n\n<commons-citation>\n\nWhy.\n\n> {QUOTE}\n\n</commons-citation>"
+    agent = Commons(scripted_chat([split(raw, 20)]), source, context_layer=notes)
+
+    await collect(agent, "What does canopy cover mean?")
+
+    assert agent.get_turns()[-1].text == raw
+
+
+async def test_the_projection_does_not_depend_on_the_chunk_boundary(
+    source: Any, notes: Any
+) -> None:
+    raw = (
+        f"Text.\n\n<commons-citation>\n\nWhy.\n\n> {QUOTE}\n\n"
+        "</commons-citation>\n\nEnd."
+    )
+    whole = Commons(
+        scripted_chat([[ContentText(text=raw)]]), source, context_layer=notes
+    )
+    pieces = Commons(scripted_chat([split(raw, 12)]), source, context_layer=notes)
+
+    assert "".join(await collect(whole, "q")) == "".join(await collect(pieces, "q"))
+
+
+# ---- the provenance marker -------------------------------------------------
+
+
+async def test_an_answer_with_no_data_tool_carries_no_marker(source: Any) -> None:
+    agent = Commons(scripted_chat([text("I cannot say.")]), source)
+
+    assert await collect(agent, "How many orders?") == ["I cannot say."]
+
+
+async def test_a_trusted_calculation_is_marked_verified(source: Any) -> None:
+    agent = Commons(
+        scripted_chat(
+            [
+                tool_request("call_measure", name="order_count", arguments="{}"),
+                text("Three orders."),
+            ]
+        ),
+        source,
+        semantic_layer=order_count_layer(),
+    )
+
+    streamed = await collect(agent, "How many orders?")
+
+    assert streamed[-1] == provenance_aside(Tag.A)
+
+
+async def test_an_uncited_query_is_marked_untrusted(source: Any) -> None:
+    agent = Commons(
+        scripted_chat(
+            [
+                tool_request("run_sql", sql="SELECT count(*) AS n FROM sales"),
+                text("Three orders."),
+            ]
+        ),
+        source,
+    )
+
+    streamed = await collect(agent, "How many orders?")
+
+    assert streamed[-1] == provenance_aside(Tag.C)
+
+
+async def test_a_verified_citation_earns_the_query_its_own_aside_instead(
+    source: Any, notes: Any
+) -> None:
+    agent = Commons(
+        scripted_chat(
+            [
+                tool_request("run_sql", sql="SELECT count(*) AS n FROM sales"),
+                [
+                    ContentText(
+                        text="Three.\n\n<commons-citation>\n\nWhy.\n\n"
+                        f"> {QUOTE}\n\n</commons-citation>"
+                    )
+                ],
+            ]
+        ),
+        source,
+        context_layer=notes,
+    )
+
+    streamed = "".join(
+        chunk for chunk in await collect(agent, "q") if isinstance(chunk, str)
+    )
+
+    # The citation's own aside says the answer is cited, so no second marker.
+    assert provenance_aside(Tag.C) not in streamed
+    assert provenance_aside(Tag.B, include_cited=True) not in streamed
+    assert "<shiny-aside" in streamed
+
+
+async def test_an_earlier_answers_tag_cannot_classify_a_later_one(
+    source: Any,
+) -> None:
+    agent = Commons(
+        scripted_chat(
+            [
+                tool_request("run_sql", sql="SELECT count(*) AS n FROM sales"),
+                text("Three orders."),
+                text("I cannot say."),
+            ]
+        ),
+        source,
+    )
+
+    await collect(agent, "How many orders?")
+    second = await collect(agent, "And how do you feel about it?")
+
+    assert second == ["I cannot say."]
+
+
+# ---- what a chat UI needs --------------------------------------------------
+
+
+async def test_the_signature_a_chat_ui_calls(source: Any) -> None:
+    # shinychat calls stream_async(input, *contents, content="all",
+    # controller=controller); anything less needs an adapter that would have
+    # to reimplement the scanner.
+    agent = Commons(
+        scripted_chat(
+            [
+                tool_request("run_sql", sql="SELECT count(*) AS n FROM sales"),
+                text("Three orders."),
+            ]
+        ),
+        source,
+    )
+    controller = StreamController()
+
+    streamed = await collect(
+        agent,
+        "How many orders?",
+        ContentText(text="an attached part"),
+        content="all",
+        controller=controller,
+    )
+
+    kinds = [type(chunk).__name__ for chunk in streamed]
+    assert "ContentToolRequest" in kinds
+    assert "ContentToolResult" in kinds
+    assert streamed[-1] == provenance_aside(Tag.C)
+
+
+async def test_a_controller_stops_the_stream(source: Any) -> None:
+    agent = Commons(scripted_chat([text("First. ", "Second.")]), source)
+    controller = StreamController()
+
+    streamed: list[Any] = []
+    async for chunk in await agent.stream_async("q", controller=controller):
+        streamed.append(chunk)
+        controller.cancel()
+
+    assert "".join(streamed) == "First. "
+
+
+async def test_structured_provider_content_passes_through(source: Any) -> None:
+    thinking = ContentToolRequest(id="t", name="run_sql", arguments={"sql": "SELECT 1"})
+    agent = Commons(scripted_chat([[thinking], text("Done.")]), source)
+
+    streamed = await collect(agent, "q", content="all")
+
+    assert streamed[0] is thinking
+
+
+# ---- the turn reminders ----------------------------------------------------
+
+
+async def test_a_claude_5_turn_carries_one_hidden_reminder(source: Any) -> None:
+    agent = Commons(scripted_chat([text("Answer.")], model="claude-opus-5"), source)
+
+    await collect(agent, "How many orders?")
+
+    reminders = [
+        content
+        for content in agent.get_turns()[0].contents
+        if isinstance(content, ContentTurnReminder)
+    ]
+    assert len(reminders) == 1
+
+
+async def test_an_older_model_gets_no_reminder(source: Any) -> None:
+    agent = Commons(scripted_chat([text("Answer.")], model="claude-sonnet-4-5"), source)
+
+    await collect(agent, "How many orders?")
+
+    assert not [
+        content
+        for content in agent.get_turns()[0].contents
+        if isinstance(content, ContentTurnReminder)
+    ]
+
+
+async def test_a_restored_conversation_reminds_the_next_turn_once(
+    source: Any,
+) -> None:
+    agent = Commons(scripted_chat([text("First."), text("Second.")]), source)
+    agent.queue_restore_reminder()
+
+    await collect(agent, "First question.")
+    first = agent.get_turns()[0].contents
+    assert [
+        content.text for content in first if isinstance(content, ContentTurnReminder)
+    ] == [RESTORED_CONVERSATION_REMINDER]
+
+    await collect(agent, "Second question.")
+    second = agent.get_turns()[2].contents
+    assert not [
+        content for content in second if isinstance(content, ContentTurnReminder)
+    ]
+
+
+async def test_an_unconsumed_stream_leaves_the_reminder_for_the_next_turn(
+    source: Any,
+) -> None:
+    agent = Commons(scripted_chat([text("Answer.")]), source)
+    agent.queue_restore_reminder()
+
+    await agent.stream_async("Never consumed.")
+
+    assert agent._restore_reminder_pending
+
+
+def test_a_failed_chat_leaves_the_reminder_for_the_next_turn(source: Any) -> None:
+    agent = Commons(scripted_chat([text("Answer.")]), source)
+    agent.queue_restore_reminder()
+
+    with pytest.raises(ValueError, match="Content objects"):
+        agent.chat(object())  # type: ignore[arg-type]
+
+    assert agent._restore_reminder_pending
+
+
+def test_replacing_the_history_drops_its_queued_reminder(source: Any) -> None:
+    agent = Commons(scripted_chat(), source)
+    agent.queue_restore_reminder()
+
+    agent.set_turns([])
+
+    assert not agent._restore_reminder_pending
+
+
+# ---- the citation request --------------------------------------------------
+
+
+async def test_one_citation_request_per_user_turn(source: Any) -> None:
+    reminder = "REMEMBER TO CITE"
+    agent = Commons(
+        scripted_chat(
+            [
+                tool_request("run_sql", sql="SELECT count(*) AS n FROM sales"),
+                tool_request("run_sql", sql="SELECT sum(revenue) AS r FROM sales"),
+                text("Answer."),
+                tool_request("run_sql", sql="SELECT count(*) AS n FROM sales"),
+                text("Second answer."),
+            ]
+        ),
+        source,
+    )
+    agent._citation_request.reminder = reminder
+
+    first = await collect(agent, "How many orders?", content="all")
+    second = await collect(agent, "And the revenue?", content="all")
+
+    def requests(streamed: list[Any]) -> int:
+        return sum(
+            1
+            for chunk in streamed
+            if isinstance(chunk, ContentToolResult) and reminder in str(chunk.value)
+        )
+
+    assert requests(first) == 1
+    assert requests(second) == 1
+
+
+def test_a_user_message_added_by_hand_restarts_the_request(source: Any) -> None:
+    agent = Commons(scripted_chat(), source)
+    agent._citation_request.requested = True
+
+    agent.add_turn(UserTurn("A new question."))
+
+    assert not agent._citation_request.requested
+
+
+def test_an_assistant_turn_is_nobody_asking_anything(source: Any) -> None:
+    agent = Commons(scripted_chat(), source)
+    agent._citation_request.requested = True
+
+    agent.add_turn(AssistantTurn([ContentText(text="An answer.")]))
+
+    assert agent._citation_request.requested
+
+
+def test_a_turn_of_tool_results_is_the_same_question_still_running(
+    source: Any,
+) -> None:
+    agent = Commons(scripted_chat(), source)
+    agent._citation_request.requested = True
+
+    agent.add_turn(UserTurn([ContentToolResult(value="6 rows")]))
+
+    assert agent._citation_request.requested
+    assert len(agent.get_turns()) == 1

--- a/pkg-py/tests/test_agent_stream.py
+++ b/pkg-py/tests/test_agent_stream.py
@@ -1,5 +1,6 @@
 """Asking an agent something: the streamed projection, the marker, the reminders."""
 
+from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any
 
@@ -286,6 +287,27 @@ async def test_a_controller_stops_the_stream(source: Any) -> None:
     assert "".join(streamed) == "First. "
 
 
+async def test_walking_away_early_closes_the_stream_it_wraps(source: Any) -> None:
+    closed = False
+
+    async def raw() -> AsyncGenerator[str, None]:
+        nonlocal closed
+        try:
+            yield "First. "
+            yield "Second."
+        finally:
+            closed = True
+
+    agent = Commons(scripted_chat(), source)
+    stream = agent._projected(raw(), 0, False)
+
+    assert await anext(stream) == "First. "
+    # No cancel, no exhaustion: the consumer just leaves.
+    await stream.aclose()
+
+    assert closed
+
+
 async def test_structured_provider_content_passes_through(source: Any) -> None:
     thinking = ContentToolRequest(id="t", name="run_sql", arguments={"sql": "SELECT 1"})
     agent = Commons(scripted_chat([[thinking], text("Done.")]), source)
@@ -370,6 +392,22 @@ def test_replacing_the_history_drops_its_queued_reminder(source: Any) -> None:
     agent.set_turns([])
 
     assert not agent._restore_reminder_pending
+
+
+def test_replacing_the_history_replaces_the_conversation(source: Any) -> None:
+    agent = Commons(scripted_chat(), source)
+
+    agent.set_turns(
+        [
+            UserTurn("An earlier question."),
+            AssistantTurn([ContentText(text="An earlier answer.")]),
+        ]
+    )
+
+    assert [turn.text for turn in agent.get_turns()] == [
+        "An earlier question.",
+        "An earlier answer.",
+    ]
 
 
 # ---- the citation request --------------------------------------------------


### PR DESCRIPTION
## Summary

Assembles the pieces the rest of M5 landed into an agent that answers a question. Per D1 this composes `chatlas.Chat` as a private `._client` rather than inheriting from it, so the public surface is a decision R never had to make.

`Commons(client, data_sources, semantic_layer=None, context_layer=None, *, instructions=None)`. The constructor validates, then assembles in R's order. `data_sources` takes one `DataSource` or a mapping of them.

## Implementation

**Construction.** A bare source is filed under an internal key and offers nothing to inject, which matches R's `have_name()` filter. Three arguments in the port plan's signature are absent: `network` only ever gates the execution tool, and `run_python` belongs to M6, while `log` and `share_with` are tracing arguments and `_tracing.py` does not exist. Each would be a parameter that does nothing until the milestone that gives it meaning adds it with its gate.

**The client is not taken over.** The agent builds its own chat from the client's provider, as `pkg-r/R/commons.R` does, so it never changes an object its caller still holds. A system prompt on the client is ignored with a warning, in R's wording. Both warnings about state the client carried fire before any other argument is checked, in R's order, so a bad later argument does not eat them. Model parameters carry over, read from the attribute behind `set_model_params()` because chatlas has no getter, and written back through the public setter; if that attribute is missing or is no longer a mapping, the agent warns and names the setter rather than dropping a temperature in silence. `kwargs_chat` is copied one level deep. The provider itself is shared, because it carries the model, which is also true of `client$get_provider()` in R.

**`stream_async()`** takes chatlas's signature without `data_model`, whose chunks are JSON to be parsed whole and would not survive an appended marker. It accepts extra positional content, a `content=` mode and a `StreamController`, which is the shape shinychat calls with, so the Shiny surface can drive an agent without an adapter that reimplements the scanner. Every `str` chunk goes through the citation scanner and only the projection is yielded, so reserved markup never reaches a browser. The provenance tag is derived after the stream from the collected tags and the scanner's verified flag, and the aside is yielded last. A consumer that walks away without cancelling still closes the provider's stream.

**`prewarm()`** covers the context store and each source with no `try`/`except`, so a cold cache fails a deploy rather than warning.

## Divergence from R

R starts a new conversation and loses history on the handed-over client in silence. This warns and names `agent.set_turns()`. History is data the caller created, and now that the client is not mutated it is recoverable, since the caller still holds it. R has no such warning because R has never had a reason to look.

## Deliberately absent

- No OpenTelemetry spans, including `commons_agent_create`, which `w0t2` retrofits in one sweep.
- No conversation-id accessors, per D5.
- No `semantic_models` or `calculations` registry, since both read warehouse semantic objects and that stays deferred.
- `Commons` is not exported from `__init__.py`. The export and the README example are `5mys`, which keeps the README from claiming an import that does not resolve.

## Tests

`tests/_provider.py` implements chatlas's `Provider` as a scripted replay, so the real `chatlas.Chat` runs the real tool loop and only the network call is scripted. `anthropic` is not a dependency here, so `ChatAnthropic` cannot be constructed in this suite.

The turn rules are pinned through both entry points: `chat()` and `stream_async()` each carry the reminder, citation-request-reset, and restore-reminder-spend tests, `set_turns()` is checked to forward rather than drop, and each of these was verified by deleting the line it guards and watching the test fail.

No new shared fixture. Nine existing fixtures already pin everything the assembly order is observable through, and the order has no output of its own. The one unpinned cross-language claim is this stream's emission order, which needs a live streaming harness that R's own streaming tests skip without development ellmer. `5mys` is asked to decide whether the end-to-end path earns a fixture, and it will have that harness.

Verified: `ruff check`, `pyrefly check src tests`, and `pytest` (1289 passing). No R files changed.
