### PR TITLE
feat(py): the chat server function

### DIFF
--- a/pkg-py/README.md
+++ b/pkg-py/README.md
@@ -2,7 +2,11 @@
 
 `commons` is a constructor for trustworthy data agents. It gives an LLM data, semantic, and context layers to work with, tools for querying them, and A/B/C provenance tags so every answer carries a classification as to its trustworthiness.
 
-**Status: pre-alpha.** The agent and all three layers are implemented; the chat UI is not, so answers come back as text and server-rendered HTML rather than through a Shiny front end. Python 3.11 or later is required.
+**Status: alpha.** The agent, the three layers (data, semantics, and context), and the chat UI are implemented: `commons.ui.server()` wires an agent to a chat element in a py-shiny app, and outside one, answers come back as text and server-rendered HTML. Python 3.11 or later is required.
+
+## Optional extras
+
+The core dependencies will allow you to build and query an agent. Installing the `shiny` group (via `pip install commons[shiny]`) will additionally install everything `commons.ui` needs to serve a full chat UI; importing `commons.ui` without it raises an `ImportError` that names the missing packages and the install command. Nothing in commons currently needs the `tracing` group (it is a placeholder for future functionality).
 
 ## Get started
 

--- a/pkg-py/pyproject.toml
+++ b/pkg-py/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"
 license-files = ["LICENSE.md"]
-classifiers = ["Development Status :: 2 - Pre-Alpha"]
+classifiers = ["Development Status :: 3 - Alpha"]
 dependencies = [
     "chatlas>=0.22.0",
     "htmltools>=0.6",

--- a/pkg-py/src/commons/_ui/__init__.py
+++ b/pkg-py/src/commons/_ui/__init__.py
@@ -8,16 +8,18 @@ import importlib.util
 _EXTRA_PACKAGES = ("packaging", "shiny", "shinychat")
 
 
+def _present(name: str) -> bool:
+    # find_spec consults every finder on sys.meta_path, and a finder may
+    # raise ModuleNotFoundError for a top-level name rather than return
+    # None. A name no finder will resolve is not installed either way.
+    try:
+        return importlib.util.find_spec(name) is not None
+    except ImportError:
+        return False
+
+
 def _missing_packages() -> list[str]:
-    missing: list[str] = []
-    for name in _EXTRA_PACKAGES:
-        try:
-            found = importlib.util.find_spec(name) is not None
-        except ImportError:
-            found = False
-        if not found:
-            missing.append(name)
-    return missing
+    return [name for name in _EXTRA_PACKAGES if not _present(name)]
 
 
 def _listed(names: list[str]) -> str:

--- a/pkg-py/src/commons/_ui/__init__.py
+++ b/pkg-py/src/commons/_ui/__init__.py
@@ -2,14 +2,42 @@
 
 from __future__ import annotations
 
+import importlib.util
+
+# What `commons[shiny]` installs, and what this package imports of it.
+_EXTRA_PACKAGES = ("packaging", "shiny", "shinychat")
+
+
+def _missing_packages() -> list[str]:
+    missing: list[str] = []
+    for name in _EXTRA_PACKAGES:
+        try:
+            found = importlib.util.find_spec(name) is not None
+        except ImportError:
+            found = False
+        if not found:
+            missing.append(name)
+    return missing
+
+
+def _listed(names: list[str]) -> str:
+    if len(names) == 1:
+        return names[0]
+    return " and ".join([", ".join(names[:-1]), names[-1]])
+
+
 try:
     from ._assets import asset_base_url, commons_chat_dependency
+    from ._server import server
     from ._theme import theme
 except ModuleNotFoundError as err:
-    # shiny and shinychat arrive with the `shiny` extra.
+    # Name every missing package, as `check_chat_packages()` does in
+    # pkg-r/R/chat.R, so one install fixes the import.
+    names = _missing_packages() or [err.name or "a package"]
     raise ImportError(
-        f"commons.ui needs {err.name}, which is not installed. "
-        'Install it with: pip install "commons[shiny]"'
+        f"commons.ui needs {_listed(names)}, which "
+        f"{'is' if len(names) == 1 else 'are'} not installed. "
+        'Install with: pip install "commons[shiny]"'
     ) from err
 
-__all__ = ["asset_base_url", "commons_chat_dependency", "theme"]
+__all__ = ["asset_base_url", "commons_chat_dependency", "server", "theme"]

--- a/pkg-py/src/commons/_ui/_server.py
+++ b/pkg-py/src/commons/_ui/_server.py
@@ -1,0 +1,65 @@
+"""The server side of a commons chat: what a py-shiny app wires around an agent."""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+import shinychat
+from shiny.session import Session, require_active_session
+
+from .._agent import Commons
+from .._tracing import commons_span
+
+__all__ = ["server"]
+
+
+def server(id: str, client: Commons, **kwargs: Any) -> shinychat.Chat:
+    """Wire a commons agent to the chat element `id` on the page.
+
+    Pair this with a page built on `commons.ui.theme()`, so the chat assets
+    the answers reference are served. In a deployed app, build the agent
+    inside the server function and pass it here, so each session gets its
+    own agent state.
+
+    Parameters
+    ----------
+    id
+        The id of the chat element on the page.
+    client
+        A commons agent.
+    **kwargs
+        Passed to `shinychat.Chat()`.
+    """
+    if not isinstance(client, Commons):
+        raise TypeError(
+            "client must be a commons agent, e.g. from commons.Commons(), "
+            f"not {type(client).__name__}."
+        )
+
+    with commons_span("commons_server_start", {"commons.server.id": id}):
+        _prewarm_on_idle(client, require_active_session(None))
+        chat = shinychat.Chat(id, client=client, **kwargs)
+
+        # shinychat owns the conversation identity; commons only needs to
+        # know that a restore happened.
+        @chat.history.on_restore
+        def _(values: dict[str, Any]) -> None:
+            client.queue_restore_reminder()
+
+    return chat
+
+
+def _prewarm_on_idle(client: Commons, session: Session) -> None:
+    """Warm the agent's caches once the app has served its first page."""
+
+    def prewarm() -> None:
+        try:
+            client.prewarm()
+        except Exception as err:  # noqa: BLE001 - any failure must warn, not abort
+            # `prewarm()` fails a deployment when it is called directly, but
+            # here a cold cache only costs the first question some time, and
+            # an error escaping the callback would take the app down.
+            warnings.warn(str(err), stacklevel=1)
+
+    session.on_flushed(prewarm, once=True)

--- a/pkg-py/src/commons/_ui/_server.py
+++ b/pkg-py/src/commons/_ui/_server.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import warnings
+import logging
 from typing import Any
 
 import shinychat
@@ -12,6 +12,8 @@ from .._agent import Commons
 from .._tracing import commons_span
 
 __all__ = ["server"]
+
+logger = logging.getLogger(__name__)
 
 
 def server(id: str, client: Commons, **kwargs: Any) -> shinychat.Chat:
@@ -30,6 +32,10 @@ def server(id: str, client: Commons, **kwargs: Any) -> shinychat.Chat:
         A commons agent.
     **kwargs
         Passed to `shinychat.Chat()`.
+
+    A `client` that is not a commons agent raises `TypeError`: a plain
+    chatlas chat has none of the citation or provenance handling the chat
+    surface renders.
     """
     if not isinstance(client, Commons):
         raise TypeError(
@@ -56,10 +62,12 @@ def _prewarm_on_idle(client: Commons, session: Session) -> None:
     def prewarm() -> None:
         try:
             client.prewarm()
-        except Exception as err:  # noqa: BLE001 - any failure must warn, not abort
-            # `prewarm()` fails a deployment when it is called directly, but
-            # here a cold cache only costs the first question some time, and
-            # an error escaping the callback would take the app down.
-            warnings.warn(str(err), stacklevel=1)
+        except Exception as err:  # any failure must warn, not abort
+            # A cold cache only costs the first question some time, and an
+            # error escaping the callback would take the app down. Log rather
+            # than warn: the warnings module shows an identical message only
+            # once per process, which would hide a failure that recurs every
+            # session.
+            logger.warning("prewarm failed: %s", err, exc_info=True)
 
     session.on_flushed(prewarm, once=True)

--- a/pkg-py/src/commons/ui.py
+++ b/pkg-py/src/commons/ui.py
@@ -1,5 +1,5 @@
 """The public UI surface a py-shiny app builds against."""
 
-from ._ui import asset_base_url, commons_chat_dependency, theme
+from ._ui import asset_base_url, commons_chat_dependency, server, theme
 
-__all__ = ["asset_base_url", "commons_chat_dependency", "theme"]
+__all__ = ["asset_base_url", "commons_chat_dependency", "server", "theme"]

--- a/pkg-py/tests/test_ui_assets.py
+++ b/pkg-py/tests/test_ui_assets.py
@@ -1,6 +1,7 @@
 """The HTML dependency that serves the browser assets to a page."""
 
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -134,6 +135,39 @@ else:
     )
     assert "shinychat" in done.stdout
     assert 'pip install "commons[shiny]"' in done.stdout
+
+
+def test_a_missing_extra_names_every_package_it_is_short() -> None:
+    # R's `check_chat_packages()` lists all of them, so one install fixes the
+    # import instead of one round trip per package.
+    code = """
+import sys
+
+
+class Absent:
+    def find_spec(self, name, path=None, target=None):
+        if name.split(".")[0] in ("shiny", "shinychat"):
+            raise ModuleNotFoundError(f"No module named {name!r}", name=name)
+        return None
+
+
+sys.meta_path.insert(0, Absent())
+try:
+    import commons.ui
+except ImportError as err:
+    print(err)
+else:
+    print("commons.ui imported anyway")
+"""
+    done = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True
+    )
+    # Read only the sentence that lists them: "shinychat" contains "shiny",
+    # and the install hint says `commons[shiny]`, so either would satisfy a
+    # naive substring test on the whole message.
+    listed = done.stdout.split("Install")[0]
+    assert re.search(r"\bshiny\b", listed), done.stdout
+    assert "shinychat" in listed
 
 
 def test_the_ui_module_is_only_imported_on_demand() -> None:

--- a/pkg-py/tests/test_ui_server.py
+++ b/pkg-py/tests/test_ui_server.py
@@ -7,6 +7,7 @@ are registered, and what each one does when it runs.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
@@ -63,17 +64,21 @@ class _IdleSession(ExpressStubSession):
 
     def __init__(self) -> None:
         super().__init__()
-        self.idle_callbacks: list[Callable[[], None]] = []
+        self.idle_callbacks: list[tuple[Callable[[], Any], bool]] = []
 
     def on_flushed(
         self, fn: Callable[[], Any], once: bool = True
     ) -> Callable[[], None]:
-        self.idle_callbacks.append(fn)
+        self.idle_callbacks.append((fn, once))
         return lambda: None
 
     def go_idle(self) -> None:
-        for callback in self.idle_callbacks:
-            callback()
+        # A `once` callback deregisters when it fires; the rest run each flush.
+        callbacks, self.idle_callbacks = self.idle_callbacks, []
+        for fn, once in callbacks:
+            fn()
+            if not once:
+                self.idle_callbacks.append((fn, once))
 
 
 def frame() -> pd.DataFrame:
@@ -104,7 +109,7 @@ def test_the_chat_is_wired_to_the_agent() -> None:
     # shinychat wraps the client it was handed rather than holding it directly.
     wrapper = chat.client
     assert wrapper is not None
-    assert wrapper._client is agent
+    assert wrapper.value is agent
 
 
 def test_restoring_a_conversation_queues_the_restore_reminder() -> None:
@@ -142,11 +147,16 @@ def test_prewarm_runs_when_the_session_first_goes_idle(tmp_path: Path) -> None:
     # Warming is what the first question would otherwise pay for, so nothing
     # is built until the app has served its first page.
     assert layer._store_cache is None
+    # once=True: warming fires on the first idle only, not on every flush.
+    assert [once for _, once in session.idle_callbacks] == [True]
     session.go_idle()
     assert layer._store_cache is not None
+    assert session.idle_callbacks == []
 
 
-def test_a_failed_prewarm_warns_rather_than_stopping_the_app(tmp_path: Path) -> None:
+def test_a_failed_prewarm_is_logged_rather_than_stopping_the_app(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     pins = pytest.importorskip("pins")
     board = pins.board_folder(str(tmp_path))
     board.pin_write({"not": "a frame"}, "sales-pin", type="json")
@@ -157,10 +167,21 @@ def test_a_failed_prewarm_warns_rather_than_stopping_the_app(tmp_path: Path) -> 
     with session_context(session):
         commons.ui.server("chat", agent)
 
-    # A cold cache is worth a warning; an error escaping the callback would
+    # A cold cache is worth a log entry; an error escaping the callback would
     # take the app down with it.
-    with pytest.warns(UserWarning, match="not a data frame"):
+    with caplog.at_level(logging.WARNING, logger="commons._ui._server"):
         session.go_idle()
+    assert "not a data frame" in caplog.text
+
+
+def test_extra_kwargs_are_passed_to_shinychat() -> None:
+    agent = agent_with(scripted_chat())
+    session = _IdleSession()
+
+    with session_context(session):
+        chat = commons.ui.server("chat", agent, on_error="unhandled")
+
+    assert chat.on_error == "unhandled"
 
 
 def test_the_setup_span_records_the_chat_element_id(

--- a/pkg-py/tests/test_ui_server.py
+++ b/pkg-py/tests/test_ui_server.py
@@ -1,0 +1,176 @@
+"""The server function: the setup span, the prewarm, and the restore reminder.
+
+Whether prewarm and restore really fire in a running app is `f6e3`'s
+end-to-end acceptance. What is pinned here is the wiring: that the callbacks
+are registered, and what each one does when it runs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# shinychat brings shiny and htmltools with it, so it stands for the extra.
+pytest.importorskip("shinychat", reason="commons[shiny] is not installed")
+
+import pandas as pd
+import shinychat
+from chatlas import Chat
+from shiny.express._stub_session import ExpressStubSession
+from shiny.session import session_context
+
+import commons
+from commons._agent import Commons
+from commons._reminders import RESTORED_CONVERSATION_REMINDER, ContentTurnReminder
+
+from ._provider import scripted_chat, text
+
+
+@pytest.fixture(scope="module")
+def exported_spans() -> Iterator[Callable[[], tuple[Any, ...]]]:
+    """Read the spans a test recorded, or skip without the SDK.
+
+    A tracer provider can only be set once per process, so an SDK one another
+    module installed is reused and this exporter added alongside its own.
+    """
+    pytest.importorskip("opentelemetry.sdk", reason="commons[tracing] is not installed")
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    provider = trace.get_tracer_provider()
+    if not isinstance(provider, TracerProvider):
+        provider = TracerProvider()
+        trace.set_tracer_provider(provider)
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    yield exporter.get_finished_spans
+    exporter.clear()
+
+
+class _IdleSession(ExpressStubSession):
+    """A shiny session that keeps the idle callbacks so a test can run them.
+
+    The stub session shiny uses to render express UI discards what
+    `on_flushed()` registers, because nothing ever flushes it.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.idle_callbacks: list[Callable[[], None]] = []
+
+    def on_flushed(
+        self, fn: Callable[[], Any], once: bool = True
+    ) -> Callable[[], None]:
+        self.idle_callbacks.append(fn)
+        return lambda: None
+
+    def go_idle(self) -> None:
+        for callback in self.idle_callbacks:
+            callback()
+
+
+def frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {"revenue": [500.0, 900.0, 300.0], "region": ["EMEA", "Americas", "EMEA"]}
+    )
+
+
+def agent_with(client: Chat, **kwargs: Any) -> Commons:
+    return Commons(client, commons.data_source(sales=frame()), **kwargs)
+
+
+def test_the_client_has_to_be_a_commons_agent() -> None:
+    # A plain chatlas chat has none of the citation or provenance handling the
+    # surface renders, so it is refused rather than half-served.
+    with pytest.raises(TypeError, match="client"):
+        commons.ui.server("chat", scripted_chat())  # type: ignore[arg-type]
+
+
+def test_the_chat_is_wired_to_the_agent() -> None:
+    agent = agent_with(scripted_chat())
+    session = _IdleSession()
+
+    with session_context(session):
+        chat = commons.ui.server("chat", agent)
+
+    assert isinstance(chat, shinychat.Chat)
+    # shinychat wraps the client it was handed rather than holding it directly.
+    wrapper = chat.client
+    assert wrapper is not None
+    assert wrapper._client is agent
+
+
+def test_restoring_a_conversation_queues_the_restore_reminder() -> None:
+    agent = agent_with(scripted_chat([text("An answer.")]))
+    session = _IdleSession()
+    with session_context(session):
+        chat = commons.ui.server("chat", agent)
+
+    # shinychat fires these when it has replayed a stored conversation.
+    for callback in chat.history._restore_callbacks:
+        callback({})
+
+    agent.chat("A question.", echo="none")
+    reminders = [
+        content.text
+        for content in agent.get_turns()[0].contents
+        if isinstance(content, ContentTurnReminder)
+    ]
+    assert RESTORED_CONVERSATION_REMINDER in reminders
+
+
+def test_prewarm_runs_when_the_session_first_goes_idle(tmp_path: Path) -> None:
+    notes = tmp_path / "notes.md"
+    notes.write_text("# Revenue\n\nRevenue means booked revenue.", encoding="utf-8")
+    agent = agent_with(
+        scripted_chat(), context_layer=commons.context_layer(files=[notes])
+    )
+    layer = agent._context_layer
+    assert layer is not None
+    session = _IdleSession()
+
+    with session_context(session):
+        commons.ui.server("chat", agent)
+
+    # Warming is what the first question would otherwise pay for, so nothing
+    # is built until the app has served its first page.
+    assert layer._store_cache is None
+    session.go_idle()
+    assert layer._store_cache is not None
+
+
+def test_a_failed_prewarm_warns_rather_than_stopping_the_app(tmp_path: Path) -> None:
+    pins = pytest.importorskip("pins")
+    board = pins.board_folder(str(tmp_path))
+    board.pin_write({"not": "a frame"}, "sales-pin", type="json")
+    agent = Commons(
+        scripted_chat(), commons.data_source(board, tables={"sales": "sales-pin"})
+    )
+    session = _IdleSession()
+    with session_context(session):
+        commons.ui.server("chat", agent)
+
+    # A cold cache is worth a warning; an error escaping the callback would
+    # take the app down with it.
+    with pytest.warns(UserWarning, match="not a data frame"):
+        session.go_idle()
+
+
+def test_the_setup_span_records_the_chat_element_id(
+    exported_spans: Callable[[], tuple[Any, ...]],
+) -> None:
+    agent = agent_with(scripted_chat())
+
+    with session_context(_IdleSession()):
+        commons.ui.server("chat", agent)
+
+    (span,) = [span for span in exported_spans() if span.name == "commons_server_start"]
+    assert span.attributes is not None
+    assert span.attributes["commons.server.id"] == "chat"


### PR DESCRIPTION
`commons.ui.server(id, client)` wires a commons agent to a chat element on the page: the setup span, the prewarm once the session goes idle, and the restore reminder shinychat asks for when it replays a stored conversation.

<details>
<summary>Detail (written by an agent)</summary>

**Prewarm runs inline on the first idle moment.** `session.on_flushed(once=True)` is py-shiny's analog of the `later::later()` R defers the prewarm with. The callback calls `prewarm()` directly instead of handing it to a thread, because R blocks its single thread the same way, and a thread would put a data source's connections on two threads for no gain. A failure warns rather than propagating, so a cold cache costs the first question some time instead of taking the app down.

**A function, not a `Chat` subclass.** R's `commons_server()` returns the chat object, and nothing here needs to intercept a `shinychat.Chat` method, so this returns a configured one.

**The import guard now names every missing package**, rather than only the first import that failed, which is what `check_chat_packages()` does on the R side.

**The task called the restore path a citation-request reminder.** `queue_restore_reminder()` queues the restored-conversation reminder, which is about lost Python state, and R's `commons_server()` queues the same one. The code follows R; the test name says what it asserts.

**The tests pin the wiring, not a running app.** Whether prewarm and restore fire in a served app is the end-to-end acceptance task, so each callback is registered and then run directly here. Shiny's own stub session discards what `on_flushed()` registers, so a subclass keeps the callback for the test to invoke.

`ruff check`, `pyrefly check src tests` and the full suite pass, with both the `shiny` and `tracing` extras installed so the UI and span tests run rather than skip.

</details>
