### PR TITLE
Situate measure `tool_result_display()`s with normal rich request display

### DIFF
--- a/pkg-py/src/commons/www/commons-chat/commons-chat.css
+++ b/pkg-py/src/commons/www/commons-chat/commons-chat.css
@@ -459,10 +459,6 @@ shiny-chat-container
   gap: 0.5rem;
 }
 
-.commons-measure-details[open] > summary {
-  order: 2;
-}
-
 .commons-measure-details[open] .commons-measure-details-more {
   display: none;
 }
@@ -472,7 +468,6 @@ shiny-chat-container
 }
 
 .commons-measure-details-body {
-  order: 1;
   white-space: pre-wrap;
 }
 

--- a/pkg-py/src/commons/www/commons-chat/commons-chat.css
+++ b/pkg-py/src/commons/www/commons-chat/commons-chat.css
@@ -437,6 +437,11 @@ shiny-chat-container
   white-space: pre-wrap;
 }
 
+/* Tag trees serialize with indentation that pre-wrap would render. */
+.commons-measure-result-value-authored {
+  white-space: normal;
+}
+
 .commons-measure-result-value > table {
   border-collapse: collapse;
   font-size: 0.85rem;

--- a/pkg-py/src/commons/www/commons-chat/commons-chat.css
+++ b/pkg-py/src/commons/www/commons-chat/commons-chat.css
@@ -434,6 +434,12 @@ shiny-chat-container
   display: none;
 }
 
+.commons-measure-details > summary:focus-visible {
+  border-radius: var(--bs-border-radius-sm, 0.25rem);
+  outline: 2px solid var(--bs-primary, #007bc2);
+  outline-offset: 2px;
+}
+
 .commons-measure-details:not([open]) {
   margin-top: -1.5rem;
   position: relative;

--- a/pkg-py/src/commons/www/commons-chat/commons-chat.css
+++ b/pkg-py/src/commons/www/commons-chat/commons-chat.css
@@ -404,6 +404,78 @@ shiny-chat-container
   white-space: pre-wrap;
 }
 
+.commons-measure-description-summary {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(to bottom, #000 55%, transparent);
+  mask-image: linear-gradient(to bottom, #000 55%, transparent);
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.commons-measure-metadata-item:has(.commons-measure-details[open])
+  > .commons-measure-description-summary {
+  display: none;
+}
+
+.commons-measure-details {
+  color: var(--bs-secondary-color, #6c757d);
+}
+
+.commons-measure-details > summary {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  list-style: none;
+}
+
+.commons-measure-details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.commons-measure-details:not([open]) {
+  margin-top: -1.5rem;
+  position: relative;
+}
+
+.commons-measure-details:not([open]) > summary {
+  min-height: 1.5rem;
+  padding-top: 0.75rem;
+}
+
+.commons-measure-details > summary > span {
+  background: var(--bs-body-bg, #fff);
+  font-size: 0.85em;
+  padding-inline: 0.5rem;
+}
+
+.commons-measure-details-less {
+  display: none;
+}
+
+.commons-measure-details[open] {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.commons-measure-details[open] > summary {
+  order: 2;
+}
+
+.commons-measure-details[open] .commons-measure-details-more {
+  display: none;
+}
+
+.commons-measure-details[open] .commons-measure-details-less {
+  display: inline;
+}
+
+.commons-measure-details-body {
+  order: 1;
+  white-space: pre-wrap;
+}
+
 .commons-measure-source-link + .commons-measure-source-link {
   margin-left: 0.75rem;
 }

--- a/pkg-r/R/commons.R
+++ b/pkg-r/R/commons.R
@@ -245,6 +245,7 @@ Commons <- R6::R6Class(
       private$registry <- semantic_state$measures
       private$fn_sources <- semantic_state$fn_sources
       private$measure_provenance <- semantic_state$measure_provenance
+      private$measure_display <- semantic_state$measure_display
       private$injections <- resolve_injections(
         private$registry,
         measure_injectables(sources)
@@ -465,6 +466,7 @@ Commons <- R6::R6Class(
     calculations = NULL,
     fn_sources = NULL,
     measure_provenance = NULL,
+    measure_display = NULL,
     injections = NULL,
     tracing = FALSE,
     first_touch = NULL,

--- a/pkg-r/R/layer-objects.R
+++ b/pkg-r/R/layer-objects.R
@@ -71,10 +71,16 @@ DataSource <- R6::R6Class(
 SemanticLayer <- R6::R6Class(
   "commons_semantic_layer",
   public = list(
-    initialize = function(measures, fn_sources, measure_provenance) {
+    initialize = function(
+      measures,
+      fn_sources,
+      measure_provenance,
+      measure_display
+    ) {
       private$measures <- measures
       private$fn_sources <- fn_sources
       private$measure_provenance <- measure_provenance
+      private$measure_display <- measure_display
     },
     print = function(...) {
       n <- length(private$measures)
@@ -85,7 +91,8 @@ SemanticLayer <- R6::R6Class(
   private = list(
     measures = NULL,
     fn_sources = NULL,
-    measure_provenance = NULL
+    measure_provenance = NULL,
+    measure_display = NULL
   ),
   lock_objects = TRUE,
   lock_class = TRUE,

--- a/pkg-r/R/measures.R
+++ b/pkg-r/R/measures.R
@@ -92,6 +92,12 @@ semantic_layer <- function(...) {
 
   measure_provenance <- expanded$provenance
   names(measure_provenance) <- names(measures)
+  measure_display <- Map(
+    measure_display_or_default,
+    measures,
+    expanded$measure_display
+  )
+  names(measure_display) <- names(measures)
 
   # Measures that didn't come from files (so no harvested source) still get a
   # readable, if comment-free, deparse.
@@ -100,15 +106,20 @@ semantic_layer <- function(...) {
     fn_sources[[nm]] <- fn_source_text(tool_fn(measures[[nm]]))
   }
 
-  new_semantic_layer(measures, fn_sources, measure_provenance)
+  new_semantic_layer(
+    measures,
+    fn_sources,
+    measure_provenance,
+    measure_display
+  )
 }
 
 # Expand each `...` element into measures: character vectors are read from disk,
 # lists of measures are spliced in, and a lone measure is kept as is. `env` is
 # the caller of semantic_layer(), so measures read from disk close over the data
 # the user defined there rather than only the global environment. Function
-# sources and provenance harvested by read_measures() ride alongside their
-# measures in an internal bundle.
+# sources, display metadata, and provenance harvested by read_measures() ride
+# alongside their measures in an internal bundle.
 expand_measures <- function(args, env = rlang::caller_env()) {
   expanded <- lapply(args, function(arg) {
     if (is.character(arg)) {
@@ -126,7 +137,11 @@ expand_measures <- function(args, env = rlang::caller_env()) {
   list(
     measures = do.call(c, lapply(expanded, `[[`, "measures")) %||% list(),
     fn_sources = fn_sources,
-    provenance = do.call(c, lapply(expanded, `[[`, "provenance")) %||% list()
+    provenance = do.call(c, lapply(expanded, `[[`, "provenance")) %||% list(),
+    measure_display = do.call(
+      c,
+      lapply(expanded, `[[`, "measure_display")
+    ) %||% list()
   )
 }
 
@@ -187,29 +202,24 @@ measure <- function(name, description, fn, arguments = list(), title = NULL) {
   rlang::check_string(description)
   rlang::check_string(title, allow_null = TRUE)
   title <- title %||% humanize_name(name)
-  td <- ellmer::tool(
+  ellmer::tool(
     fn,
     description,
     arguments = fill_injected_arguments(arguments, fn),
     name = name,
     annotations = ellmer::tool_annotations(title = title)
   )
-  set_measure_display_metadata(td, description)
 }
 
-measure_display_metadata <- function(td) {
-  attr(td, "commons_measure_display") %||% list(
+measure_default_display <- function(td) {
+  list(
     description = tool_description(td),
     details = NULL
   )
 }
 
-set_measure_display_metadata <- function(td, description, details = NULL) {
-  attr(td, "commons_measure_display") <- list(
-    description = description,
-    details = details
-  )
-  td
+measure_display_or_default <- function(td, display) {
+  display %||% measure_default_display(td)
 }
 
 # Arguments of `fn` not described in `arguments` are supplied by commons(),
@@ -265,12 +275,14 @@ resolve_injections <- function(
 new_semantic_layer <- function(
   measures = list(),
   fn_sources = character(),
-  measure_provenance = list()
+  measure_provenance = list(),
+  measure_display = list()
 ) {
   SemanticLayer$new(
     measures = measures,
     fn_sources = fn_sources,
-    measure_provenance = measure_provenance
+    measure_provenance = measure_provenance,
+    measure_display = measure_display
   )
 }
 

--- a/pkg-r/R/measures.R
+++ b/pkg-r/R/measures.R
@@ -139,9 +139,10 @@ expand_measures <- function(args, env = rlang::caller_env()) {
 #' Two return types receive special display handling: ggplots and [gt::gt()]
 #' tables are shown directly to the user in the opened measure result.
 #'
-#' For full control over a result, `fn` can return an
-#' [ellmer::ContentToolResult]. Its `value` is sent to the model and its
-#' `extra$display` controls the shinychat display. An optional `extra$data`
+#' For custom result content, `fn` can return an [ellmer::ContentToolResult].
+#' Its `value` is sent to the model and its `extra$display` supplies the
+#' shinychat body and card options. Custom HTML is presented inside the standard
+#' measure display, after its metadata and arguments. An optional `extra$data`
 #' value is made available in the agent's R session and removed from the result
 #' before it is returned to ellmer.
 #'

--- a/pkg-r/R/measures.R
+++ b/pkg-r/R/measures.R
@@ -187,13 +187,29 @@ measure <- function(name, description, fn, arguments = list(), title = NULL) {
   rlang::check_string(description)
   rlang::check_string(title, allow_null = TRUE)
   title <- title %||% humanize_name(name)
-  ellmer::tool(
+  td <- ellmer::tool(
     fn,
     description,
     arguments = fill_injected_arguments(arguments, fn),
     name = name,
     annotations = ellmer::tool_annotations(title = title)
   )
+  set_measure_display_metadata(td, description)
+}
+
+measure_display_metadata <- function(td) {
+  attr(td, "commons_measure_display") %||% list(
+    description = tool_description(td),
+    details = NULL
+  )
+}
+
+set_measure_display_metadata <- function(td, description, details = NULL) {
+  attr(td, "commons_measure_display") <- list(
+    description = description,
+    details = details
+  )
+  td
 }
 
 # Arguments of `fn` not described in `arguments` are supplied by commons(),

--- a/pkg-r/R/read-measures.R
+++ b/pkg-r/R/read-measures.R
@@ -116,9 +116,22 @@ block_to_measure <- function(block, env) {
 
   description <- block_description(block)
   arguments <- block_arguments(block, fn)
+  display <- block_display_metadata(block)
+  td <- measure(
+    name,
+    description,
+    fn,
+    arguments = arguments,
+    title = display$title
+  )
+  td <- set_measure_display_metadata(
+    td,
+    display$description,
+    display$details
+  )
 
   list(
-    measure = measure(name, description, fn, arguments = arguments),
+    measure = td,
     provenance = block_provenance(block)
   )
 }
@@ -133,6 +146,15 @@ block_description <- function(block) {
     }
   )
   paste(parts, collapse = "\n\n")
+}
+
+block_display_metadata <- function(block) {
+  ret <- roxygen2::block_get_tag_value(block, "return")
+  list(
+    title = roxygen2::block_get_tag_value(block, "title"),
+    description = roxygen2::block_get_tag_value(block, "description") %||% "",
+    details = if (!is.null(ret)) paste0("Returns: ", ret)
+  )
 }
 
 block_provenance <- function(block) {

--- a/pkg-r/R/read-measures.R
+++ b/pkg-r/R/read-measures.R
@@ -37,20 +37,24 @@ read_measures <- function(paths, env = globalenv()) {
   new_measure_files(
     measures = lapply(records, `[[`, "measure"),
     fn_sources = env_fn_sources(measure_env),
-    provenance = lapply(records, `[[`, "provenance")
+    provenance = lapply(records, `[[`, "provenance"),
+    measure_display = lapply(records, `[[`, "measure_display")
   )
 }
 
 new_measure_files <- function(
   measures = list(),
   fn_sources = character(),
-  provenance = rep(list(character()), length(measures))
+  provenance = rep(list(character()), length(measures)),
+  measure_display = NULL
 ) {
+  measure_display <- measure_display %||% rep(list(NULL), length(measures))
   structure(
     list(
       measures = measures,
       fn_sources = fn_sources,
-      provenance = provenance
+      provenance = provenance,
+      measure_display = measure_display
     ),
     class = "commons_measure_files"
   )
@@ -117,22 +121,17 @@ block_to_measure <- function(block, env) {
   description <- block_description(block)
   arguments <- block_arguments(block, fn)
   display <- block_display_metadata(block)
-  td <- measure(
-    name,
-    description,
-    fn,
-    arguments = arguments,
-    title = display$title
-  )
-  td <- set_measure_display_metadata(
-    td,
-    display$description,
-    display$details
-  )
 
   list(
-    measure = td,
-    provenance = block_provenance(block)
+    measure = measure(
+      name,
+      description,
+      fn,
+      arguments = arguments,
+      title = display$title
+    ),
+    provenance = block_provenance(block),
+    measure_display = display[c("description", "details")]
   )
 }
 

--- a/pkg-r/R/tools.R
+++ b/pkg-r/R/tools.R
@@ -323,7 +323,8 @@ tool_call_measure <- function(private) {
         injections = private$injections,
         handles = private$handles,
         sources = private$sources,
-        measure_provenance = private$measure_provenance
+        measure_provenance = private$measure_provenance,
+        measure_display = private$measure_display
       )
     },
     paste(
@@ -501,7 +502,8 @@ call_measure_tool <- function(
   injections = list(),
   handles = NULL,
   sources = list(),
-  measure_provenance = list()
+  measure_provenance = list(),
+  measure_display = list()
 ) {
   td <- registry[[name]]
   if (is.null(td)) {
@@ -515,6 +517,7 @@ call_measure_tool <- function(
   footer <- measure_source_footer(
     measure_provenance[[name]] %||% character()
   )
+  metadata <- measure_metadata(td, measure_display[[name]])
   args <- validate_measure_args(td, parse_json_args(arguments))
   # A measure takes a source's connection by the source's name; a board source
   # must have its pins loaded before that connection can answer a query.
@@ -523,23 +526,36 @@ call_measure_tool <- function(
   }
   value <- do.call(td, c(args, injections[[name]]))
   if (S7::S7_inherits(value, ellmer::ContentToolResult)) {
-    return(measure_content_tool_result(td, args, value, handles, footer))
+    return(measure_content_tool_result(
+      args,
+      value,
+      handles,
+      footer,
+      metadata
+    ))
   }
   value <- collect_lazy_table(value)
   if (is_ggplot(value)) {
     advert <- register_handle(handles, value)
-    return(measure_plot_tool_result(td, args, value, advert, footer))
+    return(measure_plot_tool_result(
+      td,
+      args,
+      value,
+      advert,
+      footer,
+      metadata
+    ))
   }
   if (is_gt_table(value)) {
     data <- recover_gt_table_data(value)
     advert <- register_handle(handles, data)
     return(measure_gt_table_tool_result(
-      td,
       args,
       value,
       data,
       advert,
-      footer
+      footer,
+      metadata
     ))
   }
   advert <- register_handle(handles, value)
@@ -547,14 +563,20 @@ call_measure_tool <- function(
     paste(c(format_measure_value(value), advert), collapse = "\n\n"),
     title = "Ran a trusted calculation",
     icon = maybe_icon("shield-check"),
-    html = measure_display_html(args, value, measure_metadata(td)),
+    html = measure_display_html(args, value, metadata),
     footer = footer,
     tag = "A",
     show_tag = FALSE
   )
 }
 
-measure_content_tool_result <- function(td, args, result, handles, footer) {
+measure_content_tool_result <- function(
+  args,
+  result,
+  handles,
+  footer,
+  metadata
+) {
   data <- result@extra$data
   result@extra$data <- NULL
   display <- result@extra$display
@@ -589,7 +611,7 @@ measure_content_tool_result <- function(td, args, result, handles, footer) {
       display$html <- measure_display_with_custom_html(
         args,
         display$html,
-        measure_metadata(td)
+        metadata
       )
     }
   }
@@ -639,7 +661,14 @@ append_handle_advert <- function(value, advert) {
   paste(c(format_measure_value(value), advert), collapse = "\n\n")
 }
 
-measure_plot_tool_result <- function(td, args, value, advert, footer) {
+measure_plot_tool_result <- function(
+  td,
+  args,
+  value,
+  advert,
+  footer,
+  metadata
+) {
   title <- tool_title(td)
   rendered <- tryCatch(
     render_plot_image(value, sprintf("Plot returned by %s", title)),
@@ -647,13 +676,13 @@ measure_plot_tool_result <- function(td, args, value, advert, footer) {
   )
   if (inherits(rendered, "error")) {
     return(measure_failure_result(
-      td,
       args,
       advert,
       conditionMessage(rendered),
       "a plot",
       "commons-measure-plot-error",
-      footer = footer
+      footer = footer,
+      metadata = metadata
     ))
   }
 
@@ -671,7 +700,7 @@ measure_plot_tool_result <- function(td, args, value, advert, footer) {
     html = measure_display_with_result_html(
       args,
       measure_result_html(rendered$html),
-      measure_metadata(td)
+      metadata
     ),
     footer = footer,
     tag = "A",
@@ -681,13 +710,13 @@ measure_plot_tool_result <- function(td, args, value, advert, footer) {
 }
 
 measure_failure_result <- function(
-  td,
   args,
   advert,
   message,
   result_type,
   class,
   footer,
+  metadata,
   model_content = NULL
 ) {
   note <- sprintf(
@@ -702,7 +731,7 @@ measure_failure_result <- function(
     html = measure_display_with_result_html(
       args,
       measure_result_html(html_escape(note), class),
-      measure_metadata(td)
+      metadata
     ),
     footer = footer,
     tag = "A",
@@ -712,12 +741,12 @@ measure_failure_result <- function(
 }
 
 measure_gt_table_tool_result <- function(
-  td,
   args,
   value,
   data,
   advert,
-  footer
+  footer,
+  metadata
 ) {
   rendered <- tryCatch(
     render_gt_table(value),
@@ -726,13 +755,13 @@ measure_gt_table_tool_result <- function(
   model_content <- df_to_markdown(data)
   if (inherits(rendered, "error")) {
     return(measure_failure_result(
-      td,
       args,
       advert,
       conditionMessage(rendered),
       "a gt table",
       "commons-measure-gt-table-error",
       footer = footer,
+      metadata = metadata,
       model_content = model_content
     ))
   }
@@ -749,7 +778,7 @@ measure_gt_table_tool_result <- function(
   display_html <- measure_display_with_result_html(
     args,
     measure_result_html(rendered$html, "commons-measure-gt-table"),
-    measure_metadata(td)
+    metadata
   )
   if (length(rendered$dependencies) > 0) {
     display_html <- htmltools::attachDependencies(
@@ -1108,9 +1137,8 @@ measure_display_with_custom_html <- function(args, result_html, metadata) {
   )
 }
 
-measure_metadata <- function(td) {
-  display <- measure_display_metadata(td)
-  description <- display$description %||% ""
+measure_metadata <- function(td, display = NULL) {
+  description <- display$description %||% tool_description(td)
   extra <- display$details %||% ""
   # Roughly three lines at chat-card width; CSS supplies the exact clamp.
   has_details <- nchar(description) > 200L

--- a/pkg-r/R/tools.R
+++ b/pkg-r/R/tools.R
@@ -523,7 +523,7 @@ call_measure_tool <- function(
   }
   value <- do.call(td, c(args, injections[[name]]))
   if (S7::S7_inherits(value, ellmer::ContentToolResult)) {
-    return(measure_content_tool_result(td, value, handles, footer))
+    return(measure_content_tool_result(td, args, value, handles, footer))
   }
   value <- collect_lazy_table(value)
   if (is_ggplot(value)) {
@@ -554,7 +554,7 @@ call_measure_tool <- function(
   )
 }
 
-measure_content_tool_result <- function(td, result, handles, footer) {
+measure_content_tool_result <- function(td, args, result, handles, footer) {
   data <- result@extra$data
   result@extra$data <- NULL
   display <- result@extra$display
@@ -577,12 +577,21 @@ measure_content_tool_result <- function(td, result, handles, footer) {
     display <- shinychat::tool_result_display(
       title = title,
       icon = icon,
-      footer = footer
+      footer = footer,
+      show_request = FALSE
     )
   } else if (is.list(display)) {
     display$title <- display$title %||% title
     display$icon <- display$icon %||% icon
     display$footer <- display$footer %||% footer
+    display$show_request <- FALSE
+    if (!is.null(display$html)) {
+      display$html <- measure_display_with_custom_html(
+        args,
+        display$html,
+        measure_metadata(td)
+      )
+    }
   }
   result@extra$display <- display
   result@extra$commons_tag <- "A"
@@ -1074,6 +1083,25 @@ measure_display_with_result_html <- function(
     measure_metadata_html(metadata),
     measure_args_html(args),
     result_html
+  )
+}
+
+measure_display_with_custom_html <- function(args, result_html, metadata) {
+  if (is.character(result_html)) {
+    result_html <- htmltools::HTML(result_html)
+  }
+  htmltools::div(
+    class = "commons-measure-display",
+    htmltools::HTML(measure_metadata_html(metadata)),
+    htmltools::HTML(measure_args_html(args)),
+    htmltools::div(
+      class = "commons-measure-result",
+      htmltools::tags$strong("Result"),
+      htmltools::div(
+        class = "commons-measure-result-value",
+        result_html
+      )
+    )
   )
 }
 

--- a/pkg-r/R/tools.R
+++ b/pkg-r/R/tools.R
@@ -1098,7 +1098,10 @@ measure_display_with_custom_html <- function(args, result_html, metadata) {
       class = "commons-measure-result",
       htmltools::tags$strong("Result"),
       htmltools::div(
-        class = "commons-measure-result-value",
+        class = paste(
+          "commons-measure-result-value",
+          "commons-measure-result-value-authored"
+        ),
         result_html
       )
     )

--- a/pkg-r/R/tools.R
+++ b/pkg-r/R/tools.R
@@ -1109,9 +1109,21 @@ measure_display_with_custom_html <- function(args, result_html, metadata) {
 }
 
 measure_metadata <- function(td) {
+  display <- measure_display_metadata(td)
+  description <- display$description %||% ""
+  extra <- display$details %||% ""
+  # Roughly three lines at chat-card width; CSS supplies the exact clamp.
+  has_details <- nchar(description) > 200L
+  parts <- c(description, extra)
+  details <- if (has_details) {
+    paste(parts[nzchar(parts)], collapse = "\n\n")
+  } else {
+    ""
+  }
   data.frame(
     title = tool_title(td),
-    description = tool_description(td),
+    description = description,
+    details = details,
     stringsAsFactors = FALSE
   )
 }
@@ -1120,6 +1132,8 @@ measure_metadata_html <- function(metadata) {
   if (is.null(metadata) || nrow(metadata) == 0L) {
     return("")
   }
+  metadata_details <- metadata$details %||% rep("", nrow(metadata))
+  metadata_details[is.na(metadata_details)] <- ""
   items <- vapply(
     seq_len(nrow(metadata)),
     function(i) {
@@ -1127,18 +1141,42 @@ measure_metadata_html <- function(metadata) {
       description <- if (is.na(description) || !nzchar(description)) {
         ""
       } else {
+        summary_class <- if (nzchar(metadata_details[[i]])) {
+          " commons-measure-description-summary"
+        } else {
+          ""
+        }
         sprintf(
-          "<div class=\"commons-measure-description\">%s</div>",
+          "<div class=\"commons-measure-description%s\">%s</div>",
+          summary_class,
           html_escape(description)
+        )
+      }
+      details <- metadata_details[[i]]
+      details <- if (!nzchar(details)) {
+        ""
+      } else {
+        sprintf(
+          paste0(
+            "<details class=\"commons-measure-details\">",
+            "<summary>",
+            "<span class=\"commons-measure-details-more\">See more</span>",
+            "<span class=\"commons-measure-details-less\">See less</span>",
+            "</summary>",
+            "<div class=\"commons-measure-details-body\">%s</div>",
+            "</details>"
+          ),
+          html_escape(details)
         )
       }
       sprintf(
         paste0(
           "<div class=\"commons-measure-metadata-item\">",
-          "<strong class=\"commons-measure-title\">%s</strong>%s</div>"
+          "<strong class=\"commons-measure-title\">%s</strong>%s%s</div>"
         ),
         html_escape(metadata$title[[i]]),
-        description
+        description,
+        details
       )
     },
     character(1)

--- a/pkg-r/R/tools.R
+++ b/pkg-r/R/tools.R
@@ -1188,12 +1188,18 @@ measure_metadata_html <- function(metadata) {
           paste0(
             "<details class=\"commons-measure-details\">",
             "<summary>",
-            "<span class=\"commons-measure-details-more\">See more</span>",
-            "<span class=\"commons-measure-details-less\">See less</span>",
+            "<span class=\"commons-measure-details-more\">",
+            "See more<span class=\"visually-hidden\"> details for %s</span>",
+            "</span>",
+            "<span class=\"commons-measure-details-less\">",
+            "See less<span class=\"visually-hidden\"> details for %s</span>",
+            "</span>",
             "</summary>",
             "<div class=\"commons-measure-details-body\">%s</div>",
             "</details>"
           ),
+          html_escape(metadata$title[[i]]),
+          html_escape(metadata$title[[i]]),
           html_escape(details)
         )
       }

--- a/pkg-r/inst/www/commons-chat/commons-chat.css
+++ b/pkg-r/inst/www/commons-chat/commons-chat.css
@@ -459,10 +459,6 @@ shiny-chat-container
   gap: 0.5rem;
 }
 
-.commons-measure-details[open] > summary {
-  order: 2;
-}
-
 .commons-measure-details[open] .commons-measure-details-more {
   display: none;
 }
@@ -472,7 +468,6 @@ shiny-chat-container
 }
 
 .commons-measure-details-body {
-  order: 1;
   white-space: pre-wrap;
 }
 

--- a/pkg-r/inst/www/commons-chat/commons-chat.css
+++ b/pkg-r/inst/www/commons-chat/commons-chat.css
@@ -437,6 +437,11 @@ shiny-chat-container
   white-space: pre-wrap;
 }
 
+/* Tag trees serialize with indentation that pre-wrap would render. */
+.commons-measure-result-value-authored {
+  white-space: normal;
+}
+
 .commons-measure-result-value > table {
   border-collapse: collapse;
   font-size: 0.85rem;

--- a/pkg-r/inst/www/commons-chat/commons-chat.css
+++ b/pkg-r/inst/www/commons-chat/commons-chat.css
@@ -434,6 +434,12 @@ shiny-chat-container
   display: none;
 }
 
+.commons-measure-details > summary:focus-visible {
+  border-radius: var(--bs-border-radius-sm, 0.25rem);
+  outline: 2px solid var(--bs-primary, #007bc2);
+  outline-offset: 2px;
+}
+
 .commons-measure-details:not([open]) {
   margin-top: -1.5rem;
   position: relative;

--- a/pkg-r/inst/www/commons-chat/commons-chat.css
+++ b/pkg-r/inst/www/commons-chat/commons-chat.css
@@ -404,6 +404,78 @@ shiny-chat-container
   white-space: pre-wrap;
 }
 
+.commons-measure-description-summary {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(to bottom, #000 55%, transparent);
+  mask-image: linear-gradient(to bottom, #000 55%, transparent);
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.commons-measure-metadata-item:has(.commons-measure-details[open])
+  > .commons-measure-description-summary {
+  display: none;
+}
+
+.commons-measure-details {
+  color: var(--bs-secondary-color, #6c757d);
+}
+
+.commons-measure-details > summary {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  list-style: none;
+}
+
+.commons-measure-details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.commons-measure-details:not([open]) {
+  margin-top: -1.5rem;
+  position: relative;
+}
+
+.commons-measure-details:not([open]) > summary {
+  min-height: 1.5rem;
+  padding-top: 0.75rem;
+}
+
+.commons-measure-details > summary > span {
+  background: var(--bs-body-bg, #fff);
+  font-size: 0.85em;
+  padding-inline: 0.5rem;
+}
+
+.commons-measure-details-less {
+  display: none;
+}
+
+.commons-measure-details[open] {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.commons-measure-details[open] > summary {
+  order: 2;
+}
+
+.commons-measure-details[open] .commons-measure-details-more {
+  display: none;
+}
+
+.commons-measure-details[open] .commons-measure-details-less {
+  display: inline;
+}
+
+.commons-measure-details-body {
+  order: 1;
+  white-space: pre-wrap;
+}
+
 .commons-measure-source-link + .commons-measure-source-link {
   margin-left: 0.75rem;
 }

--- a/pkg-r/man/measure.Rd
+++ b/pkg-r/man/measure.Rd
@@ -33,9 +33,10 @@ supply.
 Two return types receive special display handling: ggplots and \code{\link[gt:gt]{gt::gt()}}
 tables are shown directly to the user in the opened measure result.
 
-For full control over a result, \code{fn} can return an
-\link[ellmer:ContentToolResult]{ellmer::ContentToolResult}. Its \code{value} is sent to the model and its
-\code{extra$display} controls the shinychat display. An optional \code{extra$data}
+For custom result content, \code{fn} can return an \link[ellmer:ContentToolResult]{ellmer::ContentToolResult}.
+Its \code{value} is sent to the model and its \code{extra$display} supplies the
+shinychat body and card options. Custom HTML is presented inside the standard
+measure display, after its metadata and arguments. An optional \code{extra$data}
 value is made available in the agent's R session and removed from the result
 before it is returned to ellmer.
 }

--- a/pkg-r/tests/testthat/test-measures.R
+++ b/pkg-r/tests/testthat/test-measures.R
@@ -1,8 +1,14 @@
 test_that("semantic_layer stores measures by name", {
   layer <- semantic_layer(count_measure_tool())
+  state <- semantic_layer_state(layer)
 
   expect_s3_class(layer, "commons_semantic_layer")
-  expect_named(semantic_layer_state(layer)$measures, "order_count")
+  expect_named(state$measures, "order_count")
+  expect_named(state$measure_display, "order_count")
+  expect_equal(
+    state$measure_display$order_count$description,
+    tool_description(state$measures$order_count)
+  )
 })
 
 test_that("semantic_layer accepts a list of measures", {

--- a/pkg-r/tests/testthat/test-read-measures.R
+++ b/pkg-r/tests/testthat/test-read-measures.R
@@ -29,6 +29,17 @@ test_that("read_measures derives a measure from a documented function", {
   expect_match(tool_description(td), "Count orders")
   expect_match(tool_description(td), "Total orders")
   expect_match(tool_description(td), "Returns: An integer count")
+  expect_equal(tool_title(td), "Count orders")
+  metadata <- measure_metadata(td)
+  expect_equal(metadata$description, "Total orders, optionally by region.")
+  expect_equal(metadata$details, "")
+  expect_match(
+    measure_display_metadata(td)$details,
+    "Returns: An integer count",
+    fixed = TRUE
+  )
+  display <- measure_metadata_html(metadata)
+  expect_no_match(display, "commons-measure-details", fixed = TRUE)
   expect_equal(do.call(td, list()), 2026L)
 })
 

--- a/pkg-r/tests/testthat/test-read-measures.R
+++ b/pkg-r/tests/testthat/test-read-measures.R
@@ -25,16 +25,17 @@ test_that("read_measures derives a measure from a documented function", {
 
   expect_length(measures$measures, 1)
   td <- measures$measures[[1]]
+  display_metadata <- measures$measure_display[[1]]
   expect_equal(tool_name(td), "order_count")
   expect_match(tool_description(td), "Count orders")
   expect_match(tool_description(td), "Total orders")
   expect_match(tool_description(td), "Returns: An integer count")
   expect_equal(tool_title(td), "Count orders")
-  metadata <- measure_metadata(td)
+  metadata <- measure_metadata(td, display_metadata)
   expect_equal(metadata$description, "Total orders, optionally by region.")
   expect_equal(metadata$details, "")
   expect_match(
-    measure_display_metadata(td)$details,
+    display_metadata$details,
     "Returns: An integer count",
     fixed = TRUE
   )
@@ -273,9 +274,15 @@ test_that("read_measures produces measures usable in a semantic_layer", {
   ))
 
   layer <- semantic_layer(read_measures(path))
+  state <- semantic_layer_state(layer)
 
   expect_s3_class(layer, "commons_semantic_layer")
-  expect_named(semantic_layer_state(layer)$measures, "order_count")
+  expect_named(state$measures, "order_count")
+  expect_named(state$measure_display, "order_count")
+  expect_equal(
+    state$measure_display$order_count$description,
+    "Counts orders."
+  )
 })
 
 test_that("read_measures harvests measure and helper sources, comments included", {

--- a/pkg-r/tests/testthat/test-tools.R
+++ b/pkg-r/tests/testthat/test-tools.R
@@ -143,6 +143,7 @@ test_that("call_measure_tool supports custom ContentToolResult values", {
   expect_match(rendered, "commons-measure-display", fixed = TRUE)
   expect_match(rendered, "Adverse events &amp; outcomes", fixed = TRUE)
   expect_match(rendered, "Summarize adverse events.", fixed = TRUE)
+  expect_no_match(rendered, "commons-measure-details", fixed = TRUE)
   expect_match(rendered, "Population:", fixed = TRUE)
   expect_match(rendered, "ITT", fixed = TRUE)
   expect_match(rendered, "<strong>Result</strong>", fixed = TRUE)
@@ -169,6 +170,26 @@ test_that("call_measure_tool supports custom ContentToolResult values", {
     "Ran a trusted calculation"
   )
   expect_equal(res@extra$commons_tag, "A")
+})
+
+test_that("long measure descriptions can be expanded", {
+  description <- paste(
+    rep("A detailed description of the measure.", 8),
+    collapse = " "
+  )
+  td <- measure("orders", description, function() 1L)
+  td <- set_measure_display_metadata(
+    td,
+    description,
+    "Returns: The number of orders."
+  )
+
+  display <- measure_metadata_html(measure_metadata(td))
+
+  expect_match(display, "commons-measure-description-summary", fixed = TRUE)
+  expect_match(display, "commons-measure-details-more", fixed = TRUE)
+  expect_match(display, "commons-measure-details-less", fixed = TRUE)
+  expect_match(display, "Returns: The number of orders.", fixed = TRUE)
 })
 
 test_that("call_measure_tool preserves image content in ContentToolResult", {

--- a/pkg-r/tests/testthat/test-tools.R
+++ b/pkg-r/tests/testthat/test-tools.R
@@ -146,6 +146,11 @@ test_that("call_measure_tool supports custom ContentToolResult values", {
   expect_match(rendered, "Population:", fixed = TRUE)
   expect_match(rendered, "ITT", fixed = TRUE)
   expect_match(rendered, "<strong>Result</strong>", fixed = TRUE)
+  expect_match(
+    rendered,
+    "commons-measure-result-value-authored",
+    fixed = TRUE
+  )
   expect_match(rendered, "Headache", fixed = TRUE)
   expect_identical(
     vapply(

--- a/pkg-r/tests/testthat/test-tools.R
+++ b/pkg-r/tests/testthat/test-tools.R
@@ -177,7 +177,12 @@ test_that("long measure descriptions can be expanded", {
     rep("A detailed description of the measure.", 8),
     collapse = " "
   )
-  td <- measure("orders", description, function() 1L)
+  td <- measure(
+    "orders",
+    description,
+    function() 1L,
+    title = "Orders & returns"
+  )
   display_metadata <- list(
     description = description,
     details = "Returns: The number of orders."
@@ -194,6 +199,16 @@ test_that("long measure descriptions can be expanded", {
   expect_match(display, "commons-measure-description-summary", fixed = TRUE)
   expect_match(display, "commons-measure-details-more", fixed = TRUE)
   expect_match(display, "commons-measure-details-less", fixed = TRUE)
+  expect_match(
+    display,
+    "See more<span class=\"visually-hidden\"> details for Orders &amp; returns",
+    fixed = TRUE
+  )
+  expect_match(
+    display,
+    "See less<span class=\"visually-hidden\"> details for Orders &amp; returns",
+    fixed = TRUE
+  )
   expect_match(display, "Returns: The number of orders.", fixed = TRUE)
 })
 

--- a/pkg-r/tests/testthat/test-tools.R
+++ b/pkg-r/tests/testthat/test-tools.R
@@ -79,20 +79,31 @@ test_that("call_measure_tool registers scalar output as a handle", {
 
 test_that("call_measure_tool supports custom ContentToolResult values", {
   table <- data.frame(term = "Headache", count = 7)
-  display <- shinychat::tool_result_display(
-    html = htmltools::tags$table(
+  dependency <- htmltools::htmlDependency(
+    "measure-table",
+    "1.0.0",
+    src = c(href = "measure-table"),
+    stylesheet = "table.css"
+  )
+  table_html <- htmltools::attachDependencies(
+    htmltools::tags$table(
       htmltools::tags$tr(
         htmltools::tags$td("Headache"),
         htmltools::tags$td("7")
       )
     ),
-    open = TRUE
+    dependency
+  )
+  display <- shinychat::tool_result_display(
+    html = table_html,
+    open = TRUE,
+    full_screen = TRUE
   )
   registry <- list(
     table = measure(
       "table",
       "Summarize adverse events.",
-      function() {
+      function(population) {
         ellmer::ContentToolResult(
           value = "Headache: 7",
           extra = list(
@@ -102,12 +113,20 @@ test_that("call_measure_tool supports custom ContentToolResult values", {
           )
         )
       },
+      arguments = list(
+        population = ellmer::type_string("Analysis population.")
+      ),
       title = "Adverse events & outcomes"
     )
   )
   store <- new_handle_store()
 
-  res <- call_measure_tool(registry, "table", "{}", handles = store)
+  res <- call_measure_tool(
+    registry,
+    "table",
+    '{"population":"ITT"}',
+    handles = store
+  )
 
   expect_match(
     res@value,
@@ -120,8 +139,26 @@ test_that("call_measure_tool supports custom ContentToolResult values", {
   expect_identical(get_handle(store, "r1"), table)
   expect_null(res@extra$data)
   expect_identical(res@extra$custom, "preserved")
-  expect_identical(res@extra$display$html, display$html)
+  rendered <- as.character(res@extra$display$html)
+  expect_match(rendered, "commons-measure-display", fixed = TRUE)
+  expect_match(rendered, "Adverse events &amp; outcomes", fixed = TRUE)
+  expect_match(rendered, "Summarize adverse events.", fixed = TRUE)
+  expect_match(rendered, "Population:", fixed = TRUE)
+  expect_match(rendered, "ITT", fixed = TRUE)
+  expect_match(rendered, "<strong>Result</strong>", fixed = TRUE)
+  expect_match(rendered, "Headache", fixed = TRUE)
+  expect_identical(
+    vapply(
+      htmltools::findDependencies(res@extra$display$html),
+      `[[`,
+      character(1),
+      "name"
+    ),
+    "measure-table"
+  )
   expect_identical(res@extra$display$open, TRUE)
+  expect_identical(res@extra$display$full_screen, TRUE)
+  expect_identical(res@extra$display$show_request, FALSE)
   expect_identical(
     res@extra$display$title,
     "Ran a trusted calculation"
@@ -159,6 +196,7 @@ test_that("call_measure_tool preserves image content in ContentToolResult", {
   expect_identical(get_handle(store, "r1"), data)
   expect_null(res@extra$data)
   expect_identical(res@extra$display$title, "Ran a trusted calculation")
+  expect_identical(res@extra$display$show_request, FALSE)
 })
 
 test_that("call_measure_tool preserves custom ContentToolResult errors", {

--- a/pkg-r/tests/testthat/test-tools.R
+++ b/pkg-r/tests/testthat/test-tools.R
@@ -178,13 +178,18 @@ test_that("long measure descriptions can be expanded", {
     collapse = " "
   )
   td <- measure("orders", description, function() 1L)
-  td <- set_measure_display_metadata(
-    td,
-    description,
-    "Returns: The number of orders."
+  display_metadata <- list(
+    description = description,
+    details = "Returns: The number of orders."
   )
 
-  display <- measure_metadata_html(measure_metadata(td))
+  result <- call_measure_tool(
+    list(orders = td),
+    "orders",
+    "{}",
+    measure_display = list(orders = display_metadata)
+  )
+  display <- as.character(result@extra$display$html)
 
   expect_match(display, "commons-measure-description-summary", fixed = TRUE)
   expect_match(display, "commons-measure-details-more", fixed = TRUE)

--- a/www/commons-chat/commons-chat.css
+++ b/www/commons-chat/commons-chat.css
@@ -459,10 +459,6 @@ shiny-chat-container
   gap: 0.5rem;
 }
 
-.commons-measure-details[open] > summary {
-  order: 2;
-}
-
 .commons-measure-details[open] .commons-measure-details-more {
   display: none;
 }
@@ -472,7 +468,6 @@ shiny-chat-container
 }
 
 .commons-measure-details-body {
-  order: 1;
   white-space: pre-wrap;
 }
 

--- a/www/commons-chat/commons-chat.css
+++ b/www/commons-chat/commons-chat.css
@@ -437,6 +437,11 @@ shiny-chat-container
   white-space: pre-wrap;
 }
 
+/* Tag trees serialize with indentation that pre-wrap would render. */
+.commons-measure-result-value-authored {
+  white-space: normal;
+}
+
 .commons-measure-result-value > table {
   border-collapse: collapse;
   font-size: 0.85rem;

--- a/www/commons-chat/commons-chat.css
+++ b/www/commons-chat/commons-chat.css
@@ -434,6 +434,12 @@ shiny-chat-container
   display: none;
 }
 
+.commons-measure-details > summary:focus-visible {
+  border-radius: var(--bs-border-radius-sm, 0.25rem);
+  outline: 2px solid var(--bs-primary, #007bc2);
+  outline-offset: 2px;
+}
+
 .commons-measure-details:not([open]) {
   margin-top: -1.5rem;
   position: relative;

--- a/www/commons-chat/commons-chat.css
+++ b/www/commons-chat/commons-chat.css
@@ -404,6 +404,78 @@ shiny-chat-container
   white-space: pre-wrap;
 }
 
+.commons-measure-description-summary {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(to bottom, #000 55%, transparent);
+  mask-image: linear-gradient(to bottom, #000 55%, transparent);
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.commons-measure-metadata-item:has(.commons-measure-details[open])
+  > .commons-measure-description-summary {
+  display: none;
+}
+
+.commons-measure-details {
+  color: var(--bs-secondary-color, #6c757d);
+}
+
+.commons-measure-details > summary {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  list-style: none;
+}
+
+.commons-measure-details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.commons-measure-details:not([open]) {
+  margin-top: -1.5rem;
+  position: relative;
+}
+
+.commons-measure-details:not([open]) > summary {
+  min-height: 1.5rem;
+  padding-top: 0.75rem;
+}
+
+.commons-measure-details > summary > span {
+  background: var(--bs-body-bg, #fff);
+  font-size: 0.85em;
+  padding-inline: 0.5rem;
+}
+
+.commons-measure-details-less {
+  display: none;
+}
+
+.commons-measure-details[open] {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.commons-measure-details[open] > summary {
+  order: 2;
+}
+
+.commons-measure-details[open] .commons-measure-details-more {
+  display: none;
+}
+
+.commons-measure-details[open] .commons-measure-details-less {
+  display: inline;
+}
+
+.commons-measure-details-body {
+  order: 1;
+  white-space: pre-wrap;
+}
+
 .commons-measure-source-link + .commons-measure-source-link {
   margin-left: 0.75rem;
 }


### PR DESCRIPTION
Closes #348. More context in that issue.

The app with this PR shows the measure title and description, where the description fades out in the third line with a 'See more' button, so that users can focus on the main tool result display:

> <img height="686" alt="Screenshot 2026-09-10 at 3 50 37 PM" src="https://github.com/user-attachments/assets/18b1376c-a4b3-49f9-bc2a-9953d5a6d501" />
