### PR TITLE
recover trajectories with omitted rich content

### DIFF
--- a/pkg-r/R/trajectory-read.R
+++ b/pkg-r/R/trajectory-read.R
@@ -796,12 +796,30 @@ latest_chat_spans <- function(chat_spans) {
   for (span in chat_spans) {
     id <- span_conversation_id(span)
     prev <- latest[[id]]
-    if (is.null(prev) || span_time(span) > span_time(prev)) {
+    if (is.null(prev) || chat_span_is_preferred(span, prev)) {
       latest[[id]] <- span
     }
   }
 
   latest[order(vapply(latest, span_time, character(1)))]
+}
+
+chat_span_is_preferred <- function(candidate, current) {
+  candidate_is_title <- is_conversation_title_span(candidate)
+  current_is_title <- is_conversation_title_span(current)
+  if (!identical(candidate_is_title, current_is_title)) {
+    return(!candidate_is_title)
+  }
+  span_time(candidate) > span_time(current)
+}
+
+shinychat_title_prompt <- "You title chat conversations."
+
+is_conversation_title_span <- function(span) {
+  system <- semconv_system_turns(
+    span$attributes[["gen_ai.system_instructions"]]
+  )
+  length(system) > 0 && startsWith(system[[1]]@text, shinychat_title_prompt)
 }
 
 empty_turn_provenance <- function() {

--- a/pkg-r/R/trajectory-read.R
+++ b/pkg-r/R/trajectory-read.R
@@ -738,9 +738,9 @@ posixct_nanos <- function(time) {
   sprintf("%.0f", as.numeric(time) * 1e9)
 }
 
-# ellmer's chat spans repeat the full message history, so the latest chat
-# span in a conversation carries the whole trajectory: group chat spans by
-# conversation, keep the last one, and parse its GenAI-semconv messages.
+# ellmer's chat spans usually repeat the full message history. Group them by
+# conversation and keep the last one, recovering when rich content causes its
+# input history to be omitted.
 build_trajectories <- function(spans) {
   index <- span_index(spans)
   chat_spans <- Filter(is_chat_span, spans)
@@ -754,7 +754,11 @@ build_trajectories <- function(spans) {
     unname(latest),
     lapply(calls, function(call) call$chat_span)
   )
-  parsed <- parse_chat_spans_once(selected)
+  parsed <- parse_chat_spans_once(
+    selected,
+    by_trace = chat_spans_by_trace(chat_spans),
+    index = index
+  )
   candidates <- recorded_call_candidates(calls, parsed)
 
   Map(
@@ -852,10 +856,137 @@ latest_recorded_call_spans <- function(
   latest
 }
 
-parse_chat_spans_once <- function(spans) {
+parse_chat_spans_once <- function(spans, by_trace = NULL, index = NULL) {
   keys <- vapply(spans, exchange_key, character(1))
   spans <- spans[!duplicated(keys)]
-  rlang::set_names(lapply(spans, trajectory_turns), keys[!duplicated(keys)])
+  turns <- lapply(spans, trajectory_turns)
+  if (!is.null(by_trace) && !is.null(index)) {
+    turns <- Map(recover_missing_input, spans, turns, MoreArgs = list(
+      by_trace = by_trace,
+      index = index
+    ))
+  }
+  rlang::set_names(turns, keys[!duplicated(keys)])
+}
+
+chat_spans_by_trace <- function(spans) {
+  split(spans, vapply(spans, `[[`, character(1), "trace_id"))
+}
+
+# ellmer omits the full input attribute when rich content cannot be serialized.
+# Recover what the trace still records, but only within the same agent turn.
+recover_missing_input <- function(span, turns, by_trace, index) {
+  if (!is.null(parse_semconv_json(
+    span$attributes[["gen_ai.input.messages"]]
+  ))) {
+    return(turns)
+  }
+
+  turn_span <- conversation_turn_ancestor(span, index)
+  if (is.null(turn_span)) {
+    return(turns)
+  }
+  turn_key <- exchange_key(turn_span)
+  trace_spans <- by_trace[[span$trace_id]]
+  if (is.null(trace_spans)) {
+    return(turns)
+  }
+  id <- span_conversation_id(span)
+  trace_spans <- Filter(
+    function(candidate) {
+      candidate_turn <- conversation_turn_ancestor(candidate, index)
+      identical(span_conversation_id(candidate), id) &&
+        !is.null(candidate_turn) &&
+        identical(exchange_key(candidate_turn), turn_key)
+    },
+    trace_spans
+  )
+  trace_spans <- trace_spans[order(vapply(
+    trace_spans,
+    span_time,
+    character(1)
+  ))]
+  keys <- vapply(trace_spans, exchange_key, character(1))
+  target <- match(exchange_key(span), keys)
+  if (is.na(target)) {
+    return(turns)
+  }
+
+  prior <- trace_spans[seq_len(target - 1L)]
+  valid <- vapply(
+    prior,
+    function(candidate) {
+      !is.null(parse_semconv_json(
+        candidate$attributes[["gen_ai.input.messages"]]
+      ))
+    },
+    logical(1)
+  )
+  if (any(valid)) {
+    history_index <- utils::tail(which(valid), 1L)
+    history <- prior[[history_index]]
+  } else {
+    history_index <- 1L
+    history <- NULL
+  }
+
+  output_spans <- trace_spans[seq.int(history_index, target)]
+  recovered_trajectory_turns(span, history, output_spans)
+}
+
+recovered_trajectory_turns <- function(latest, history, output_spans) {
+  requests <- new.env(parent = emptyenv())
+  system <- semconv_system_turns(
+    latest$attributes[["gen_ai.system_instructions"]]
+  )
+  if (length(system) == 0 && !is.null(history)) {
+    system <- semconv_system_turns(
+      history$attributes[["gen_ai.system_instructions"]]
+    )
+  }
+  input <- if (is.null(history)) {
+    ellmer::UserTurn("(Input content was not captured.)")
+  } else {
+    semconv_message_turns(
+      history$attributes[["gen_ai.input.messages"]],
+      requests
+    )
+  }
+  output <- list()
+  for (i in seq_along(output_spans)) {
+    turns <- semconv_message_turns(
+      output_spans[[i]]$attributes[["gen_ai.output.messages"]],
+      requests
+    )
+    output <- c(output, turns)
+    if (i < length(output_spans)) {
+      missing <- missing_tool_results(turns)
+      if (!is.null(missing)) {
+        output[[length(output) + 1L]] <- missing
+      }
+    }
+  }
+  unname(c(system, input, output))
+}
+
+missing_tool_results <- function(turns) {
+  requests <- unlist(lapply(turns, function(turn) {
+    Filter(
+      function(content) {
+        S7::S7_inherits(content, ellmer::ContentToolRequest)
+      },
+      turn@contents
+    )
+  }), recursive = FALSE)
+  if (length(requests) == 0) {
+    return(NULL)
+  }
+  ellmer::UserTurn(lapply(requests, function(request) {
+    ellmer::ContentToolResult(
+      value = "(Tool result was not captured.)",
+      request = request
+    )
+  }))
 }
 
 recorded_call_candidates <- function(call_spans, parsed_turns) {

--- a/pkg-r/R/trajectory-read.R
+++ b/pkg-r/R/trajectory-read.R
@@ -756,7 +756,7 @@ build_trajectories <- function(spans) {
   )
   parsed <- parse_chat_spans_once(
     selected,
-    by_trace = chat_spans_by_trace(chat_spans),
+    by_conversation = chat_spans_by_conversation(chat_spans),
     index = index
   )
   candidates <- recorded_call_candidates(calls, parsed)
@@ -874,26 +874,30 @@ latest_recorded_call_spans <- function(
   latest
 }
 
-parse_chat_spans_once <- function(spans, by_trace = NULL, index = NULL) {
+parse_chat_spans_once <- function(
+  spans,
+  by_conversation = NULL,
+  index = NULL
+) {
   keys <- vapply(spans, exchange_key, character(1))
   spans <- spans[!duplicated(keys)]
   turns <- lapply(spans, trajectory_turns)
-  if (!is.null(by_trace) && !is.null(index)) {
+  if (!is.null(by_conversation) && !is.null(index)) {
     turns <- Map(recover_missing_input, spans, turns, MoreArgs = list(
-      by_trace = by_trace,
+      by_conversation = by_conversation,
       index = index
     ))
   }
   rlang::set_names(turns, keys[!duplicated(keys)])
 }
 
-chat_spans_by_trace <- function(spans) {
-  split(spans, vapply(spans, `[[`, character(1), "trace_id"))
+chat_spans_by_conversation <- function(spans) {
+  split(spans, vapply(spans, span_conversation_id, character(1)))
 }
 
 # ellmer omits the full input attribute when rich content cannot be serialized.
-# Recover what the trace still records, but only within the same agent turn.
-recover_missing_input <- function(span, turns, by_trace, index) {
+# Recover what the conversation still records from its latest valid snapshot.
+recover_missing_input <- function(span, turns, by_conversation, index) {
   if (!is.null(parse_semconv_json(
     span$attributes[["gen_ai.input.messages"]]
   ))) {
@@ -904,33 +908,32 @@ recover_missing_input <- function(span, turns, by_trace, index) {
   if (is.null(turn_span)) {
     return(turns)
   }
-  turn_key <- exchange_key(turn_span)
-  trace_spans <- by_trace[[span$trace_id]]
-  if (is.null(trace_spans)) {
+  id <- span_conversation_id(span)
+  conversation_spans <- by_conversation[[id]]
+  if (is.null(conversation_spans)) {
     return(turns)
   }
-  id <- span_conversation_id(span)
-  trace_spans <- Filter(
+  conversation_spans <- Filter(
     function(candidate) {
       candidate_turn <- conversation_turn_ancestor(candidate, index)
       identical(span_conversation_id(candidate), id) &&
         !is.null(candidate_turn) &&
-        identical(exchange_key(candidate_turn), turn_key)
+        !is_conversation_title_span(candidate)
     },
-    trace_spans
+    conversation_spans
   )
-  trace_spans <- trace_spans[order(vapply(
-    trace_spans,
+  conversation_spans <- conversation_spans[order(vapply(
+    conversation_spans,
     span_time,
     character(1)
   ))]
-  keys <- vapply(trace_spans, exchange_key, character(1))
+  keys <- vapply(conversation_spans, exchange_key, character(1))
   target <- match(exchange_key(span), keys)
   if (is.na(target)) {
     return(turns)
   }
 
-  prior <- trace_spans[seq_len(target - 1L)]
+  prior <- conversation_spans[seq_len(target - 1L)]
   valid <- vapply(
     prior,
     function(candidate) {
@@ -948,11 +951,11 @@ recover_missing_input <- function(span, turns, by_trace, index) {
     history <- NULL
   }
 
-  output_spans <- trace_spans[seq.int(history_index, target)]
-  recovered_trajectory_turns(span, history, output_spans)
+  output_spans <- conversation_spans[seq.int(history_index, target)]
+  recovered_trajectory_turns(span, history, output_spans, index)
 }
 
-recovered_trajectory_turns <- function(latest, history, output_spans) {
+recovered_trajectory_turns <- function(latest, history, output_spans, index) {
   requests <- new.env(parent = emptyenv())
   system <- semconv_system_turns(
     latest$attributes[["gen_ai.system_instructions"]]
@@ -963,7 +966,7 @@ recovered_trajectory_turns <- function(latest, history, output_spans) {
     )
   }
   input <- if (is.null(history)) {
-    ellmer::UserTurn("(Input content was not captured.)")
+    missing_input_turn()
   } else {
     semconv_message_turns(
       history$attributes[["gen_ai.input.messages"]],
@@ -971,20 +974,34 @@ recovered_trajectory_turns <- function(latest, history, output_spans) {
     )
   }
   output <- list()
+  previous_turns <- NULL
+  previous_turn_key <- NULL
   for (i in seq_along(output_spans)) {
+    turn_span <- conversation_turn_ancestor(output_spans[[i]], index)
+    turn_key <- exchange_key(turn_span)
+    if (!is.null(previous_turn_key)) {
+      if (identical(turn_key, previous_turn_key)) {
+        missing <- missing_tool_results(previous_turns)
+        if (!is.null(missing)) {
+          output[[length(output) + 1L]] <- missing
+        }
+      } else {
+        output[[length(output) + 1L]] <- missing_input_turn()
+      }
+    }
     turns <- semconv_message_turns(
       output_spans[[i]]$attributes[["gen_ai.output.messages"]],
       requests
     )
     output <- c(output, turns)
-    if (i < length(output_spans)) {
-      missing <- missing_tool_results(turns)
-      if (!is.null(missing)) {
-        output[[length(output) + 1L]] <- missing
-      }
-    }
+    previous_turns <- turns
+    previous_turn_key <- turn_key
   }
   unname(c(system, input, output))
+}
+
+missing_input_turn <- function() {
+  ellmer::UserTurn("(Input content was not captured.)")
 }
 
 missing_tool_results <- function(turns) {

--- a/pkg-r/R/trajectory-review.R
+++ b/pkg-r/R/trajectory-review.R
@@ -172,8 +172,6 @@ drop_side_conversations <- function(trajectories) {
 
 # Title generation shares the agent's client, so its calls enter the trace
 # store.
-shinychat_title_prompt <- "You title chat conversations."
-
 is_side_conversation <- function(turns) {
   if (length(split_exchanges(turns)) == 0) {
     return(TRUE)

--- a/pkg-r/tests/testthat/test-trajectories.R
+++ b/pkg-r/tests/testthat/test-trajectories.R
@@ -219,6 +219,67 @@ semconv_messages_json <- function(messages) {
   jsonlite::toJSON(messages, auto_unbox = TRUE)
 }
 
+test_that("title generation does not replace the conversation it titles", {
+  image_question <- list(
+    role = "user",
+    parts = list(
+      list(type = "text", content = "What do you see?"),
+      list(type = "generic", class = "ContentImageInline")
+    )
+  )
+  first_answer <- text_semconv_message("assistant", "I see a chart.")
+  followup <- text_semconv_message("user", "Can you verify it?")
+  final_answer <- text_semconv_message("assistant", "Yes, it is accurate.")
+  title_prompt <- semconv_messages_json(list(list(
+    type = "text",
+    content = paste(shinychat_title_prompt, "Reply with ONLY a title.")
+  )))
+  spans <- parse_otlp_lines(otlp_test_line(list(
+    chat_test_span(
+      "first-trace",
+      "chat1",
+      conversation_id = "conv-a",
+      input_messages = semconv_messages_json(list(image_question)),
+      output_messages = semconv_messages_json(list(first_answer)),
+      end_time = "10"
+    ),
+    chat_test_span(
+      "second-trace",
+      "chat2",
+      conversation_id = "conv-a",
+      input_messages = semconv_messages_json(list(
+        image_question,
+        first_answer,
+        followup
+      )),
+      output_messages = semconv_messages_json(list(final_answer)),
+      end_time = "20"
+    ),
+    chat_test_span(
+      "second-trace",
+      "title",
+      conversation_id = "conv-a",
+      system_instructions = title_prompt,
+      input_messages = semconv_messages_json(list(
+        text_semconv_message("user", "user: What do you see?")
+      )),
+      output_messages = semconv_messages_json(list(
+        text_semconv_message("assistant", "Chart verification")
+      )),
+      end_time = "30"
+    )
+  )))
+
+  turns <- build_trajectories(spans)[["conv-a"]]$turns
+
+  expect_identical(
+    vapply(turns, function(turn) turn@role, character(1)),
+    c("user", "assistant", "user", "assistant")
+  )
+  expect_equal(turns[[1]]@text, "What do you see?")
+  expect_equal(turns[[4]]@text, "Yes, it is accurate.")
+})
+
 test_that("missing latest input recovers history and subsequent outputs", {
   question <- text_semconv_message("user", "Make a plot.")
   plot_request <- list(

--- a/pkg-r/tests/testthat/test-trajectories.R
+++ b/pkg-r/tests/testthat/test-trajectories.R
@@ -334,6 +334,72 @@ test_that("missing latest input recovers history and subsequent outputs", {
   expect_length(split_exchanges(turns), 1)
 })
 
+test_that("missing input in a later agent turn preserves earlier exchanges", {
+  question <- text_semconv_message("user", "Make a plot.")
+  plot_request <- list(
+    role = "assistant",
+    parts = list(list(
+      type = "tool_call",
+      id = "plot-1",
+      name = "run_r",
+      arguments = list(code = "plot(1:10)")
+    ))
+  )
+  plot_answer <- text_semconv_message(
+    "assistant",
+    "The plot is shown above."
+  )
+  followup_answer <- text_semconv_message(
+    "assistant",
+    "The result is unchanged."
+  )
+  spans <- parse_otlp_lines(otlp_test_line(list(
+    conversation_test_span("first-trace", "root1"),
+    chat_test_span(
+      "first-trace",
+      "chat1",
+      parent_span_id = "root1",
+      conversation_id = "conv-a",
+      input_messages = semconv_messages_json(list(question)),
+      output_messages = semconv_messages_json(list(plot_request)),
+      end_time = "10"
+    ),
+    chat_test_span(
+      "first-trace",
+      "chat2",
+      parent_span_id = "root1",
+      conversation_id = "conv-a",
+      output_messages = semconv_messages_json(list(plot_answer)),
+      end_time = "20"
+    ),
+    conversation_test_span("second-trace", "root2"),
+    chat_test_span(
+      "second-trace",
+      "chat3",
+      parent_span_id = "root2",
+      conversation_id = "conv-a",
+      output_messages = semconv_messages_json(list(followup_answer)),
+      end_time = "30"
+    )
+  )))
+
+  turns <- build_trajectories(spans)[["conv-a"]]$turns
+
+  expect_identical(
+    vapply(turns, function(turn) turn@role, character(1)),
+    c("user", "assistant", "user", "assistant", "user", "assistant")
+  )
+  expect_equal(turns[[1]]@text, "Make a plot.")
+  expect_equal(
+    turns[[3]]@contents[[1]]@value,
+    "(Tool result was not captured.)"
+  )
+  expect_equal(turns[[4]]@text, "The plot is shown above.")
+  expect_equal(turns[[5]]@text, "(Input content was not captured.)")
+  expect_equal(turns[[6]]@text, "The result is unchanged.")
+  expect_length(split_exchanges(turns), 2)
+})
+
 test_that("missing initial rich input is represented explicitly", {
   spans <- parse_otlp_lines(otlp_test_line(list(
     conversation_test_span("t1", "root"),

--- a/pkg-r/tests/testthat/test-trajectories.R
+++ b/pkg-r/tests/testthat/test-trajectories.R
@@ -219,6 +219,115 @@ semconv_messages_json <- function(messages) {
   jsonlite::toJSON(messages, auto_unbox = TRUE)
 }
 
+test_that("missing latest input recovers history and subsequent outputs", {
+  question <- text_semconv_message("user", "Make a plot.")
+  plot_request <- list(
+    role = "assistant",
+    parts = list(list(
+      type = "tool_call",
+      id = "plot-1",
+      name = "run_r",
+      arguments = list(code = "plot(1:10)")
+    ))
+  )
+  final <- text_semconv_message("assistant", "The plot is shown above.")
+  spans <- parse_otlp_lines(otlp_test_line(list(
+    conversation_test_span("t1", "root"),
+    chat_test_span(
+      "t1",
+      "chat1",
+      parent_span_id = "root",
+      conversation_id = "conv-a",
+      input_messages = semconv_messages_json(list(question)),
+      output_messages = semconv_messages_json(list(plot_request)),
+      end_time = "10"
+    ),
+    chat_test_span(
+      "t1",
+      "chat2",
+      parent_span_id = "root",
+      conversation_id = "conv-a",
+      output_messages = semconv_messages_json(list(final)),
+      end_time = "20"
+    )
+  )))
+
+  turns <- build_trajectories(spans)[["conv-a"]]$turns
+
+  expect_identical(
+    vapply(turns, function(turn) turn@role, character(1)),
+    c("user", "assistant", "user", "assistant")
+  )
+  expect_equal(turns[[1]]@text, "Make a plot.")
+  expect_equal(turns[[2]]@contents[[1]]@name, "run_r")
+  expect_s7_class(turns[[3]]@contents[[1]], ellmer::ContentToolResult)
+  expect_equal(
+    turns[[3]]@contents[[1]]@value,
+    "(Tool result was not captured.)"
+  )
+  expect_identical(
+    turns[[3]]@contents[[1]]@request,
+    turns[[2]]@contents[[1]]
+  )
+  expect_equal(turns[[4]]@text, "The plot is shown above.")
+  expect_length(split_exchanges(turns), 1)
+})
+
+test_that("missing initial rich input is represented explicitly", {
+  spans <- parse_otlp_lines(otlp_test_line(list(
+    conversation_test_span("t1", "root"),
+    chat_test_span(
+      "t1",
+      "chat1",
+      parent_span_id = "root",
+      conversation_id = "conv-a",
+      output_messages = semconv_messages_json(list(
+        text_semconv_message("assistant", "I can describe that image.")
+      )),
+      end_time = "10"
+    )
+  )))
+
+  turns <- build_trajectories(spans)[["conv-a"]]$turns
+
+  expect_identical(
+    vapply(turns, function(turn) turn@role, character(1)),
+    c("user", "assistant")
+  )
+  expect_equal(turns[[1]]@text, "(Input content was not captured.)")
+  expect_equal(turns[[2]]@text, "I can describe that image.")
+  expect_length(split_exchanges(turns), 1)
+})
+
+test_that("missing input outside an agent turn does not invent a user turn", {
+  spans <- parse_otlp_lines(otlp_test_line(list(
+    chat_test_span(
+      "old-trace",
+      "chat1",
+      conversation_id = "conv-a",
+      input_messages = semconv_messages_json(list(
+        text_semconv_message("user", "Old question")
+      )),
+      end_time = "10"
+    ),
+    chat_test_span(
+      "new-trace",
+      "chat2",
+      conversation_id = "conv-a",
+      output_messages = semconv_messages_json(list(
+        text_semconv_message("assistant", "Unrelated answer")
+      )),
+      end_time = "20"
+    )
+  )))
+
+  turns <- build_trajectories(spans)[["conv-a"]]$turns
+
+  expect_length(turns, 1)
+  expect_identical(turns[[1]]@role, "assistant")
+  expect_equal(turns[[1]]@text, "Unrelated answer")
+})
+
 recorded_call_test_spans <- function(
   trace_id,
   conversation_id,


### PR DESCRIPTION
Closes #341.

Reconstructs chat outputs from the last valid input snapshot within the same agent turn in `trajectory_read()`. Represents omitted rich inputs and tool results with explicit placeholders so affected conversations remain reviewable `trajectory_review()`.