### PR TITLE
feat(py): tool-result presentation

### DIFF
--- a/pkg-py/pyproject.toml
+++ b/pkg-py/pyproject.toml
@@ -9,8 +9,6 @@ license-files = ["LICENSE.md"]
 classifiers = ["Development Status :: 2 - Pre-Alpha"]
 dependencies = [
     "chatlas>=0.22.0",
-    # A tool result's display fields are htmltools tag children, and a plain
-    # string is escaped rather than rendered, so building one is not optional.
     "htmltools>=0.6",
     "pydantic>=2",
     "duckdb>=1.0",
@@ -33,8 +31,7 @@ tracing = [
     "opentelemetry-exporter-otlp-json-file",
     "httpx>=0.27",
 ]
-# Everything `commons.ui` needs beyond the core dependencies. shiny arrives
-# with shinychat, but the UI layer imports it directly, so it is named here.
+# Everything `commons.ui` needs beyond the core dependencies.
 shiny = [
     "packaging>=23",
     "shiny>=1.7",

--- a/pkg-py/pyproject.toml
+++ b/pkg-py/pyproject.toml
@@ -9,6 +9,9 @@ license-files = ["LICENSE.md"]
 classifiers = ["Development Status :: 2 - Pre-Alpha"]
 dependencies = [
     "chatlas>=0.22.0",
+    # A tool result's display fields are htmltools tag children, and a plain
+    # string is escaped rather than rendered, so building one is not optional.
+    "htmltools>=0.6",
     "pydantic>=2",
     "duckdb>=1.0",
     "raghilda>=0.2.1",
@@ -30,10 +33,9 @@ tracing = [
     "opentelemetry-exporter-otlp-json-file",
     "httpx>=0.27",
 ]
-# Everything `commons.ui` needs. htmltools and shiny arrive with shinychat,
-# but the UI layer imports both directly, so they are named here.
+# Everything `commons.ui` needs beyond the core dependencies. shiny arrives
+# with shinychat, but the UI layer imports it directly, so it is named here.
 shiny = [
-    "htmltools>=0.6",
     "packaging>=23",
     "shiny>=1.7",
     "shinychat>=0.7,<0.8",

--- a/pkg-py/src/commons/_citations.py
+++ b/pkg-py/src/commons/_citations.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Literal, get_args
 from chatlas import ContentToolResult, Turn
 from chatlas.types import ContentText
 
+from ._display import DISPLAY_EXTRA_KEY, tool_display
 from ._icons import icon_url
 from ._measures import Measure, measure_schema_text
 from ._prompt import read_prompt
@@ -290,13 +291,34 @@ def citation_icon_url(kind: str) -> str | None:
     return icon_url(_KIND_ICONS.get(kind))
 
 
-def tool_result(value: Any, tag: Tag | None = None) -> ContentToolResult:
+def tool_result(
+    value: Any,
+    tag: Tag | None = None,
+    *,
+    title: str | None = None,
+    html: Any = None,
+    markdown: str | None = None,
+    footer: Any = None,
+    open: bool = False,
+) -> ContentToolResult:
     """A tool result carrying the provenance tag of the output it holds.
 
     The tag is read back off ``extra`` when the turn is classified, so it is
     set here rather than at the point a result is added to the conversation.
+    It stays out of the title: it is what the reader classifies an answer by,
+    not a caption for the row that produced it.
+
+    The remaining arguments are the display envelope; see ``_display``.
     """
-    return ContentToolResult(value=value, extra={TAG_EXTRA_KEY: tag})
+    return ContentToolResult(
+        value=value,
+        extra={
+            TAG_EXTRA_KEY: tag,
+            DISPLAY_EXTRA_KEY: tool_display(
+                title, html=html, markdown=markdown, footer=footer, open=open
+            ),
+        },
+    )
 
 
 def citation_reminder_text() -> str:

--- a/pkg-py/src/commons/_display.py
+++ b/pkg-py/src/commons/_display.py
@@ -98,6 +98,7 @@ def measure_display_html(
     args: Mapping[str, Any],
     value: Any,
     *,
+    from_query: bool = False,
     title: str | None = None,
     description: str | None = None,
 ) -> Tag:
@@ -105,13 +106,20 @@ def measure_display_html(
 
     Built as tags rather than assembled text, so every value a measure or the
     model supplied is escaped by htmltools on the way in.
+
+    ``from_query`` says the value is rows a data source answered with. It
+    cannot be guessed: an empty list is an empty result to a query and an
+    empty answer to a measure, and the two read differently.
     """
     return div(
         _metadata_html(title, description),
         _args_html(args),
         div(
             tags.strong("Result"),
-            div(_value_html(value), class_="commons-measure-result-value"),
+            div(
+                _value_html(value, from_query),
+                class_="commons-measure-result-value",
+            ),
             class_="commons-measure-result",
         ),
         class_="commons-measure-display",
@@ -174,8 +182,8 @@ def _args_html(args: Mapping[str, Any]) -> Tag | None:
     )
 
 
-def _value_html(value: Any) -> TagChild:
-    rows = _as_rows(value)
+def _value_html(value: Any, from_query: bool) -> TagChild:
+    rows = _as_rows(value, from_query)
     if rows is None:
         return render_value(value)
     if not rows:
@@ -202,15 +210,11 @@ def _value_html(value: Any) -> TagChild:
     )
 
 
-def _as_rows(value: Any) -> list[Mapping[str, Any]] | None:
-    """The rows behind a value, whether it arrived as a frame or as rows.
-
-    A data source answers a query with rows, while a measure is more likely
-    to return a frame, and both reach this card.
-    """
+def _as_rows(value: Any, from_query: bool) -> list[Mapping[str, Any]] | None:
+    """The rows behind a value, whether it arrived as a frame or as rows."""
     if is_frame(value):
         return cast("list[Mapping[str, Any]] | None", frame_rows(value))
-    if isinstance(value, list) and all(isinstance(row, Mapping) for row in value):
+    if from_query and isinstance(value, list):
         return value
     return None
 

--- a/pkg-py/src/commons/_display.py
+++ b/pkg-py/src/commons/_display.py
@@ -158,9 +158,7 @@ def _metadata_html(title: str | None, description: str | None) -> Tag | None:
 
 
 def _args_html(args: Mapping[str, Any]) -> Tag | None:
-    # An argument the caller left out is not an argument the measure ran with.
-    given = {name: value for name, value in args.items() if value is not None}
-    if not given:
+    if not args:
         return None
     return div(
         *(
@@ -170,7 +168,7 @@ def _args_html(args: Mapping[str, Any]) -> Tag | None:
                 tags.span(_format_arg(value), class_="commons-measure-arg-value"),
                 class_="commons-measure-arg",
             )
-            for name, value in given.items()
+            for name, value in args.items()
         ),
         class_="commons-measure-args",
     )
@@ -180,6 +178,9 @@ def _value_html(value: Any) -> TagChild:
     rows = _as_rows(value)
     if rows is None:
         return render_value(value)
+    if not rows:
+        # The same words the model is given, so the card cannot disagree.
+        return "No rows."
     # Union rather than the first row's keys: a driver may omit a null column.
     columns = list(dict.fromkeys(key for row in rows for key in row))
     shown = rows[:MAX_MARKDOWN_ROWS]
@@ -209,7 +210,7 @@ def _as_rows(value: Any) -> list[Mapping[str, Any]] | None:
     """
     if is_frame(value):
         return cast("list[Mapping[str, Any]] | None", frame_rows(value))
-    if isinstance(value, list) and value and all(isinstance(r, Mapping) for r in value):
+    if isinstance(value, list) and all(isinstance(row, Mapping) for row in value):
         return value
     return None
 

--- a/pkg-py/src/commons/_display.py
+++ b/pkg-py/src/commons/_display.py
@@ -14,12 +14,12 @@ from __future__ import annotations
 import re
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 from htmltools import Tag, TagChild, TagList, div, tags
 
 from ._frames import is_frame
-from ._rows import frame_rows, render_value
+from ._rows import MAX_MARKDOWN_ROWS, frame_rows, render_value
 
 _URL = re.compile(r"https?://", re.IGNORECASE)
 
@@ -158,7 +158,9 @@ def _metadata_html(title: str | None, description: str | None) -> Tag | None:
 
 
 def _args_html(args: Mapping[str, Any]) -> Tag | None:
-    if not args:
+    # An argument the caller left out is not an argument the measure ran with.
+    given = {name: value for name, value in args.items() if value is not None}
+    if not given:
         return None
     return div(
         *(
@@ -168,23 +170,48 @@ def _args_html(args: Mapping[str, Any]) -> Tag | None:
                 tags.span(_format_arg(value), class_="commons-measure-arg-value"),
                 class_="commons-measure-arg",
             )
-            for name, value in args.items()
+            for name, value in given.items()
         ),
         class_="commons-measure-args",
     )
 
 
 def _value_html(value: Any) -> TagChild:
-    rows = frame_rows(value) if is_frame(value) else None
+    rows = _as_rows(value)
     if rows is None:
         return render_value(value)
-    columns = list(rows[0]) if rows else []
-    return tags.table(
-        tags.thead(tags.tr(*(tags.th(column) for column in columns))),
-        tags.tbody(
-            *(tags.tr(*(tags.td(render_value(row[c])) for c in columns)) for row in rows)
+    # Union rather than the first row's keys: a driver may omit a null column.
+    columns = list(dict.fromkeys(key for row in rows for key in row))
+    shown = rows[:MAX_MARKDOWN_ROWS]
+    return TagList(
+        tags.table(
+            tags.thead(tags.tr(*(tags.th(column) for column in columns))),
+            tags.tbody(
+                *(
+                    tags.tr(
+                        *(tags.td(render_value(row.get(c))) for c in columns)
+                    )
+                    for row in shown
+                )
+            ),
         ),
+        tags.p(f"{len(rows) - len(shown)} more rows not shown")
+        if len(rows) > len(shown)
+        else None,
     )
+
+
+def _as_rows(value: Any) -> list[Mapping[str, Any]] | None:
+    """The rows behind a value, whether it arrived as a frame or as rows.
+
+    A data source answers a query with rows, while a measure is more likely
+    to return a frame, and both reach this card.
+    """
+    if is_frame(value):
+        return cast("list[Mapping[str, Any]] | None", frame_rows(value))
+    if isinstance(value, list) and value and all(isinstance(r, Mapping) for r in value):
+        return value
+    return None
 
 
 def _label(name: str) -> str:

--- a/pkg-py/src/commons/_display.py
+++ b/pkg-py/src/commons/_display.py
@@ -11,8 +11,17 @@ one when bsicons is absent, so an iconless row is a branch R already has.
 
 from __future__ import annotations
 
+import re
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any
+
+from htmltools import Tag, TagChild, TagList, div, tags
+
+from ._frames import is_frame
+from ._rows import frame_rows, render_value
+
+_URL = re.compile(r"https?://", re.IGNORECASE)
 
 __all__ = [
     "CONTEXT_SEARCH",
@@ -22,6 +31,8 @@ __all__ = [
     "TRUSTED_CALL",
     "TRUSTED_SEARCH",
     "Title",
+    "measure_display_html",
+    "measure_source_footer",
     "tool_display",
     "visible_result_note",
 ]
@@ -81,3 +92,112 @@ def visible_result_note(kind: str) -> str:
         f"This {kind} is already visible to the user. "
         "**Do not recreate or repeat it**."
     )
+
+
+def measure_display_html(
+    args: Mapping[str, Any],
+    value: Any,
+    *,
+    title: str | None = None,
+    description: str | None = None,
+) -> Tag:
+    """The card behind a trusted calculation: what ran, with what, and the answer.
+
+    Built as tags rather than assembled text, so every value a measure or the
+    model supplied is escaped by htmltools on the way in.
+    """
+    return div(
+        _metadata_html(title, description),
+        _args_html(args),
+        div(
+            tags.strong("Result"),
+            div(_value_html(value), class_="commons-measure-result-value"),
+            class_="commons-measure-result",
+        ),
+        class_="commons-measure-display",
+    )
+
+
+def measure_source_footer(provenance: Iterable[str]) -> TagList | None:
+    """Links back to wherever the measure's definition came from.
+
+    Only the URLs in `provenance` become links; the rest of it is prose for
+    the model rather than something a reader can follow.
+    """
+    urls = list(dict.fromkeys(url for url in provenance if _URL.match(url)))
+    if not urls:
+        return None
+    return TagList(
+        *(
+            tags.a(
+                "View source" if len(urls) == 1 else f"Source {position}",
+                class_="commons-measure-source-link",
+                href=url,
+                target="_blank",
+                # A chat app loses its session when a link navigates the page.
+                rel="noopener noreferrer",
+            )
+            for position, url in enumerate(urls, start=1)
+        )
+    )
+
+
+def _metadata_html(title: str | None, description: str | None) -> Tag | None:
+    if not title:
+        return None
+    return div(
+        div(
+            tags.strong(title, class_="commons-measure-title"),
+            div(description, class_="commons-measure-description")
+            if description
+            else None,
+            class_="commons-measure-metadata-item",
+        ),
+        class_="commons-measure-metadata",
+    )
+
+
+def _args_html(args: Mapping[str, Any]) -> Tag | None:
+    if not args:
+        return None
+    return div(
+        *(
+            div(
+                tags.span(f"{_label(name)}:", class_="commons-measure-arg-name"),
+                " ",
+                tags.span(_format_arg(value), class_="commons-measure-arg-value"),
+                class_="commons-measure-arg",
+            )
+            for name, value in args.items()
+        ),
+        class_="commons-measure-args",
+    )
+
+
+def _value_html(value: Any) -> TagChild:
+    rows = frame_rows(value) if is_frame(value) else None
+    if rows is None:
+        return render_value(value)
+    columns = list(rows[0]) if rows else []
+    return tags.table(
+        tags.thead(tags.tr(*(tags.th(column) for column in columns))),
+        tags.tbody(
+            *(tags.tr(*(tags.td(render_value(row[c])) for c in columns)) for row in rows)
+        ),
+    )
+
+
+def _label(name: str) -> str:
+    """An argument name as a reader would write it."""
+    spelled = name.replace("_", " ")
+    return spelled[:1].upper() + spelled[1:]
+
+
+def _format_arg(value: Any) -> str:
+    if isinstance(value, (list, tuple)):
+        return ", ".join(_format_arg(item) for item in value)
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, (int, float)):
+        return f"{value:,.0f}" if float(value).is_integer() else f"{value:,}"
+    return render_value(value)

--- a/pkg-py/src/commons/_display.py
+++ b/pkg-py/src/commons/_display.py
@@ -11,11 +11,43 @@ one when bsicons is absent, so an iconless row is a branch R already has.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
-__all__ = ["DISPLAY_EXTRA_KEY", "tool_display", "visible_result_note"]
+__all__ = [
+    "CONTEXT_SEARCH",
+    "DATA_RETRIEVAL",
+    "DISPLAY_EXTRA_KEY",
+    "TABLE_INSPECTION",
+    "TRUSTED_CALL",
+    "TRUSTED_SEARCH",
+    "Title",
+    "tool_display",
+    "visible_result_note",
+]
 
 DISPLAY_EXTRA_KEY = "display"
+
+
+@dataclass(frozen=True)
+class Title:
+    """What a tool row says while it runs, and once its result arrives.
+
+    shinychat shows the tool definition's title until the result carries one
+    of its own, and conjugates neither, so both tenses are written out.
+    """
+
+    running: str
+    settled: str
+
+
+TRUSTED_SEARCH = Title(
+    "Searching for a trusted calculation", "Searched for a trusted calculation"
+)
+TRUSTED_CALL = Title("Running a trusted calculation", "Ran a trusted calculation")
+CONTEXT_SEARCH = Title("Searching context", "Searched context")
+TABLE_INSPECTION = Title("Inspecting a table", "Inspected a table")
+DATA_RETRIEVAL = Title("Retrieving data", "Retrieved data")
 
 
 def tool_display(

--- a/pkg-py/src/commons/_display.py
+++ b/pkg-py/src/commons/_display.py
@@ -1,0 +1,51 @@
+"""How a tool result asks to be shown in a chat UI.
+
+shinychat reads the presentation off ``extra["display"]``, accepting either
+its own ``ToolResultDisplay`` or a plain mapping it splats into one. commons
+builds the mapping, so a result carries its presentation whether or not the
+``shiny`` extra is installed and nothing here imports shinychat.
+
+Icons are left out. R fills them from bsicons and renders these rows without
+one when bsicons is absent, so an iconless row is a branch R already has.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["DISPLAY_EXTRA_KEY", "tool_display", "visible_result_note"]
+
+DISPLAY_EXTRA_KEY = "display"
+
+
+def tool_display(
+    title: str | None = None,
+    *,
+    html: Any = None,
+    markdown: str | None = None,
+    footer: Any = None,
+    open: bool = False,
+) -> dict[str, Any]:
+    """The display envelope for a tool result.
+
+    ``show_request`` is always off: the arguments commons sends a tool are
+    its own plumbing, and a reader who wants them can open the card.
+    """
+    display: dict[str, Any] = {"show_request": False, "open": open}
+    if title is not None:
+        display["title"] = title
+    if html is not None:
+        display["html"] = html
+    if markdown is not None:
+        display["markdown"] = markdown
+    if footer is not None:
+        display["footer"] = footer
+    return display
+
+
+def visible_result_note(kind: str) -> str:
+    """Tell the model the user can already see this result."""
+    return (
+        f"This {kind} is already visible to the user. "
+        "**Do not recreate or repeat it**."
+    )

--- a/pkg-py/src/commons/_pool.py
+++ b/pkg-py/src/commons/_pool.py
@@ -17,6 +17,7 @@ from sqlglot import expressions as exp
 
 from ._citations import tool_result
 from ._definitions import ExportRecord, applied_text
+from ._display import TRUSTED_CALL
 from ._measures import Measure, measure_schema_text
 from ._provenance import Tag
 from ._rows import rows_to_markdown
@@ -278,7 +279,7 @@ def call_metrics(
     body = "\n\n".join(
         part for part in (rows_to_markdown(rows), applied_text(applied), advert) if part
     )
-    return tool_result(body, tag=Tag.A)
+    return tool_result(body, tag=Tag.A, title=TRUSTED_CALL.settled)
 
 
 def _resolve_names(

--- a/pkg-py/src/commons/_pool.py
+++ b/pkg-py/src/commons/_pool.py
@@ -297,6 +297,7 @@ def call_metrics(
                 if value is not None
             },
             rows,
+            from_query=True,
         ),
     )
 

--- a/pkg-py/src/commons/_pool.py
+++ b/pkg-py/src/commons/_pool.py
@@ -17,7 +17,7 @@ from sqlglot import expressions as exp
 
 from ._citations import tool_result
 from ._definitions import ExportRecord, applied_text
-from ._display import TRUSTED_CALL
+from ._display import TRUSTED_CALL, measure_display_html
 from ._measures import Measure, measure_schema_text
 from ._provenance import Tag
 from ._rows import rows_to_markdown
@@ -279,7 +279,15 @@ def call_metrics(
     body = "\n\n".join(
         part for part in (rows_to_markdown(rows), applied_text(applied), advert) if part
     )
-    return tool_result(body, tag=Tag.A, title=TRUSTED_CALL.settled)
+    return tool_result(
+        body,
+        tag=Tag.A,
+        title=TRUSTED_CALL.settled,
+        markdown=f"```sql\n{sql}\n```\n\n{rows_to_markdown(rows)}",
+        html=measure_display_html(
+            {"metrics": metrics, "dimensions": dimensions, "filters": filters}, rows
+        ),
+    )
 
 
 def _resolve_names(

--- a/pkg-py/src/commons/_pool.py
+++ b/pkg-py/src/commons/_pool.py
@@ -284,8 +284,19 @@ def call_metrics(
         tag=Tag.A,
         title=TRUSTED_CALL.settled,
         markdown=f"```sql\n{sql}\n```\n\n{rows_to_markdown(rows)}",
+        # Only the arguments the caller gave: an omitted one is not how the
+        # query ran, unlike a measure argument explicitly set to null.
         html=measure_display_html(
-            {"metrics": metrics, "dimensions": dimensions, "filters": filters}, rows
+            {
+                name: value
+                for name, value in (
+                    ("metrics", metrics),
+                    ("dimensions", dimensions),
+                    ("filters", filters),
+                )
+                if value is not None
+            },
+            rows,
         ),
     )
 

--- a/pkg-py/src/commons/_tools.py
+++ b/pkg-py/src/commons/_tools.py
@@ -35,6 +35,13 @@ from ._citations import CitationRequest, tool_result
 from ._context_layer import ContextLayer
 from ._data_source import DataSource, TableId
 from ._definitions import Registry, applied_text, expand_tokens, index_overflows
+from ._display import (
+    CONTEXT_SEARCH,
+    DATA_RETRIEVAL,
+    TABLE_INSPECTION,
+    TRUSTED_CALL,
+    TRUSTED_SEARCH,
+)
 from ._frames import describe_frame, is_frame
 from ._handles import HandleStore
 from ._measures import Measure
@@ -197,13 +204,14 @@ def _tool(
     name: str,
     description: str,
     parameters: dict[str, Any],
+    title: str,
 ) -> Tool:
     return Tool(
         func=func,
         name=name,
         description=description,
         parameters=parameters,
-        annotations=_READ_ONLY,
+        annotations={**_READ_ONLY, "title": title},
     )
 
 
@@ -248,7 +256,10 @@ def _search_pool(context: ToolContext) -> Tool:
 
     def search_pool(query: str) -> ContentToolResult:
         return tool_result(
-            search_pool_text(context.measures, context.definitions, query, source_names)
+            search_pool_text(
+                context.measures, context.definitions, query, source_names
+            ),
+            title=TRUSTED_SEARCH.settled,
         )
 
     return _tool(
@@ -261,6 +272,7 @@ def _search_pool(context: ToolContext) -> Tool:
             {"query": _string("What you want to compute, in plain language.")},
             ["query"],
         ),
+        TRUSTED_SEARCH.running,
     )
 
 
@@ -296,7 +308,7 @@ def _call_measure(context: ToolContext) -> Tool:
         body = "\n\n".join(
             part for part in (_format_measure_value(value), advert) if part
         )
-        return tool_result(body, tag=Tag.A)
+        return tool_result(body, tag=Tag.A, title=TRUSTED_CALL.settled)
 
     return _tool(
         call_measure,
@@ -316,6 +328,7 @@ def _call_measure(context: ToolContext) -> Tool:
             },
             ["name", "arguments"],
         ),
+        TRUSTED_CALL.running,
     )
 
 
@@ -428,6 +441,7 @@ def _call_metrics(context: ToolContext) -> Tool:
             ["metrics"],
             context.sources,
         ),
+        TRUSTED_CALL.running,
     )
 
 
@@ -440,16 +454,22 @@ def _search_catalog(context: ToolContext) -> Tool:
     ) -> ContentToolResult:
         _, resolved = _resolve_source(context.sources, source)
         if not catalog_searchable(resolved):
-            return tool_result("This data source does not have a searchable catalog.")
+            return tool_result(
+                "This data source does not have a searchable catalog.",
+                title=TRUSTED_SEARCH.settled,
+            )
         results = _catalog_search(resolved, query, kinds)
         if not results:
-            return tool_result(f'No catalog objects found for "{query}".')
+            return tool_result(
+                f'No catalog objects found for "{query}".',
+                title=TRUSTED_SEARCH.settled,
+            )
         lines = [
             f"- `{label}` ({relation.kind or 'unknown kind'}): "
             f"{relation.description or 'No description.'}"
             for label, relation in results.items()
         ]
-        return tool_result("\n".join(lines))
+        return tool_result("\n".join(lines), title=TRUSTED_SEARCH.settled)
 
     return _tool(
         search_catalog,
@@ -464,6 +484,7 @@ def _search_catalog(context: ToolContext) -> Tool:
             ["query"],
             context.sources,
         ),
+        TRUSTED_SEARCH.running,
     )
 
 
@@ -504,10 +525,15 @@ def _queryable(source: DataSource, manifest: Manifest) -> Callable[[str], bool]:
 def _search_context(context: ToolContext) -> Tool:
     def search_context(query: str) -> ContentToolResult:
         if context.context_layer is None:
-            return tool_result("No context layer is configured for this agent.")
+            return tool_result(
+                "No context layer is configured for this agent.",
+                title=CONTEXT_SEARCH.settled,
+            )
         hits = context.context_layer.search(query)
         body = "\n\n---\n\n".join(hits) if hits else f'No context found for "{query}".'
-        return _with_citation_request(tool_result(body), context)
+        return _with_citation_request(
+            tool_result(body, title=CONTEXT_SEARCH.settled), context
+        )
 
     return _tool(
         search_context,
@@ -517,6 +543,7 @@ def _search_context(context: ToolContext) -> Tool:
             {"query": _string("What you need context about, in plain language.")},
             ["query"],
         ),
+        CONTEXT_SEARCH.running,
     )
 
 
@@ -535,7 +562,8 @@ def _describe_table(context: ToolContext) -> Tool:
     def describe_table(table: str, source: str | None = None) -> ContentToolResult:
         label, resolved = _resolve_source(context.sources, source)
         return tool_result(
-            _describe_table_text(resolved, label, table, context.first_touch)
+            _describe_table_text(resolved, label, table, context.first_touch),
+            title=TABLE_INSPECTION.settled,
         )
 
     return _tool(
@@ -550,6 +578,7 @@ def _describe_table(context: ToolContext) -> Tool:
             ["table"],
             context.sources,
         ),
+        TABLE_INSPECTION.running,
     )
 
 
@@ -656,7 +685,9 @@ def _run_sql(context: ToolContext) -> Tool:
             )
             if part
         )
-        return _with_citation_request(tool_result(body, tag=Tag.B), context)
+        return _with_citation_request(
+            tool_result(body, tag=Tag.B, title=DATA_RETRIEVAL.settled), context
+        )
 
     return _tool(
         run_sql,
@@ -671,6 +702,7 @@ def _run_sql(context: ToolContext) -> Tool:
             ["sql"],
             context.sources,
         ),
+        DATA_RETRIEVAL.running,
     )
 
 

--- a/pkg-py/src/commons/_tools.py
+++ b/pkg-py/src/commons/_tools.py
@@ -42,6 +42,8 @@ from ._display import (
     TABLE_INSPECTION,
     TRUSTED_CALL,
     TRUSTED_SEARCH,
+    measure_display_html,
+    measure_source_footer,
     tool_display,
     visible_result_note,
 )
@@ -312,7 +314,15 @@ def _call_measure(context: ToolContext) -> Tool:
         body = "\n\n".join(
             part for part in (_format_measure_value(value), advert) if part
         )
-        return tool_result(body, tag=Tag.A, title=TRUSTED_CALL.settled)
+        return tool_result(
+            body,
+            tag=Tag.A,
+            title=TRUSTED_CALL.settled,
+            html=measure_display_html(
+                args, value, title=record.title, description=record.description
+            ),
+            footer=measure_source_footer(record.provenance),
+        )
 
     return _tool(
         call_measure,

--- a/pkg-py/src/commons/_tools.py
+++ b/pkg-py/src/commons/_tools.py
@@ -38,15 +38,18 @@ from ._definitions import Registry, applied_text, expand_tokens, index_overflows
 from ._display import (
     CONTEXT_SEARCH,
     DATA_RETRIEVAL,
+    DISPLAY_EXTRA_KEY,
     TABLE_INSPECTION,
     TRUSTED_CALL,
     TRUSTED_SEARCH,
+    tool_display,
+    visible_result_note,
 )
 from ._frames import describe_frame, is_frame
 from ._handles import HandleStore
 from ._measures import Measure
 from ._pool import call_metrics, search_pool_text
-from ._provenance import Tag
+from ._provenance import TAG_EXTRA_KEY, Tag
 from ._rows import frame_rows, render_value, rows_to_markdown
 from ._sample_summary import SAMPLE_SUMMARY_HEADING, sample_summary
 
@@ -301,9 +304,10 @@ def _call_measure(context: ToolContext) -> Tool:
                 source.ensure_loaded()
         value = record.func(**args, **injected)
         # A measure that built its own tool result — a plot, a displayable
-        # table — has already said how it should look; return it untouched.
+        # table — has already said how it should look; commons only fills in
+        # what it alone knows.
         if isinstance(value, ContentToolResult):
-            return value
+            return _finish_measure_result(value, context)
         advert = context.handles.register(value)
         body = "\n\n".join(
             part for part in (_format_measure_value(value), advert) if part
@@ -330,6 +334,57 @@ def _call_measure(context: ToolContext) -> Tool:
         ),
         TRUSTED_CALL.running,
     )
+
+
+def _finish_measure_result(
+    result: ContentToolResult, context: ToolContext
+) -> ContentToolResult:
+    """Fill in what commons knows about a result a measure built for itself.
+
+    That is the trusted tag, a default title, the handle the values behind
+    the display are reachable by, and the note that stops the model repeating
+    a result the reader can already see. An errored result gets none of it:
+    the model is sent the error rather than the value, so anything added to
+    the value would never arrive.
+    """
+    extra = dict(result.extra or {})
+    data = extra.pop("data", None)
+    display = _titled(extra.get(DISPLAY_EXTRA_KEY))
+    extra[DISPLAY_EXTRA_KEY] = display
+    extra[TAG_EXTRA_KEY] = Tag.A
+    result.extra = extra
+
+    if result.error is None:
+        parts = [_format_measure_value(result.value), context.handles.register(data)]
+        if any(_display_field(display, name) is not None for name in _SHOWN_FIELDS):
+            parts.insert(0, visible_result_note("measure result"))
+        result.value = "\n\n".join(part for part in parts if part)
+    return result
+
+
+# The fields that put the result itself in front of the reader, rather than
+# only a row saying the tool ran.
+_SHOWN_FIELDS = ("html", "markdown", "text")
+
+
+def _display_field(display: Any, name: str) -> Any:
+    """Read one field off a display, however the measure chose to build it."""
+    if isinstance(display, Mapping):
+        return display.get(name)
+    return getattr(display, name, None)
+
+
+def _titled(display: Any) -> Any:
+    """Give a display the default title, unless the measure chose its own."""
+    if display is None:
+        return tool_display(TRUSTED_CALL.settled)
+    if isinstance(display, Mapping):
+        return {"title": TRUSTED_CALL.settled, **display}
+    if getattr(display, "title", None) is None:
+        # A shinychat ToolResultDisplay, which its own documentation
+        # recommends over the mapping commons builds.
+        display.title = TRUSTED_CALL.settled
+    return display
 
 
 def _parse_json_arguments(arguments: Any) -> dict[str, Any]:

--- a/pkg-py/src/commons/_tools.py
+++ b/pkg-py/src/commons/_tools.py
@@ -309,7 +309,7 @@ def _call_measure(context: ToolContext) -> Tool:
         # table — has already said how it should look; commons only fills in
         # what it alone knows.
         if isinstance(value, ContentToolResult):
-            return _finish_measure_result(value, context)
+            return _finish_measure_result(value, record, context)
         advert = context.handles.register(value)
         body = "\n\n".join(
             part for part in (_format_measure_value(value), advert) if part
@@ -347,7 +347,7 @@ def _call_measure(context: ToolContext) -> Tool:
 
 
 def _finish_measure_result(
-    result: ContentToolResult, context: ToolContext
+    result: ContentToolResult, record: Measure, context: ToolContext
 ) -> ContentToolResult:
     """Fill in what commons knows about a result a measure built for itself.
 
@@ -362,7 +362,9 @@ def _finish_measure_result(
     """
     extra = dict(result.extra or {})
     data = extra.pop("data", None)
-    display = _titled(extra.get(DISPLAY_EXTRA_KEY))
+    display = _defaulted(
+        extra.get(DISPLAY_EXTRA_KEY), measure_source_footer(record.provenance)
+    )
     extra[DISPLAY_EXTRA_KEY] = display
     result.extra = extra
     if result.error is not None:
@@ -388,19 +390,22 @@ def _display_field(display: Any, name: str) -> Any:
     return getattr(display, name, None)
 
 
-def _titled(display: Any) -> Any:
-    """Give a display the default title, unless the measure chose its own."""
+def _defaulted(display: Any, footer: Any) -> Any:
+    """Fill a display's title and footer, unless the measure chose its own."""
+    defaults = {"title": TRUSTED_CALL.settled, "footer": footer}
     if display is None:
-        return tool_display(TRUSTED_CALL.settled)
+        return tool_display(TRUSTED_CALL.settled, footer=footer)
     if isinstance(display, Mapping):
-        titled = dict(display)
-        if titled.get("title") is None:
-            titled["title"] = TRUSTED_CALL.settled
-        return titled
-    if getattr(display, "title", None) is None:
-        # A shinychat ToolResultDisplay, which its own documentation
-        # recommends over the mapping commons builds.
-        display.title = TRUSTED_CALL.settled
+        filled = dict(display)
+        for name, default in defaults.items():
+            if filled.get(name) is None:
+                filled[name] = default
+        return filled
+    # A shinychat ToolResultDisplay, which its own documentation recommends
+    # over the mapping commons builds.
+    for name, default in defaults.items():
+        if getattr(display, name, None) is None:
+            setattr(display, name, default)
     return display
 
 

--- a/pkg-py/src/commons/_tools.py
+++ b/pkg-py/src/commons/_tools.py
@@ -366,6 +366,8 @@ def _finish_measure_result(
         extra.get(DISPLAY_EXTRA_KEY), measure_source_footer(record.provenance)
     )
     extra[DISPLAY_EXTRA_KEY] = display
+    # The tag is commons' to set, so a measure never keeps one it supplied.
+    extra.pop(TAG_EXTRA_KEY, None)
     result.extra = extra
     if result.error is not None:
         return result

--- a/pkg-py/src/commons/_tools.py
+++ b/pkg-py/src/commons/_tools.py
@@ -353,22 +353,26 @@ def _finish_measure_result(
 
     That is the trusted tag, a default title, the handle the values behind
     the display are reachable by, and the note that stops the model repeating
-    a result the reader can already see. An errored result gets none of it:
-    the model is sent the error rather than the value, so anything added to
-    the value would never arrive.
+    a result the reader can already see.
+
+    An errored result keeps only the title. The model is sent the error
+    rather than the value, so anything added to the value would never arrive,
+    and the tag would let a calculation that failed promote the answer that
+    follows it to a verified one.
     """
     extra = dict(result.extra or {})
     data = extra.pop("data", None)
     display = _titled(extra.get(DISPLAY_EXTRA_KEY))
     extra[DISPLAY_EXTRA_KEY] = display
-    extra[TAG_EXTRA_KEY] = Tag.A
     result.extra = extra
+    if result.error is not None:
+        return result
 
-    if result.error is None:
-        parts = [_format_measure_value(result.value), context.handles.register(data)]
-        if any(_display_field(display, name) is not None for name in _SHOWN_FIELDS):
-            parts.insert(0, visible_result_note("measure result"))
-        result.value = "\n\n".join(part for part in parts if part)
+    extra[TAG_EXTRA_KEY] = Tag.A
+    parts = [_format_measure_value(result.value), context.handles.register(data)]
+    if any(_display_field(display, name) is not None for name in _SHOWN_FIELDS):
+        parts.insert(0, visible_result_note("measure result"))
+    result.value = "\n\n".join(part for part in parts if part)
     return result
 
 
@@ -389,7 +393,10 @@ def _titled(display: Any) -> Any:
     if display is None:
         return tool_display(TRUSTED_CALL.settled)
     if isinstance(display, Mapping):
-        return {"title": TRUSTED_CALL.settled, **display}
+        titled = dict(display)
+        if titled.get("title") is None:
+            titled["title"] = TRUSTED_CALL.settled
+        return titled
     if getattr(display, "title", None) is None:
         # A shinychat ToolResultDisplay, which its own documentation
         # recommends over the mapping commons builds.

--- a/pkg-py/src/commons/_ui/__init__.py
+++ b/pkg-py/src/commons/_ui/__init__.py
@@ -6,7 +6,7 @@ try:
     from ._assets import asset_base_url, commons_chat_dependency
     from ._theme import theme
 except ModuleNotFoundError as err:
-    # shiny, shinychat and htmltools arrive with the `shiny` extra.
+    # shiny and shinychat arrive with the `shiny` extra.
     raise ImportError(
         f"commons.ui needs {err.name}, which is not installed. "
         'Install it with: pip install "commons[shiny]"'

--- a/pkg-py/tests/test_citation_request.py
+++ b/pkg-py/tests/test_citation_request.py
@@ -29,7 +29,7 @@ def test_tool_result_carries_its_provenance_tag():
 
     assert isinstance(result, ContentToolResult)
     assert result.value == "6 rows"
-    assert result.extra == {"commons_tag": Tag.B}
+    assert result.extra["commons_tag"] == Tag.B
 
 
 def test_shared_citation_request_cases():

--- a/pkg-py/tests/test_measure_html.py
+++ b/pkg-py/tests/test_measure_html.py
@@ -11,6 +11,7 @@ from typing import Any
 import pandas as pd
 
 from commons._display import measure_display_html, measure_source_footer
+from commons._rows import MAX_MARKDOWN_ROWS
 
 
 def rendered(tag: Any) -> str:
@@ -99,3 +100,35 @@ def test_a_link_opens_away_from_the_app() -> None:
 
     assert 'target="_blank"' in html
     assert "noopener" in html
+
+
+def test_query_rows_are_drawn_as_a_table() -> None:
+    """`call_metrics` hands its result over as rows, not as a frame."""
+    rows = [{"region": "EMEA", "revenue": 500.0}]
+
+    html = rendered(measure_display_html({}, rows))
+
+    assert "<table" in html
+    assert "EMEA" in html
+
+
+def test_a_long_table_is_capped_and_says_so() -> None:
+    rows = [{"n": n} for n in range(MAX_MARKDOWN_ROWS + 5)]
+
+    html = rendered(measure_display_html({}, rows))
+
+    assert html.count("<tr") == MAX_MARKDOWN_ROWS + 1
+    assert "5 more rows not shown" in html
+
+
+def test_a_column_a_row_omits_is_still_a_column() -> None:
+    """A driver may leave a null column out of a row it returns."""
+    html = rendered(measure_display_html({}, [{"a": 1}, {"a": 2, "b": 3}]))
+
+    assert "<th>b</th>" in html
+
+
+def test_an_argument_that_was_not_given_is_left_out() -> None:
+    html = rendered(measure_display_html({"metrics": ["revenue"], "filters": None}, 41))
+
+    assert "Filters" not in html

--- a/pkg-py/tests/test_measure_html.py
+++ b/pkg-py/tests/test_measure_html.py
@@ -128,7 +128,14 @@ def test_a_column_a_row_omits_is_still_a_column() -> None:
     assert "<th>b</th>" in html
 
 
-def test_an_argument_that_was_not_given_is_left_out() -> None:
-    html = rendered(measure_display_html({"metrics": ["revenue"], "filters": None}, 41))
 
-    assert "Filters" not in html
+def test_a_query_that_matched_nothing_says_so() -> None:
+    """The card and the markdown the model reads must not disagree."""
+    assert "No rows." in rendered(measure_display_html({}, []))
+
+
+def test_an_argument_explicitly_set_to_null_is_still_shown() -> None:
+    """A null argument can override a non-null default, so it is how it ran."""
+    html = rendered(measure_display_html({"region": None}, 41))
+
+    assert "Region" in html

--- a/pkg-py/tests/test_measure_html.py
+++ b/pkg-py/tests/test_measure_html.py
@@ -106,7 +106,7 @@ def test_query_rows_are_drawn_as_a_table() -> None:
     """`call_metrics` hands its result over as rows, not as a frame."""
     rows = [{"region": "EMEA", "revenue": 500.0}]
 
-    html = rendered(measure_display_html({}, rows))
+    html = rendered(measure_display_html({}, rows, from_query=True))
 
     assert "<table" in html
     assert "EMEA" in html
@@ -115,7 +115,7 @@ def test_query_rows_are_drawn_as_a_table() -> None:
 def test_a_long_table_is_capped_and_says_so() -> None:
     rows = [{"n": n} for n in range(MAX_MARKDOWN_ROWS + 5)]
 
-    html = rendered(measure_display_html({}, rows))
+    html = rendered(measure_display_html({}, rows, from_query=True))
 
     assert html.count("<tr") == MAX_MARKDOWN_ROWS + 1
     assert "5 more rows not shown" in html
@@ -123,7 +123,9 @@ def test_a_long_table_is_capped_and_says_so() -> None:
 
 def test_a_column_a_row_omits_is_still_a_column() -> None:
     """A driver may leave a null column out of a row it returns."""
-    html = rendered(measure_display_html({}, [{"a": 1}, {"a": 2, "b": 3}]))
+    html = rendered(
+        measure_display_html({}, [{"a": 1}, {"a": 2, "b": 3}], from_query=True)
+    )
 
     assert "<th>b</th>" in html
 
@@ -131,7 +133,12 @@ def test_a_column_a_row_omits_is_still_a_column() -> None:
 
 def test_a_query_that_matched_nothing_says_so() -> None:
     """The card and the markdown the model reads must not disagree."""
-    assert "No rows." in rendered(measure_display_html({}, []))
+    assert "No rows." in rendered(measure_display_html({}, [], from_query=True))
+
+
+def test_a_measure_that_returned_an_empty_list_is_not_a_query() -> None:
+    """An empty list is an empty result to a query, an empty answer to a measure."""
+    assert "No rows." not in rendered(measure_display_html({}, []))
 
 
 def test_an_argument_explicitly_set_to_null_is_still_shown() -> None:

--- a/pkg-py/tests/test_measure_html.py
+++ b/pkg-py/tests/test_measure_html.py
@@ -1,0 +1,101 @@
+"""The card a measure result draws: its metadata, its arguments, its value.
+
+`www/commons-chat/commons-chat.css` styles these class names, and both
+packages serve that one stylesheet, so the class names are the contract
+these tests hold. The markup is rendered rather than inspected as tags,
+because escaping is the part worth proving.
+"""
+
+from typing import Any
+
+import pandas as pd
+
+from commons._display import measure_display_html, measure_source_footer
+
+
+def rendered(tag: Any) -> str:
+    return str(tag) if tag is None else tag.get_html_string()
+
+
+def test_a_value_is_shown_as_the_result() -> None:
+    html = rendered(measure_display_html({}, 41))
+
+    assert "commons-measure-result-value" in html
+    assert "41" in html
+
+
+def test_an_argument_is_labelled_and_shown() -> None:
+    html = rendered(measure_display_html({"region_name": "EMEA"}, 41))
+
+    assert "Region name" in html
+    assert "EMEA" in html
+
+
+def test_a_measure_with_no_arguments_draws_no_argument_block() -> None:
+    assert "commons-measure-args" not in rendered(measure_display_html({}, 41))
+
+
+def test_a_large_number_is_grouped_for_reading() -> None:
+    html = rendered(measure_display_html({"floor": 1234567}, 41))
+
+    assert "1,234,567" in html
+
+
+def test_a_frame_is_drawn_as_a_table() -> None:
+    frame = pd.DataFrame({"region": ["EMEA"], "revenue": [500.0]})
+
+    html = rendered(measure_display_html({}, frame))
+
+    assert "<table" in html
+    assert "EMEA" in html
+
+
+def test_a_measures_title_and_description_head_the_card() -> None:
+    html = rendered(
+        measure_display_html({}, 41, title="Net revenue", description="After refunds.")
+    )
+
+    assert "Net revenue" in html
+    assert "After refunds." in html
+
+
+def test_markup_in_a_value_is_shown_rather_than_rendered() -> None:
+    html = rendered(measure_display_html({}, "<script>alert(1)</script>"))
+
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_markup_in_an_argument_is_shown_rather_than_rendered() -> None:
+    html = rendered(measure_display_html({"region": "<b>EMEA</b>"}, 41))
+
+    assert "<b>EMEA</b>" not in html
+
+
+def test_a_measure_with_no_source_links_gets_no_footer() -> None:
+    assert measure_source_footer(()) is None
+    assert measure_source_footer(("Derived from the finance handbook.",)) is None
+
+
+def test_one_source_link_is_named_plainly() -> None:
+    html = rendered(measure_source_footer(("https://example.com/handbook",)))
+
+    assert "View source" in html
+    assert 'href="https://example.com/handbook"' in html
+
+
+def test_several_source_links_are_numbered() -> None:
+    html = rendered(
+        measure_source_footer(("https://example.com/a", "https://example.com/b"))
+    )
+
+    assert "Source 1" in html
+    assert "Source 2" in html
+
+
+def test_a_link_opens_away_from_the_app() -> None:
+    """A chat app loses its session if a link navigates the page."""
+    html = rendered(measure_source_footer(("https://example.com/a",)))
+
+    assert 'target="_blank"' in html
+    assert "noopener" in html

--- a/pkg-py/tests/test_tool_display.py
+++ b/pkg-py/tests/test_tool_display.py
@@ -6,18 +6,27 @@ shinychat. These tests read it back through `get_tool_result_display()`,
 which is the code that consumes it, rather than asserting on the dictionary.
 """
 
-import pytest
-from chatlas import ContentToolRequest, ContentToolResult
+from typing import Any
 
+import pandas as pd
+import pytest
+from chatlas import ContentToolRequest, ContentToolResult, Tool
+
+from commons import DataSource, data_source, measure
 from commons._citations import tool_result
+from commons._definitions import ExportRecord, Registry
+from commons._measures import as_measure
 from commons._provenance import TAG_EXTRA_KEY, Tag
+from commons._tools import ToolContext, build_commons_tools
 
 pytest.importorskip("shinychat")
 
-from shinychat._chat_normalize_chatlas import (  # noqa: E402
+# From the private module rather than `shinychat.types`, whose public name
+# resolves to an import-error stub when chatlas is absent.
+from shinychat._chat_normalize_chatlas import (
+    ToolResultDisplay,
     get_tool_result_display,
 )
-from shinychat.types import ToolResultDisplay  # noqa: E402
 
 
 def shown(result: ContentToolResult) -> ToolResultDisplay:
@@ -53,3 +62,106 @@ def test_a_display_does_not_cost_a_result_its_tag() -> None:
 def test_markdown_is_what_the_reader_sees_in_the_card() -> None:
     result = tool_result("6 rows", title="Retrieved data", markdown="| a |\n|---|")
     assert shown(result).markdown == "| a |\n|---|"
+
+
+# ---- the titles a reader sees ---------------------------------------------
+
+
+def source() -> DataSource:
+    return data_source(
+        sales=pd.DataFrame({"revenue": [500.0, 900.0], "region": ["EMEA", "AMER"]})
+    )
+
+
+def tools(**kwargs: Any) -> list[Tool]:
+    return build_commons_tools(ToolContext(sources={"sales_db": source()}, **kwargs))
+
+
+def find(built: list[Tool], name: str) -> Tool:
+    return next(tool for tool in built if tool.name == name)
+
+
+def ran(built: list[Tool], tool: str, **kwargs: Any) -> ToolResultDisplay:
+    result = find(built, tool).func(**kwargs)
+    assert isinstance(result, ContentToolResult)
+    return shown(result)
+
+
+def _net_revenue() -> ExportRecord:
+    return ExportRecord(
+        name="net_revenue",
+        table="sales",
+        source="sales_db",
+        kind="metric",
+        type="number",
+        expression="SUM(revenue)",
+        label=None,
+        description=None,
+        details=None,
+        columns=["revenue"],
+        definitions=[],
+        sql="sum(revenue)",
+        target="SQL(duckdb)",
+        notes=[],
+        mixed_grain=False,
+    )
+
+
+def measures() -> dict[str, Any]:
+    @measure(description="Count orders in a region.")
+    def order_count() -> int:
+        return 2
+
+    found = as_measure(order_count)
+    assert found is not None
+    return {found.name: found}
+
+
+@pytest.mark.parametrize(
+    ("name", "kwargs", "title"),
+    [
+        ("run_sql", {"sql": "SELECT 1 AS n"}, "Retrieved data"),
+        ("describe_table", {"table": "sales"}, "Inspected a table"),
+    ],
+)
+def test_a_settled_result_is_titled_in_the_past_tense(
+    name: str, kwargs: dict[str, Any], title: str
+) -> None:
+    assert ran(tools(), name, **kwargs).title == title
+
+
+def test_a_measure_result_says_the_calculation_was_trusted() -> None:
+    built = tools(measures=measures())
+
+    display = ran(built, "call_measure", name="order_count", arguments="{}")
+
+    assert display.title == "Ran a trusted calculation"
+
+
+def test_a_pool_search_is_titled_for_what_it_searched() -> None:
+    built = tools(measures=measures())
+
+    assert ran(built, "search_pool", query="orders").title == (
+        "Searched for a trusted calculation"
+    )
+
+
+def test_a_running_tool_is_titled_in_the_present_tense() -> None:
+    """shinychat shows the definition title until the result arrives."""
+    annotations = find(tools(), "run_sql").annotations
+
+    assert annotations is not None
+    assert annotations["title"] == "Retrieving data"
+
+
+def test_a_metrics_result_says_the_calculation_was_trusted() -> None:
+    built = build_commons_tools(
+        ToolContext(
+            sources={"sales_db": source()},
+            definitions=Registry([_net_revenue()]),
+        )
+    )
+
+    display = ran(built, "call_metrics", metrics=["net_revenue"])
+
+    assert display.title == "Ran a trusted calculation"

--- a/pkg-py/tests/test_tool_display.py
+++ b/pkg-py/tests/test_tool_display.py
@@ -390,3 +390,24 @@ def test_a_measure_keeps_the_footer_it_chose() -> None:
 
     assert isinstance(result, ContentToolResult)
     assert "Ask the finance team." in markup(shown(result).footer)
+
+
+def test_a_failed_calculation_cannot_claim_the_trusted_tag_itself() -> None:
+    """The tag is commons' to set, so a measure does not get to keep one."""
+
+    @measure(description="Revenue, when it can be had.")
+    def revenue() -> ContentToolResult:
+        return ContentToolResult(
+            value=None,
+            error=RuntimeError("no rows"),
+            extra={TAG_EXTRA_KEY: Tag.A, "display": {"markdown": "**no rows**"}},
+        )
+
+    found = as_measure(revenue)
+    assert found is not None
+    built = tools(measures={found.name: found})
+
+    result = find(built, "call_measure").func(name="revenue", arguments="{}")
+
+    assert isinstance(result, ContentToolResult)
+    assert TAG_EXTRA_KEY not in (result.extra or {})

--- a/pkg-py/tests/test_tool_display.py
+++ b/pkg-py/tests/test_tool_display.py
@@ -411,3 +411,15 @@ def test_a_failed_calculation_cannot_claim_the_trusted_tag_itself() -> None:
 
     assert isinstance(result, ContentToolResult)
     assert TAG_EXTRA_KEY not in (result.extra or {})
+
+
+def test_a_metrics_card_shows_only_the_arguments_the_model_gave() -> None:
+    built = build_commons_tools(
+        ToolContext(
+            sources={"sales_db": source()}, definitions=Registry([_net_revenue()])
+        )
+    )
+
+    display = ran(built, "call_metrics", metrics=["net_revenue"])
+
+    assert "Dimensions" not in markup(display.html)

--- a/pkg-py/tests/test_tool_display.py
+++ b/pkg-py/tests/test_tool_display.py
@@ -357,3 +357,36 @@ def test_a_display_that_names_no_title_still_gets_the_default() -> None:
     result = measure_result(display={"title": None, "markdown": "**41**"})
 
     assert shown(result).title == "Ran a trusted calculation"
+
+
+def displaying_sourced(display: dict[str, Any]) -> Any:
+    """A measure that draws its own result and records where it came from."""
+
+    @measure(
+        description="Revenue, already drawn.",
+        provenance=["https://example.com/handbook"],
+    )
+    def revenue() -> ContentToolResult:
+        return ContentToolResult(value="41", extra={"display": display})
+
+    found = as_measure(revenue)
+    assert found is not None
+    return {found.name: found}
+
+
+def test_a_measures_own_result_still_links_back_to_its_source() -> None:
+    built = tools(measures=displaying_sourced({"markdown": "**41**"}))
+
+    result = find(built, "call_measure").func(name="revenue", arguments="{}")
+
+    assert isinstance(result, ContentToolResult)
+    assert "https://example.com/handbook" in markup(shown(result).footer)
+
+
+def test_a_measure_keeps_the_footer_it_chose() -> None:
+    built = tools(measures=displaying_sourced({"footer": "Ask the finance team."}))
+
+    result = find(built, "call_measure").func(name="revenue", arguments="{}")
+
+    assert isinstance(result, ContentToolResult)
+    assert "Ask the finance team." in markup(shown(result).footer)

--- a/pkg-py/tests/test_tool_display.py
+++ b/pkg-py/tests/test_tool_display.py
@@ -318,3 +318,42 @@ def test_a_metrics_result_shows_the_query_it_ran() -> None:
 
     assert display.markdown is not None
     assert display.markdown.startswith("```sql\n")
+
+
+def failing(display: dict[str, Any]) -> Any:
+    """A measure whose own result reports that the calculation failed."""
+
+    @measure(description="Revenue, when it can be had.")
+    def revenue() -> ContentToolResult:
+        return ContentToolResult(
+            value=None, error=RuntimeError("no rows"), extra={"display": display}
+        )
+
+    found = as_measure(revenue)
+    assert found is not None
+    return {found.name: found}
+
+
+def test_a_failed_calculation_is_not_trusted() -> None:
+    """A tag here would let a failure promote the answer that follows it."""
+    built = tools(measures=failing({"markdown": "**no rows**"}))
+
+    result = find(built, "call_measure").func(name="revenue", arguments="{}")
+
+    assert isinstance(result, ContentToolResult)
+    assert TAG_EXTRA_KEY not in (result.extra or {})
+
+
+def test_a_failed_calculation_keeps_the_error_the_measure_reported() -> None:
+    built = tools(measures=failing({"markdown": "**no rows**"}))
+
+    result = find(built, "call_measure").func(name="revenue", arguments="{}")
+
+    assert isinstance(result, ContentToolResult)
+    assert result.value is None
+
+
+def test_a_display_that_names_no_title_still_gets_the_default() -> None:
+    result = measure_result(display={"title": None, "markdown": "**41**"})
+
+    assert shown(result).title == "Ran a trusted calculation"

--- a/pkg-py/tests/test_tool_display.py
+++ b/pkg-py/tests/test_tool_display.py
@@ -6,11 +6,13 @@ shinychat. These tests read it back through `get_tool_result_display()`,
 which is the code that consumes it, rather than asserting on the dictionary.
 """
 
-from typing import Any
+from typing import Annotated, Any
 
 import pandas as pd
 import pytest
 from chatlas import ContentToolRequest, ContentToolResult, Tool
+from htmltools import TagList
+from pydantic import Field
 
 from commons import DataSource, data_source, measure
 from commons._citations import tool_result
@@ -27,6 +29,11 @@ from shinychat._chat_normalize_chatlas import (
     ToolResultDisplay,
     get_tool_result_display,
 )
+
+
+def markup(child: Any) -> str:
+    """Any tag child rendered, since a display field may be either shape."""
+    return TagList(child).get_html_string()
 
 
 def shown(result: ContentToolResult) -> ToolResultDisplay:
@@ -240,3 +247,74 @@ def test_a_measure_may_use_shinychats_own_display_class() -> None:
 
     assert shown(result).title == "Ran a trusted calculation"
     assert "already visible to the user" in str(result.value)
+
+
+# ---- the card behind a trusted calculation --------------------------------
+
+
+def sourced() -> dict[str, Any]:
+    @measure(
+        description="Count orders in a region.",
+        provenance=["https://example.com/handbook"],
+    )
+    def order_count(
+        region: Annotated[str, Field(description="Which region.")] = "EMEA",
+    ) -> int:
+        return 2
+
+    found = as_measure(order_count)
+    assert found is not None
+    return {found.name: found}
+
+
+def test_a_measure_result_draws_the_arguments_it_ran_with() -> None:
+    built = tools(measures=sourced())
+
+    display = ran(built, "call_measure", name="order_count", arguments='{"region": "AMER"}')
+
+    assert display.html is not None
+    assert "AMER" in markup(display.html)
+
+
+def test_a_measure_result_names_the_measure_that_ran() -> None:
+    built = tools(measures=sourced())
+
+    display = ran(built, "call_measure", name="order_count", arguments="{}")
+
+    assert display.html is not None
+    assert "Count orders in a region." in markup(display.html)
+
+
+def test_a_measures_provenance_becomes_a_source_link() -> None:
+    built = tools(measures=sourced())
+
+    display = ran(built, "call_measure", name="order_count", arguments="{}")
+
+    assert display.footer is not None
+    assert "https://example.com/handbook" in markup(display.footer)
+
+
+def test_a_metrics_result_draws_the_metrics_it_computed() -> None:
+    built = build_commons_tools(
+        ToolContext(
+            sources={"sales_db": source()}, definitions=Registry([_net_revenue()])
+        )
+    )
+
+    display = ran(built, "call_metrics", metrics=["net_revenue"])
+
+    assert display.html is not None
+    assert "net_revenue" in markup(display.html)
+
+
+def test_a_metrics_result_shows_the_query_it_ran() -> None:
+    built = build_commons_tools(
+        ToolContext(
+            sources={"sales_db": source()}, definitions=Registry([_net_revenue()])
+        )
+    )
+
+    display = ran(built, "call_metrics", metrics=["net_revenue"])
+
+    assert display.markdown is not None
+    assert display.markdown.startswith("```sql\n")

--- a/pkg-py/tests/test_tool_display.py
+++ b/pkg-py/tests/test_tool_display.py
@@ -1,0 +1,55 @@
+"""How a tool result asks to be shown, read back through shinychat's own reader.
+
+`extra["display"]` is a plain dictionary rather than a `ToolResultDisplay`,
+so that core can describe a result's presentation without importing
+shinychat. These tests read it back through `get_tool_result_display()`,
+which is the code that consumes it, rather than asserting on the dictionary.
+"""
+
+import pytest
+from chatlas import ContentToolRequest, ContentToolResult
+
+from commons._citations import tool_result
+from commons._provenance import TAG_EXTRA_KEY, Tag
+
+pytest.importorskip("shinychat")
+
+from shinychat._chat_normalize_chatlas import (  # noqa: E402
+    get_tool_result_display,
+)
+from shinychat.types import ToolResultDisplay  # noqa: E402
+
+
+def shown(result: ContentToolResult) -> ToolResultDisplay:
+    """The display shinychat builds for `result`, as it would when rendering."""
+    request = ContentToolRequest(id="1", name="run_sql", arguments={})
+    return get_tool_result_display(result, request)
+
+
+def test_a_result_with_no_title_asks_for_nothing() -> None:
+    assert shown(tool_result("6 rows")).title is None
+
+
+def test_a_title_reaches_the_reader() -> None:
+    result = tool_result("chunks", title="Searched context")
+    assert shown(result).title == "Searched context"
+
+
+def test_a_tag_stays_out_of_the_title() -> None:
+    """The tag is provenance the reader classifies by, not a caption.
+
+    R has a `show_tag` argument that would append "SQL query (B)", but every
+    call site passes `show_tag = FALSE`, so no R title carries one either.
+    """
+    result = tool_result("6 rows", title="Retrieved data", tag=Tag.B)
+    assert shown(result).title == "Retrieved data"
+
+
+def test_a_display_does_not_cost_a_result_its_tag() -> None:
+    result = tool_result("41", title="Ran a trusted calculation", tag=Tag.A)
+    assert result.extra[TAG_EXTRA_KEY] is Tag.A
+
+
+def test_markdown_is_what_the_reader_sees_in_the_card() -> None:
+    result = tool_result("6 rows", title="Retrieved data", markdown="| a |\n|---|")
+    assert shown(result).markdown == "| a |\n|---|"

--- a/pkg-py/tests/test_tool_display.py
+++ b/pkg-py/tests/test_tool_display.py
@@ -165,3 +165,78 @@ def test_a_metrics_result_says_the_calculation_was_trusted() -> None:
     display = ran(built, "call_metrics", metrics=["net_revenue"])
 
     assert display.title == "Ran a trusted calculation"
+
+
+# ---- a measure that builds its own result ---------------------------------
+
+
+def displaying(display: dict[str, Any], value: Any = "41", data: Any = None) -> Any:
+    """A measure that returns a finished tool result, as a measure may."""
+
+    @measure(description="Revenue, already drawn.")
+    def revenue() -> ContentToolResult:
+        return ContentToolResult(
+            value=value, extra={"display": display, "data": data}
+        )
+
+    found = as_measure(revenue)
+    assert found is not None
+    return {found.name: found}
+
+
+def measure_result(**kwargs: Any) -> ContentToolResult:
+    built = tools(measures=displaying(**kwargs))
+    result = find(built, "call_measure").func(name="revenue", arguments="{}")
+    assert isinstance(result, ContentToolResult)
+    return result
+
+
+def test_a_measures_own_result_still_carries_the_a_tag() -> None:
+    result = measure_result(display={"markdown": "**41**"})
+
+    assert result.extra[TAG_EXTRA_KEY] is Tag.A
+
+
+def test_a_measures_own_result_gets_the_default_title() -> None:
+    result = measure_result(display={"markdown": "**41**"})
+
+    assert shown(result).title == "Ran a trusted calculation"
+
+
+def test_a_measure_keeps_the_title_it_chose() -> None:
+    result = measure_result(display={"title": "Drew the revenue curve"})
+
+    assert shown(result).title == "Drew the revenue curve"
+
+
+def test_a_visible_result_tells_the_model_not_to_repeat_it() -> None:
+    result = measure_result(display={"markdown": "**41**"})
+
+    assert "already visible to the user" in str(result.value)
+
+
+def test_a_result_the_user_cannot_see_carries_no_such_note() -> None:
+    result = measure_result(display={"title": "Counted the orders"})
+
+    assert "already visible" not in str(result.value)
+
+
+def test_a_measures_data_is_reachable_as_a_handle() -> None:
+    result = measure_result(display={"title": "Counted"}, data=[1, 2, 3])
+
+    assert "r1" in str(result.value)
+
+
+def test_the_data_does_not_travel_to_the_model_as_metadata() -> None:
+    """`data` is how a measure hands commons the values behind its display."""
+    result = measure_result(display={"title": "Counted"}, data=[1, 2, 3])
+
+    assert "data" not in result.extra
+
+
+def test_a_measure_may_use_shinychats_own_display_class() -> None:
+    """shinychat's docs tell tool authors to build a `ToolResultDisplay`."""
+    result = measure_result(display=ToolResultDisplay(markdown="**41**"))
+
+    assert shown(result).title == "Ran a trusted calculation"
+    assert "already visible to the user" in str(result.value)

--- a/pkg-py/tests/test_tools.py
+++ b/pkg-py/tests/test_tools.py
@@ -314,7 +314,10 @@ def test_every_tool_is_declared_read_only(plain: DataSource) -> None:
         )
     )
 
-    assert all(tool.annotations == {"readOnlyHint": True} for tool in tools)
+    assert all(
+        tool.annotations is not None and tool.annotations["readOnlyHint"]
+        for tool in tools
+    )
 
 
 # ---- search_context --------------------------------------------------------

--- a/pkg-py/tests/test_ui_assets.py
+++ b/pkg-py/tests/test_ui_assets.py
@@ -143,6 +143,6 @@ def test_the_ui_module_is_only_imported_on_demand() -> None:
         "import sys, commons\n"
         "assert 'shiny' not in sys.modules, 'importing commons imported shiny'\n"
         "commons.ui.commons_chat_dependency()\n"
-        "assert 'htmltools' in sys.modules, 'commons.ui imported no extra'\n"
+        "assert 'shiny' in sys.modules, 'commons.ui imported no extra'\n"
     )
     subprocess.run([sys.executable, "-c", code], check=True)

--- a/pkg-py/uv.lock
+++ b/pkg-py/uv.lock
@@ -309,6 +309,7 @@ dependencies = [
     { name = "chatlas" },
     { name = "duckdb" },
     { name = "google-re2" },
+    { name = "htmltools" },
     { name = "jinja2" },
     { name = "pyarrow" },
     { name = "pydantic" },
@@ -320,7 +321,6 @@ dependencies = [
 
 [package.optional-dependencies]
 shiny = [
-    { name = "htmltools" },
     { name = "packaging" },
     { name = "shiny" },
     { name = "shinychat" },
@@ -348,7 +348,7 @@ requires-dist = [
     { name = "chatlas", specifier = ">=0.22.0" },
     { name = "duckdb", specifier = ">=1.0" },
     { name = "google-re2", specifier = ">=1.1.20251105" },
-    { name = "htmltools", marker = "extra == 'shiny'", specifier = ">=0.6" },
+    { name = "htmltools", specifier = ">=0.6" },
     { name = "httpx", marker = "extra == 'tracing'", specifier = ">=0.27" },
     { name = "jinja2", specifier = ">=3" },
     { name = "opentelemetry-exporter-otlp-json-file", marker = "extra == 'tracing'" },


### PR DESCRIPTION
Tool results now say how they should be shown: a title on every tool row, and the card behind a trusted calculation. htmltools moves from the `shiny` extra into the core dependencies, because a result cannot describe its own markup without it.

<details>
<summary>Detail (written by an agent)</summary>

**Why htmltools is now a core dependency.** A display field is a tag child, and htmltools escapes a plain string instead of rendering it. Only `htmltools.HTML` renders as markup, and in this version it is not a `str` subclass. `pkg-r/DESCRIPTION` imports htmltools unconditionally for the same reason. Core still imports no shinychat: shinychat splats a plain mapping into its own `ToolResultDisplay`, so the display envelope stays a dictionary.

**Two deliberate departures from R.** R has a `show_tag` argument that appends "SQL query (B)" to a title, but every R call site passes `show_tag = FALSE`. `tag_label()` therefore never runs, and both are left out here. An errored measure result also earns no provenance tag here, and a tag the measure supplied is stripped. R tags it and counts it toward the next answer's provenance outcome, which can mark that answer `Verified answer` after a calculation failed. I'm tracking this locally on the R side in kata `z16p` to fix in a follow-up after conf.

**Nothing is pinned in `tests/shared/` this round.** The per-tool title copy is inline literals in R with no accessor. A fixture that both suites read needs an R-side change first.

**Out of scope, as the issue records.** The plot and gt result paths have no chosen Python equivalent. Icons are left out, which matches the branch R itself takes when bsicons is absent.

</details>
