### PR TITLE
fix(ci): name the deploy target explicitly on both Connect deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Both steps deploy the same directory, and rsconnect keeps a deployment
+      # record for it in the user config directory, which the two steps share.
+      # The dev step's record names a server whose credential is dropped when
+      # that step exits, so staging must name its target rather than let
+      # rsconnect infer one from the record. "connect-actions" is the nickname
+      # the action logs in under.
       - name: Deploy to Connect (dev)
         uses: posit-dev/connect-actions/deploy@main
         with:
@@ -25,7 +31,7 @@ jobs:
           content-guid: d7a36cae-8f27-448b-a478-61b81fbe3942
           path: pkg-r/inst
           github-token: ${{ github.token }}
-          rsconnect-args: --title biodiversity-explorer
+          rsconnect-args: --name connect-actions --title biodiversity-explorer
 
       - name: Deploy to Connect (staging)
         uses: posit-dev/connect-actions/deploy@main
@@ -34,4 +40,4 @@ jobs:
           content-guid: ad662e1b-5048-4acc-9ad7-f9478c92274e
           path: pkg-r/inst
           github-token: ${{ github.token }}
-          rsconnect-args: --title biodiversity-explorer
+          rsconnect-args: --name connect-actions --title biodiversity-explorer


### PR DESCRIPTION
Fixes #318. The `deploy` job has failed on every run since rsconnect-python 1.31.0 was published.

Both steps deploy `pkg-r/inst`. For a manifest deploy rsconnect derives its deployment-record path from the deploy target, giving `manifest.json/rsconnect-python/manifest.json.json`, which can never be created because `manifest.json` is a file. The save falls back to the user config directory, which the two steps share. The dev step's record names the dev server, whose credential is removed when that step exits, so staging infers a target it can no longer resolve. Earlier rsconnect versions deployed anyway; 1.31.0 asks for an explicit target instead.

[Both steps](https://github.com/posit-dev/commons/pull/320/files#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3) now pass `--name connect-actions`, the nickname the action logs in under, which skips record inference. The dev step gets it too: it is only safe today because it runs first. `--server` would also name a target, but a trailing slash in the secret would not match the saved credential and would lose its API key.

This couples the workflow to the action's login nickname. The durable fix belongs in `posit-dev/connect-actions`, which could name the server for each deploy itself.

Verified two ways. Locally, a fixture holding a dev record with only the staging credential saved reproduces the error text exactly, and adding `--name` gets past target resolution. In CI, this PR touches `.github/workflows/deploy.yml`, a trigger path, so the `deploy` job runs here.
