### PR TITLE
feat(py): icon URLs for the citation and provenance asides

### DIFF
--- a/pkg-py/src/commons/_citations.py
+++ b/pkg-py/src/commons/_citations.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Literal, get_args
 from chatlas import ContentToolResult, Turn
 from chatlas.types import ContentText
 
+from ._icons import icon_url
 from ._measures import Measure, measure_schema_text
 from ._prompt import read_prompt
 from ._provenance import TAG_EXTRA_KEY, Tag, escape_attr
@@ -32,6 +33,7 @@ __all__ = [
     "ParsedCitation",
     "build_citation_corpus",
     "citation_aside_html",
+    "citation_icon_url",
     "citation_reminder_text",
     "match_citation",
     "normalize_citation",
@@ -55,7 +57,17 @@ _DOUBLE_QUOTES = re.compile("[\u201c\u201d]")
 _DASHES = re.compile("[\u2013\u2014]")
 
 CitationKind = Literal["prose", "definition", "schema"]
+
 CitationStatus = Literal["accepted", "rejected", "malformed"]
+
+# The uniform quote mark on every citation pill, whatever the source's kind.
+_CITATION_MARK = "citation-mark.svg"
+
+_KIND_ICONS: dict[str, str] = {
+    "prose": "citation-prose.svg",
+    "definition": "citation-definition.svg",
+    "schema": "citation-schema.svg",
+}
 
 
 @dataclass(frozen=True)
@@ -242,23 +254,40 @@ def build_citation_corpus(
 def citation_aside_html(quote: str, explanation: str, label: str, kind: str) -> str:
     """Render a verified citation as the aside shinychat displays.
 
-    ``kind`` selects the icon the UI layer draws beside the label. No icon is
-    emitted yet: the URL comes from the served asset bundle, which arrives with
-    the Python UI (D10).
+    The pill carries the uniform quote mark and ``kind`` selects the icon in
+    the body title. Both are omitted when no asset bundle serves them.
     """
+    mark = icon_url(_CITATION_MARK)
+    icon_attr = "" if mark is None else f' icon="{escape_attr(mark)}"'
+    kind_icon = citation_icon_url(kind)
+    kind_img = (
+        "" if kind_icon is None else f'<img src="{escape_attr(kind_icon)}" alt="">'
+    )
     reason = f"{explanation}\n\n" if explanation else ""
     blockquote = "> " + quote.strip().replace("\n", "\n> ")
     # shinychat only renders the popover's title row for grouped asides, so the
     # body carries its own title to keep the source named for a lone citation.
+    # commons-chat.css hides shinychat's row, which is why the kind's icon goes
+    # here and the aside's own icon attribute only styles the pill.
     title = (
         '<span class="commons-citation-title">'
+        f"{kind_img}"
         '<span class="commons-citation-title-label">'
         f"{html.escape(label, quote=False)}</span></span>\n\n"
     )
     return (
-        f'<shiny-aside label="{escape_attr(label)}">'
+        f'<shiny-aside label="{escape_attr(label)}"{icon_attr}>'
         f"{title}{reason}{blockquote}</shiny-aside>"
     )
+
+
+def citation_icon_url(kind: str) -> str | None:
+    """The served URL of the icon for one citation kind, or None.
+
+    A kind with no icon of its own renders the aside without one rather than
+    falling back to another kind's.
+    """
+    return icon_url(_KIND_ICONS.get(kind))
 
 
 def tool_result(value: Any, tag: Tag | None = None) -> ContentToolResult:

--- a/pkg-py/src/commons/_icons.py
+++ b/pkg-py/src/commons/_icons.py
@@ -1,0 +1,52 @@
+"""Where the browser serves the icons the asides reference.
+
+The asides are rendered mid-stream by ``_citations.py`` and ``_provenance.py``,
+neither of which may import shiny, so an icon URL has to be resolvable at scan
+time rather than patched into finished HTML. The UI layer records the URL its
+asset bundle is served under and the asides resolve against it. With no bundle
+recorded, no icon is emitted. ``pkg-r/R/citations.R`` reads the dependency
+directly, which it can because R's asides and its UI ship in one package.
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+from pathlib import Path
+
+__all__ = ["get_asset_base_url", "icon_url", "set_asset_base_url"]
+
+_FIGS_SUBDIR = "www/commons-chat/figs"
+
+_asset_base_url: str | None = None
+
+
+def set_asset_base_url(base: str | None) -> None:
+    """Record the URL the asset bundle is served under, or None for no bundle.
+
+    Process-wide, which costs nothing across concurrent sessions: the URL
+    carries the installed package's version and its assets' newest mtime, so
+    every session in one process derives the same string.
+    """
+    global _asset_base_url
+    _asset_base_url = base
+
+
+def get_asset_base_url() -> str | None:
+    """The URL the asset bundle is served under, or None when none is."""
+    return _asset_base_url
+
+
+def icon_url(file: str | None) -> str | None:
+    """The served URL of one icon in ``figs/``.
+
+    None when no bundle is being served, when the caller names no icon, or
+    when the bundle does not ship the file, since a URL nothing backs renders
+    as a broken image rather than as no icon at all.
+    """
+    if file is None or _asset_base_url is None or not _figs_path(file).is_file():
+        return None
+    return f"{_asset_base_url}/figs/{file}"
+
+
+def _figs_path(file: str) -> Path:
+    return Path(str(importlib.resources.files("commons"))) / _FIGS_SUBDIR / file

--- a/pkg-py/src/commons/_icons.py
+++ b/pkg-py/src/commons/_icons.py
@@ -1,11 +1,15 @@
-"""Where the browser serves the icons the asides reference.
+"""Where the browser serves the icons referenced by the asides.
 
-The asides are rendered mid-stream by ``_citations.py`` and ``_provenance.py``,
-neither of which may import shiny, so an icon URL has to be resolvable at scan
-time rather than patched into finished HTML. The UI layer records the URL its
-asset bundle is served under and the asides resolve against it. With no bundle
-recorded, no icon is emitted. ``pkg-r/R/citations.R`` reads the dependency
-directly, which it can because R's asides and its UI ship in one package.
+``_citations.py`` and ``_provenance.py`` build asides as finished HTML
+strings while the model's response streams, with no post-processing pass,
+so an icon URL must be complete the moment an aside is written. In the Python
+package, they are core modules while shiny is an optional extra, so it is not
+guaranteed they would be able to ask the UI layer where its assets are served;
+the UI layer instead records the served URL through this module's
+``set_asset_base_url()`` when it builds the ``HTMLDependency`` carrying
+the assets. If no URL is recorded, no icon is emitted. This differs from the
+R implementation, which ships the commons core, asides, and UI in one package, so
+``pkg-r/R/citations.R`` reads the dependency directly.
 """
 
 from __future__ import annotations
@@ -23,9 +27,9 @@ _asset_base_url: str | None = None
 def set_asset_base_url(base: str | None) -> None:
     """Record the URL the asset bundle is served under, or None for no bundle.
 
-    Process-wide, which costs nothing across concurrent sessions: the URL
-    carries the installed package's version and its assets' newest mtime, so
-    every session in one process derives the same string.
+    Process-wide, which is safe across concurrent sessions: the URL
+    carries the package version and the assets' newest mtime, so every
+    session in a process derives the same string.
     """
     global _asset_base_url
     _asset_base_url = base
@@ -39,9 +43,9 @@ def get_asset_base_url() -> str | None:
 def icon_url(file: str | None) -> str | None:
     """The served URL of one icon in ``figs/``.
 
-    None when no bundle is being served, when the caller names no icon, or
-    when the bundle does not ship the file, since a URL nothing backs renders
-    as a broken image rather than as no icon at all.
+    None when no bundle is served, when ``file`` is None, or when the
+    bundle does not ship the file: an unbacked URL renders as a broken
+    image rather than no icon.
     """
     if file is None or _asset_base_url is None or not _figs_path(file).is_file():
         return None

--- a/pkg-py/src/commons/_provenance.py
+++ b/pkg-py/src/commons/_provenance.py
@@ -15,6 +15,8 @@ from typing import Final
 
 from chatlas import ContentToolResult, Turn
 
+from ._icons import icon_url
+
 __all__ = [
     "PROVENANCE_DISPLAY",
     "TAG_EXTRA_KEY",
@@ -146,13 +148,14 @@ def provenance_aside(tag: Tag | None, *, include_cited: bool = False) -> str:
     because the verified citation's own aside already says as much; a review
     context passes ``include_cited`` to see every outcome.
 
-    No icon: its URL comes from the served asset bundle, which arrives with
-    the Python UI (see ``citation_aside_html``).
+    The outcome's icon is omitted when no asset bundle serves it.
     """
     if tag is None or (tag is Tag.B and not include_cited):
         return ""
     display = PROVENANCE_DISPLAY[tag]
+    icon = icon_url(display.icon)
+    icon_attr = "" if icon is None else f' icon="{escape_attr(icon)}"'
     return (
-        f'<shiny-aside label="{escape_attr(display.label)}">'
+        f'<shiny-aside label="{escape_attr(display.label)}"{icon_attr}>'
         f"{display.body} {_INFO_CONTROL}</shiny-aside>"
     )

--- a/pkg-py/src/commons/_ui/_assets.py
+++ b/pkg-py/src/commons/_ui/_assets.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from htmltools import HTMLDependency
 from packaging.version import Version
 
+from .._icons import set_asset_base_url
+
 __all__ = ["asset_base_url", "commons_chat_dependency"]
 
 _SUBDIR = "www/commons-chat"
@@ -27,7 +29,7 @@ def _asset_version() -> str:
 
 def commons_chat_dependency() -> HTMLDependency:
     """The dependency serving the chat script, stylesheet and icons."""
-    return HTMLDependency(
+    dep = HTMLDependency(
         name="commons-chat",
         version=_asset_version(),
         source={"package": "commons", "subdir": _SUBDIR},
@@ -35,9 +37,22 @@ def commons_chat_dependency() -> HTMLDependency:
         stylesheet={"href": "commons-chat.css"},
         all_files=True,
     )
+    # The asides build icon URLs as they stream and cannot import shiny, so
+    # this is where they learn where the icons are. Told on every build rather
+    # than once, because the version carries an asset mtime.
+    set_asset_base_url(_base_url(dep))
+    return dep
 
 
 def asset_base_url() -> str:
-    """The directory the assets are served under, relative to the library."""
-    dep = commons_chat_dependency()
-    return f"{dep.name}-{dep.version}"
+    """The URL the assets are served under on a page.
+
+    Includes the library prefix htmltools renders a dependency's own hrefs
+    under, so the result is a URL that resolves rather than the name of the
+    directory holding the assets.
+    """
+    return _base_url(commons_chat_dependency())
+
+
+def _base_url(dep: HTMLDependency) -> str:
+    return dep.source_path_map()["href"]

--- a/pkg-py/src/commons/_ui/_assets.py
+++ b/pkg-py/src/commons/_ui/_assets.py
@@ -37,20 +37,14 @@ def commons_chat_dependency() -> HTMLDependency:
         stylesheet={"href": "commons-chat.css"},
         all_files=True,
     )
-    # The asides build icon URLs as they stream and cannot import shiny, so
-    # this is where they learn where the icons are. Told on every build rather
-    # than once, because the version carries an asset mtime.
+    # Asides resolve icon URLs against this base; see _icons.py. Set per
+    # build, not once: the URL embeds the assets' newest mtime.
     set_asset_base_url(_base_url(dep))
     return dep
 
 
 def asset_base_url() -> str:
-    """The URL the assets are served under on a page.
-
-    Includes the library prefix htmltools renders a dependency's own hrefs
-    under, so the result is a URL that resolves rather than the name of the
-    directory holding the assets.
-    """
+    """The URL the assets are served under on a page."""
     return _base_url(commons_chat_dependency())
 
 

--- a/pkg-py/tests/conftest.py
+++ b/pkg-py/tests/conftest.py
@@ -1,0 +1,28 @@
+"""Fixtures every test module gets."""
+
+from collections.abc import Iterator
+
+import pytest
+
+from commons._icons import get_asset_base_url, set_asset_base_url
+
+# A stand-in for a served bundle: the live URL carries the assets' newest
+# mtime, so no literal can name it.
+_BUNDLE = "lib/commons-chat-0.1.0.1"
+
+
+@pytest.fixture(autouse=True)
+def _no_asset_bundle() -> Iterator[None]:
+    # Where the bundle is served is process-wide state the UI layer sets, so
+    # a test that renders an aside would otherwise depend on import order.
+    before = get_asset_base_url()
+    set_asset_base_url(None)
+    yield
+    set_asset_base_url(before)
+
+
+@pytest.fixture
+def served_bundle() -> str:
+    """Serve a bundle for the duration of one test, and give its base URL."""
+    set_asset_base_url(_BUNDLE)
+    return _BUNDLE

--- a/pkg-py/tests/test_citation_scan.py
+++ b/pkg-py/tests/test_citation_scan.py
@@ -155,3 +155,38 @@ def test_the_aside_omits_the_explanation_when_the_model_gave_none() -> None:
     html = citation_aside_html(SAMPLE_QUOTE, "", "documentation", "prose")
 
     assert html.endswith(f"</span>\n\n> {SAMPLE_QUOTE}</shiny-aside>")
+
+
+def test_the_aside_names_no_icon_without_a_served_bundle() -> None:
+    # An icon URL is only knowable once a bundle is being served, and a bare
+    # filename in the page would 404.
+    html = citation_aside_html(SAMPLE_QUOTE, "why", "documentation", "prose")
+
+    assert "icon=" not in html
+    assert "<img" not in html
+
+
+def test_a_served_bundle_marks_the_pill_and_titles_the_body(
+    served_bundle: str,
+) -> None:
+    # commons-chat.css hides shinychat's own popover title row, so the pill
+    # carries the uniform quote mark and the body title carries the per-kind
+    # icon the reader actually sees.
+    html = citation_aside_html(SAMPLE_QUOTE, "why", "documentation", "prose")
+
+    assert html.startswith(
+        '<shiny-aside label="documentation" '
+        f'icon="{served_bundle}/figs/citation-mark.svg">'
+        '<span class="commons-citation-title">'
+        f'<img src="{served_bundle}/figs/citation-prose.svg" alt="">'
+    )
+
+
+def test_a_kind_with_no_icon_still_renders_the_titled_aside(
+    served_bundle: str,
+) -> None:
+    html = citation_aside_html(SAMPLE_QUOTE, "why", "documentation", "unknown")
+
+    assert f'icon="{served_bundle}/figs/citation-mark.svg"' in html
+    assert "<img" not in html
+    assert '<span class="commons-citation-title-label">documentation</span>' in html

--- a/pkg-py/tests/test_icons.py
+++ b/pkg-py/tests/test_icons.py
@@ -1,0 +1,64 @@
+"""Icon URLs, resolved against whichever asset bundle is being served."""
+
+from typing import get_args
+
+import pytest
+
+from commons._citations import CitationKind, citation_icon_url
+from commons._icons import get_asset_base_url, icon_url, set_asset_base_url
+from commons._provenance import PROVENANCE_DISPLAY
+
+KIND_ICONS = {
+    "prose": "citation-prose.svg",
+    "definition": "citation-definition.svg",
+    "schema": "citation-schema.svg",
+}
+
+
+def test_nothing_resolves_until_a_bundle_is_served() -> None:
+    assert get_asset_base_url() is None
+    assert icon_url("citation-mark.svg") is None
+
+
+def test_a_served_bundle_holds_its_icons_under_figs(served_bundle: str) -> None:
+    assert icon_url("citation-mark.svg") == f"{served_bundle}/figs/citation-mark.svg"
+
+
+def test_a_file_the_bundle_does_not_ship_has_no_icon(served_bundle: str) -> None:
+    # A URL under the served path that no file backs renders as a broken
+    # image, which is worse than no icon.
+    assert icon_url("missing.svg") is None
+
+
+def test_a_marker_that_names_no_icon_resolves_to_none(served_bundle: str) -> None:
+    assert icon_url(None) is None
+
+
+def test_the_kinds_with_an_icon_are_every_kind_there_is() -> None:
+    assert set(KIND_ICONS) == set(get_args(CitationKind))
+
+
+@pytest.mark.parametrize(("kind", "file"), KIND_ICONS.items())
+def test_each_citation_kind_names_its_own_icon(
+    kind: str, file: str, served_bundle: str
+) -> None:
+    assert citation_icon_url(kind) == f"{served_bundle}/figs/{file}"
+
+
+def test_an_unknown_citation_kind_has_no_icon(served_bundle: str) -> None:
+    # The kind arrives off a verified corpus entry, but a kind added without
+    # an icon must render its aside rather than a broken image.
+    assert citation_icon_url("unknown") is None
+
+
+def test_every_provenance_icon_is_a_file_the_bundle_ships(served_bundle: str) -> None:
+    named = [d.icon for d in PROVENANCE_DISPLAY.values() if d.icon is not None]
+
+    assert named
+    assert all(icon_url(file) is not None for file in named)
+
+
+def test_a_bundle_can_be_taken_away_again(served_bundle: str) -> None:
+    set_asset_base_url(None)
+
+    assert icon_url("citation-mark.svg") is None

--- a/pkg-py/tests/test_provenance.py
+++ b/pkg-py/tests/test_provenance.py
@@ -159,8 +159,27 @@ def test_the_marker_carries_the_info_control() -> None:
     )
 
 
-def test_the_marker_names_no_icon_yet() -> None:
-    # The icon URL comes from the served asset bundle, which arrives with the
-    # Python UI. R emits one; a bare filename here would 404.
+def test_the_marker_names_no_icon_without_a_served_bundle() -> None:
+    # An icon URL is only knowable once a bundle is being served, and a bare
+    # filename in the page would 404.
     assert "icon=" not in provenance_aside(Tag.A)
     assert "data:image" not in provenance_aside(Tag.A)
+
+
+@pytest.mark.parametrize("tag", [Tag.A, Tag.C])
+def test_a_served_bundle_puts_the_outcome_icon_on_the_marker(
+    tag: Tag, served_bundle: str
+) -> None:
+    icon = PROVENANCE_DISPLAY[tag].icon
+
+    assert icon is not None
+    assert f'icon="{served_bundle}/figs/{icon}"' in provenance_aside(tag)
+
+
+def test_the_outcome_with_no_icon_of_its_own_renders_without_one(
+    served_bundle: str,
+) -> None:
+    marker = provenance_aside(Tag.B, include_cited=True)
+
+    assert marker
+    assert "icon=" not in marker

--- a/pkg-py/tests/test_ui_assets.py
+++ b/pkg-py/tests/test_ui_assets.py
@@ -10,6 +10,7 @@ import pytest
 # shinychat brings shiny and htmltools with it, so it stands for the extra.
 pytest.importorskip("shinychat", reason="commons[shiny] is not installed")
 
+from commons._icons import get_asset_base_url
 from commons._ui._assets import (
     asset_base_url,
     commons_chat_dependency,
@@ -19,7 +20,7 @@ from commons._ui._assets import (
 def test_the_dependency_serves_the_chat_script_and_stylesheet() -> None:
     dep = commons_chat_dependency()
     assert dep.name == "commons-chat"
-    rendered = dep.as_dict(lib_prefix=None)
+    rendered = dep.as_dict()
     base = asset_base_url()
     assert rendered["script"] == [{"src": f"{base}/commons-chat.js"}]
     assert rendered["stylesheet"][0]["href"] == f"{base}/commons-chat.css"
@@ -66,10 +67,44 @@ def test_the_ui_module_imports_like_any_other_submodule() -> None:
     assert imported is commons_chat_dependency
 
 
-def test_the_base_url_is_where_htmltools_serves_the_assets() -> None:
+def test_the_base_url_carries_the_library_prefix() -> None:
+    # htmltools renders a dependency's hrefs under a library prefix, so the
+    # bare directory name is not a URL that resolves in a page.
     dep = commons_chat_dependency()
-    href = dep.as_dict()["stylesheet"][0]["href"]
-    assert href == f"lib/{asset_base_url()}/commons-chat.css"
+    directory = f"{dep.name}-{dep.version}"
+
+    assert asset_base_url() != directory
+    assert asset_base_url().endswith(f"/{directory}")
+
+
+def test_building_the_dependency_tells_the_asides_where_it_is_served() -> None:
+    # The asides resolve their icon URLs as they stream, before any page has
+    # rendered, so registering the bundle is what hands them its URL.
+    assert get_asset_base_url() is None
+
+    commons_chat_dependency()
+
+    assert get_asset_base_url() == asset_base_url()
+
+
+async def test_the_icon_urls_the_asides_emit_resolve_on_a_real_page() -> None:
+    # The whole seam, end to end: a page carrying the theme serves the bundle
+    # at the URL the asides built their icon links from.
+    httpx = pytest.importorskip("httpx")
+    from shiny import App, ui
+
+    from commons._citations import citation_icon_url
+    from commons._icons import icon_url
+    from commons.ui import theme
+
+    app = App(ui.page_fluid(ui.h1("commons"), theme=theme()), lambda i, o, s: None)
+    urls = [citation_icon_url("prose"), icon_url("trusted-icon.svg")]
+    assert all(url is not None for url in urls)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://page") as client:
+        for url in urls:
+            assert (await client.get(f"/{url}")).status_code == 200, url
 
 
 def test_a_missing_extra_names_the_package_and_the_install() -> None:


### PR DESCRIPTION
Adds icons on the citation and provenance asides, matching what R renders. Stacks on #327. Kata `25gj`, task 3 of the [M8 plan](https://github.com/posit-dev/commons/blob/main/docs/superpowers/plans/2026-09-07-m8-shiny-ui.md).

<details>
<summary><b>Design notes, and what was left out</b> (agent-written)</summary>

### Where the icons go

The citation pill gets the uniform quote mark and the body title gets the per-kind icon. `commons-chat.css` hides shinychat's own popover title row, so the body's title is what a reader sees.

### Why a process-wide value

`_citations.py` and `_provenance.py` cannot import shiny, and the scanner emits its finished HTML mid-stream, so an icon URL has to be resolvable at scan time rather than patched in afterwards. `_icons.py` holds one base URL that [the UI layer sets when it builds the asset dependency](https://github.com/posit-dev/commons/pull/329/files#diff-daff9b4acf3e4ba73035e6f5afac7a341d377b599555f83e9ffc522244f3b5d6). No icon is emitted while it is unset, which is what both asides did before.

Process-wide costs nothing across concurrent sessions. The URL is a function of the installed package's version and its assets' newest mtime, so every session in one process derives the same string. Threading the value through instead would have put a shiny-shaped parameter on `Commons` and its scanner, and the server function receives an agent it did not construct. It is set on every dependency build rather than once at import, so an asset edited inside a live process cannot leave the icon URLs pointing at the previous version.

The one cost is test-visible. [An autouse fixture](https://github.com/posit-dev/commons/pull/329/files#diff-3a3d83afa66969dc7e8fe5236beee254c6765f377ad1283a1f5e2000cebb256c) clears the base URL per test, so a module that imports `commons.ui` cannot change what another module's asides render.

### The `asset_base_url()` change

It previously returned the bare directory name, `commons-chat-<version>`, matching R's `dep$name-dep$version`. That is correct for R, which serves each dependency at its own prefix, and wrong for Python, where htmltools renders dependency hrefs under a library prefix that a shiny page takes the default of. Checked with a real request through a page built with `commons.ui.theme()`: the prefixed path returns 200 and the bare one 404s. The value now comes from htmltools rather than restating the prefix, and [that same request is a test](https://github.com/posit-dev/commons/pull/329/files#diff-ff7970761211ddce0c4c2cc8368446748a182e9e373445d6683893e779c4f33e).

### No shared fixture for the icon filenames

The URL carries an asset mtime, so no literal can name it, and `tests/shared/citations.json` already declares that each package renders asides with the icon URLs it can resolve. What is left to agree on is the citation kind to filename mapping, three entries in [`_citations.py`](https://github.com/posit-dev/commons/pull/329/files#diff-e996620c6cf8c554168fc06eea69e866f44b4f7c0e4b7d4bb2719966280cc2e7) and in `pkg-r/R/citations.R`.

Accepted without a fixture, and the risk stated plainly: a kind mapped to the wrong file that the bundle does ship renders the wrong icon in one package, and nothing errors. Only a filename the bundle does not ship yields no icon instead. What it costs is a cosmetic icon on a pill, with the label and the verified quote beside it unaffected, which is the weigh-the-cost case `tests/shared/README.md` says to accept. Both packages read one `www/` directory whose staleness CI checks, and `tests/shared/provenance.json` pins the two provenance filenames inside `provenance_display`.

### Deliberately not folded in

Kata `3fq1` wants the model-authored quote and explanation escaped, and it edits the same function. It has to land in both packages, it changes the aside body a reader sees, and it needs its own call on how much of the explanation's markdown is meant to render. The overlap is two adjacent lines.

</details>
