### PR TITLE
feat(py): export the agent and pin M5's acceptance bar

### DIFF
--- a/pkg-py/README.md
+++ b/pkg-py/README.md
@@ -1,7 +1,45 @@
 # commons
 
-`commons` is a constructor for trustworthy data agents. Once implemented, this package will give an LLM data, semantic, and context layers to work with, tools for querying them, and A/B/C provenance tags so every answer carries a classification as to its trustworthiness.
+`commons` is a constructor for trustworthy data agents. It gives an LLM data, semantic, and context layers to work with, tools for querying them, and A/B/C provenance tags so every answer carries a classification as to its trustworthiness.
 
-**Status: pre-alpha.** The package exports the data and semantic layers (`data_source`, `list_tables`, `measure`, `semantic_layer`, and their types) and the context layer (`context_layer()` and the `ContextLayer` it returns), which reads text or Markdown files and retrieves from them; the agent constructor that ties them together is not implemented yet. Python 3.11 or later is required.
+**Status: pre-alpha.** The agent and all three layers are implemented; the chat UI is not, so answers come back as text and server-rendered HTML rather than through a Shiny front end. Python 3.11 or later is required.
+
+## Get started
+
+An agent needs a chat client and at least one data source. A semantic layer of trusted calculations and a context layer of prose are optional, and each one changes which tools the agent registers. Every parameter the model supplies to a measure needs a description, which is what the model reads to decide how to call it.
+
+```python
+from typing import Annotated
+
+import chatlas
+import commons
+import pandas as pd
+from pydantic import Field
+
+sales = pd.DataFrame(
+    {"revenue": [500.0, 900.0, 300.0], "region": ["EMEA", "Americas", "EMEA"]}
+)
+
+
+@commons.measure(description="Total revenue for one region.")
+def region_revenue(
+    region: Annotated[str, Field(description="Which region to total.")] = "EMEA",
+) -> float:
+    return float(sales[sales["region"] == region]["revenue"].sum())
+
+
+agent = commons.Commons(
+    chatlas.ChatAnthropic(model="claude-sonnet-5"),
+    commons.data_source(sales=sales, dictionary="data-dict.yaml"),
+    semantic_layer=commons.semantic_layer(region_revenue),
+    context_layer=commons.context_layer(files=["reporting-policy.md"]),
+)
+
+agent.chat("What is EMEA revenue?")
+```
+
+`region_revenue` is trusted code, so an answer that runs it is tagged `Tag.A` and displays the verified marker. A question no measure covers sends the agent to `run_sql` or the context layer instead, and the answer comes back cited or untrusted depending on whether it quotes something the context layer can verify.
+
+Use `stream_async()` in place of `chat()` to stream an answer as it arrives. Its signature is chatlas's, so a chat UI can drive the agent directly.
 
 Behavior that both implementations must agree on belongs in [`tests/shared/`](https://github.com/posit-dev/commons/tree/main/tests/shared) at the repository root, which that directory's README defines as the authority. The provenance tag rules and display copy, the citation dialect, and the context layer's frontmatter handling are governed that way; both suites run those cases.

--- a/pkg-py/README.md
+++ b/pkg-py/README.md
@@ -6,7 +6,7 @@
 
 ## Get started
 
-An agent needs a chat client and at least one data source. A semantic layer of trusted calculations and a context layer of prose are optional, and each one changes which tools the agent registers. Every parameter the model supplies to a measure needs a description, which is what the model reads to decide how to call it.
+An agent needs a chat client and at least one data source. A semantic layer of trusted calculations and a context layer of prose are both optional. The semantic layer changes which tools the agent registers, since a measure is what `call_measure` calls. The context layer does not: `search_context` is always registered, and without a layer behind it the tool reports that none is configured. Every parameter the model supplies to a measure needs a description, which is what the model reads to decide how to call it.
 
 ```python
 from typing import Annotated

--- a/pkg-py/src/commons/__init__.py
+++ b/pkg-py/src/commons/__init__.py
@@ -5,16 +5,20 @@ querying them, and A/B/C provenance semantics so every answer carries a
 classification as to how much it can be trusted.
 """
 
+from ._agent import Commons
 from ._context_layer import ContextLayer, context_layer
 from ._data_source import DataSource, data_source, list_tables
 from ._measures import Injected, Measure, SemanticLayer, measure, semantic_layer
+from ._provenance import Tag
 
 __all__: list[str] = [
+    "Commons",
     "ContextLayer",
     "DataSource",
     "Injected",
     "Measure",
     "SemanticLayer",
+    "Tag",
     "context_layer",
     "data_source",
     "list_tables",

--- a/pkg-py/tests/test_acceptance.py
+++ b/pkg-py/tests/test_acceptance.py
@@ -1,0 +1,176 @@
+"""M5's acceptance bar: one agent, all three layers, through the public API.
+
+The pieces underneath have their own tests. What this file asserts is that
+they agree once assembled: a question the measures cover comes back verified,
+a question they do not comes back untrusted or cited, and a citation reaches
+the consumer as server-rendered HTML rather than as the model's own markup.
+
+The conversation is scripted rather than answered by a live model, as the R
+suite's agent tests are. That makes this a regression guard on the assembly,
+not evidence that a real model picks the right tool; kata `j9dq` under M9
+holds the live-model question for both packages.
+"""
+
+from pathlib import Path
+from typing import Annotated, Any
+
+import pandas as pd
+import pytest
+from chatlas import ContentToolRequest, ContentToolResult
+from chatlas.types import ContentText
+from pydantic import Field
+
+import commons
+from commons import (
+    Commons,
+    Tag,
+    context_layer,
+    data_source,
+    measure,
+    semantic_layer,
+)
+from commons._provenance import provenance_aside
+
+from ._provider import scripted_chat, text
+
+DICTIONARY = """
+name: sales
+description: What the shop sold.
+tables:
+  - name: sales
+    description: One row per order line.
+    columns:
+      - name: revenue
+        type: number
+        description: Line revenue, in dollars.
+      - name: region
+        type: string
+        description: Sales region the order line belongs to.
+"""
+
+# Prose no measure covers, so the only way to it is the context layer.
+QUOTE = "Bookings are recognised in the region the order shipped from."
+
+
+def frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {"revenue": [500.0, 900.0, 300.0], "region": ["EMEA", "Americas", "EMEA"]}
+    )
+
+
+@pytest.fixture
+def agent_layers(tmp_path: Path) -> dict[str, Any]:
+    """A documented DuckDB source, a measure over it, and prose beside it."""
+    dictionary = tmp_path / "data-dict.yaml"
+    dictionary.write_text(DICTIONARY, encoding="utf-8")
+    notes = tmp_path / "policy.md"
+    notes.write_text(QUOTE, encoding="utf-8")
+
+    @measure(description="Total revenue for one region.")
+    def region_revenue(
+        region: Annotated[str, Field(description="Which region to total.")] = "EMEA",
+    ) -> float:
+        rows = frame()
+        return float(rows[rows["region"] == region]["revenue"].sum())
+
+    return {
+        "data_sources": data_source(sales=frame(), dictionary=dictionary),
+        "semantic_layer": semantic_layer(region_revenue),
+        "context_layer": context_layer(files=[notes]),
+    }
+
+
+def agent(*responses: Any, **layers: Any) -> Commons:
+    return Commons(scripted_chat(responses), **layers)
+
+
+def call(tool: str, /, **arguments: Any) -> list[Any]:
+    return [ContentToolRequest(id=f"call-{tool}", name=tool, arguments=arguments)]
+
+
+async def stream(built: Commons, question: str) -> list[Any]:
+    return [chunk async for chunk in await built.stream_async(question)]
+
+
+def tool_results(built: Commons) -> list[str]:
+    """Which tools the conversation actually ran, in order."""
+    return [
+        content.name
+        for turn in built.get_turns()
+        for content in turn.contents
+        if isinstance(content, ContentToolResult)
+    ]
+
+
+# ---- the public surface ----------------------------------------------------
+
+
+def test_the_package_exports_the_agent() -> None:
+    assert commons.Commons is Commons
+    assert commons.Tag is Tag
+
+
+def test_every_exported_name_resolves() -> None:
+    for name in commons.__all__:
+        assert getattr(commons, name, None) is not None, name
+
+
+# ---- the acceptance bar ----------------------------------------------------
+
+
+async def test_a_measure_covered_question_comes_back_verified(
+    agent_layers: dict[str, Any],
+) -> None:
+    built = agent(
+        call("call_measure", name="region_revenue", arguments='{"region": "EMEA"}'),
+        text("EMEA revenue is $800."),
+        **agent_layers,
+    )
+
+    streamed = await stream(built, "What is EMEA revenue?")
+
+    assert streamed[-1] == provenance_aside(Tag.A)
+
+
+async def test_a_question_the_measures_do_not_cover_comes_back_untrusted(
+    agent_layers: dict[str, Any],
+) -> None:
+    built = agent(
+        call("run_sql", sql="SELECT count(*) AS n FROM sales"),
+        text("Three order lines."),
+        **agent_layers,
+    )
+
+    streamed = await stream(built, "How many order lines are there?")
+
+    assert streamed[-1] == provenance_aside(Tag.C)
+
+
+async def test_a_cited_fallback_answer_renders_its_citation_server_side(
+    agent_layers: dict[str, Any],
+) -> None:
+    built = agent(
+        call("search_context", query="revenue recognition"),
+        [
+            ContentText(
+                text="Shipped-from region.\n\n<commons-citation>\n\n"
+                f"The policy says so.\n\n> {QUOTE}\n\n</commons-citation>"
+            )
+        ],
+        **agent_layers,
+    )
+
+    streamed = "".join(
+        chunk
+        for chunk in await stream(built, "Which region books revenue?")
+        if isinstance(chunk, str)
+    )
+
+    # Without this the rest passes on an answer that reached no tool at all,
+    # since an untagged answer has no marker to look for either.
+    assert tool_results(built) == ["search_context"]
+    assert "<commons-citation>" not in streamed
+    assert "<shiny-aside" in streamed
+    assert QUOTE in streamed
+    # The citation's own aside says the answer is cited, so no second marker.
+    assert provenance_aside(Tag.C) not in streamed

--- a/pkg-py/tests/test_measures.py
+++ b/pkg-py/tests/test_measures.py
@@ -1018,11 +1018,13 @@ def test_public_api_exposes_the_semantic_layer() -> None:
     import commons
 
     assert set(commons.__all__) == {
+        "Commons",
         "ContextLayer",
         "DataSource",
         "Injected",
         "Measure",
         "SemanticLayer",
+        "Tag",
         "context_layer",
         "data_source",
         "list_tables",


### PR DESCRIPTION
Closes the last open child of M5 (kata `5mys`). Stacked on #311.

`Commons` and `Tag` join the package exports. That is the list the port plan names, and it is what makes the package usable rather than only complete. There is no `commons()` construction helper, per D1. `test_measures.py` pinned the exact set of exported names, so it grows the two new ones.

`tests/test_acceptance.py` drives one agent over all three layers and asserts the milestone's bar in one place: a measure-covered question ends tagged A, a question outside the measures ends untrusted, and a citation reaches the consumer as server-rendered HTML. I checked each assertion by deleting the tool call that earns it. The citation case passed with its tool call removed, because an answer that reaches no tool carries no marker either, so it now also asserts which tools ran.

**The conversation is scripted, not answered by a live model.** The issue asked for a live agent. We deferred that to match R, whose `helper-commons.R` builds a real `chat_anthropic()` client but never calls it. The consequence is worth stating plainly: this test guards the assembly against regressions, and it is not evidence that a real model picks the right tool. No workflow holds an `ANTHROPIC_API_KEY` today, so a live test would skip in CI forever. kata `j9dq` under M9 holds that question for both packages at once.

**No `tests/shared/` fixture**, which answers the open question in the issue body. The contract underneath is already pinned per issue by `provenance.json`, the tool-registration fixture, and the prompt snapshots. With neither package calling a live model, no end-to-end behavior remains for a shared fixture to pin, and a Python-only file in that directory is a review defect by the repository's own rule.

The README was a 7-line stub that said the agent did not exist yet. It now carries a worked example. Running that example verbatim caught a real error in it, because a measure parameter needs an `Annotated` field description.

From `pkg-py/`: ruff clean, pyrefly reports 0 errors over `src tests`, and 1294 tests pass. No R files change.
