### PR TITLE
test: use public chat$new_chat() in restore-reminder test

### DIFF
--- a/pkg-r/tests/testthat/test-chat.R
+++ b/pkg-r/tests/testthat/test-chat.R
@@ -53,6 +53,8 @@ test_that("commons_server queues a restore reminder when history is restored", {
       chat <- commons_server("chat", client = agent)
     },
     {
+      # shinychat has no public hook to fire a restore under testServer, so
+      # drive the history controller it stashes on the session.
       controller <- shinychat:::get_session_chat_bookmark_info(
         session,
         "chat.history-controller"
@@ -60,11 +62,7 @@ test_that("commons_server queues a restore reminder when history is restored", {
       controller$restore_app_state(list())
       expect_true(agent$.__enclos_env__$private$restore_reminder_pending)
 
-      chat$clear()
-      expect_false(agent$.__enclos_env__$private$restore_reminder_pending)
-
-      controller$restore_app_state(list())
-      controller$new_chat()
+      chat$new_chat()
       expect_false(agent$.__enclos_env__$private$restore_reminder_pending)
     }
   )


### PR DESCRIPTION
Closes #324

## Summary
shinychat (posit-dev/shinychat#399) made `clear()` abort when conversation history is enabled, which is the only configuration `commons_server()` creates — so the restore-reminder test's `chat$clear()` assertion had no reachable behavior left to exercise. This drops that assertion (the reset path is identical to `new_chat()`'s, and the agent-level lifecycle is already covered by unit tests in test-commons.R) and replaces the internal `controller$new_chat()` call with the public `chat$new_chat()` on the object `chat_server()` returns. One internal reach remains: firing a restore under `testServer` requires the history controller (`shinychat:::get_session_chat_bookmark_info`), since shinychat exposes no public restore trigger; a comment in the test says so.

## Verification
`testthat::test_file("tests/testthat/test-chat.R")` passes against shinychat main (0.5.0, local install from ../shinychat/pkg-r, which includes the `clear()` guard).
