### PR TITLE
feat(py): the construction-time sandbox gate and the worker's address-space limit

### DIFF
--- a/pkg-py/src/commons/_execution/_runtime/__init__.py
+++ b/pkg-py/src/commons/_execution/_runtime/__init__.py
@@ -1,0 +1,8 @@
+"""What runs inside the worker process, and nothing else.
+
+Every module here mutates the process it is imported into: it lowers resource
+limits, engages a sandbox on itself, and takes over stdout. Importing one from
+the parent would restrict the parent. Nothing here imports ``commons``, which
+is what lets the worker be launched by absolute path on an interpreter that
+has never heard of the package.
+"""

--- a/pkg-py/src/commons/_execution/_runtime/_limits.py
+++ b/pkg-py/src/commons/_execution/_runtime/_limits.py
@@ -1,0 +1,39 @@
+"""The address-space cap the worker puts on itself.
+
+This runs in the child, before the sandbox engages and long before any
+model-written code is loaded. It is a guard against a runaway allocation
+taking the host down with it, not a security boundary; the sandbox is that.
+"""
+
+from __future__ import annotations
+
+import resource
+
+__all__ = ["DEFAULT_ADDRESS_SPACE", "apply_address_space_limit"]
+
+# Ample headroom for a data frame or two and the libraries that read them. A
+# smaller limit inherited from a container still wins, as it should: the host
+# knows how much memory it is prepared to give away and this does not.
+DEFAULT_ADDRESS_SPACE = 8 * 1024**3
+
+
+def apply_address_space_limit(limit: int = DEFAULT_ADDRESS_SPACE) -> int | None:
+    """Cap this process's address space, and report what stuck.
+
+    Returns the limit in force afterwards, which is ``limit`` or whatever
+    smaller limit was already inherited. Returns ``None`` where the kernel
+    does not enforce ``RLIMIT_AS`` at all: recent macOS rejects the call, and
+    refusing to start the worker over a missing backstop would trade a working
+    sandbox for none.
+    """
+    soft, hard = resource.getrlimit(resource.RLIMIT_AS)
+    for inherited in (soft, hard):
+        if inherited != resource.RLIM_INFINITY and inherited < limit:
+            limit = inherited
+    try:
+        resource.setrlimit(resource.RLIMIT_AS, (limit, limit))
+    except (OSError, ValueError):
+        # CPython raises ValueError for the kernel's EINVAL, which is how a
+        # host that has no RLIMIT_AS to set answers.
+        return None
+    return limit

--- a/pkg-py/src/commons/_execution/_sandbox.py
+++ b/pkg-py/src/commons/_execution/_sandbox.py
@@ -1,0 +1,127 @@
+"""Whether this host can sandbox the worker, decided before anything runs.
+
+The worker sandboxes itself, in the child, before any model-written code is
+loaded. What lives here is the parent's half: a probe of what the host offers
+and the gate that turns that into a refusal, so a host commons cannot protect
+is reported when the agent is constructed rather than when a model first asks
+to run code.
+
+The same decision is made by ``run_r_protection_mode()`` in
+``pkg-r/R/sandbox.R``.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+from dataclasses import dataclass
+from typing import Literal
+
+__all__ = [
+    "ALLOW_UNSAFE_FALLBACK",
+    "ProtectionMode",
+    "SandboxCapabilities",
+    "protection_mode",
+    "sandbox_capabilities",
+]
+
+ProtectionMode = Literal["sandbox", "guardrails"]
+
+# An environment variable rather than a constructor keyword: accepting weaker
+# protection should take a deliberate act outside the code, not a keyword a
+# caller can pass without noticing what it gives up.
+ALLOW_UNSAFE_FALLBACK = "COMMONS_ALLOW_UNSAFE_FALLBACK"
+
+_AFFIRMATIVE = frozenset({"1", "true", "yes", "on"})
+
+_OPT_IN = (
+    f"For local development only, set {ALLOW_UNSAFE_FALLBACK}=1 to accept "
+    "best-effort guardrails, which are not a security boundary."
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class SandboxCapabilities:
+    """What the running kernel offers the worker.
+
+    ``landlock_abi`` is the Landlock ABI version, ``0`` where the syscall
+    exists but reports no usable version and ``-1`` where it does not exist.
+    """
+
+    landlock_abi: int
+    seccomp: bool
+    seatbelt: bool
+    userns: bool
+
+
+def sandbox_capabilities() -> SandboxCapabilities:
+    """Probe this host for each mechanism the worker can restrict itself with.
+
+    Each field is filled in by the ctypes module that implements its
+    mechanism, none of which exist yet. Until they do this reports every
+    mechanism unavailable, so ``protection_mode()`` refuses every host: the
+    safe direction to be wrong in while the sandbox is being built.
+    """
+    return SandboxCapabilities(
+        landlock_abi=-1, seccomp=False, seatbelt=False, userns=False
+    )
+
+
+def _guardrails_allowed() -> bool:
+    return os.environ.get(ALLOW_UNSAFE_FALLBACK, "").strip().lower() in _AFFIRMATIVE
+
+
+def protection_mode(
+    capabilities: SandboxCapabilities | None = None,
+    *,
+    sysname: str | None = None,
+) -> ProtectionMode:
+    """How much the worker can be protected on this host.
+
+    Returns ``"sandbox"`` when the host offers a real sandbox. Otherwise
+    raises, unless guardrails have been opted into, in which case it returns
+    ``"guardrails"``: a scratch-directory working directory, an address-space
+    limit, and a warning. Guardrails are a way to keep working on a host
+    commons cannot protect, not a weaker sandbox.
+
+    ``capabilities`` and ``sysname`` default to this host; passing them is
+    how the decision table is exercised from any machine. There is
+    deliberately no argument for the opt-in: the only way to accept
+    guardrails is to set the environment variable.
+    """
+    if capabilities is None:
+        capabilities = sandbox_capabilities()
+    if sysname is None:
+        sysname = platform.system()
+
+    if sysname == "Linux":
+        available = capabilities.seccomp and (
+            capabilities.landlock_abi >= 1 or capabilities.userns
+        )
+    elif sysname == "Darwin":
+        available = capabilities.seatbelt
+    else:
+        available = False
+
+    if available:
+        return "sandbox"
+    if _guardrails_allowed():
+        return "guardrails"
+
+    if sysname == "Linux" and not capabilities.seccomp:
+        raise RuntimeError(
+            "commons cannot sandbox the code execution worker because this "
+            f"Linux host does not support seccomp. {_OPT_IN}"
+        )
+    if sysname == "Linux":
+        raise RuntimeError(
+            "commons cannot sandbox the code execution worker because this "
+            "Linux host offers neither Landlock nor unprivileged user "
+            "namespaces. Use a kernel with Landlock, or enable unprivileged "
+            "user namespaces: check `sysctl user.max_user_namespaces` and, in "
+            f"a container, its seccomp profile. {_OPT_IN}"
+        )
+    raise RuntimeError(
+        "commons cannot sandbox the code execution worker on "
+        f"{sysname}. {_OPT_IN}"
+    )

--- a/pkg-py/tests/test_execution_limits.py
+++ b/pkg-py/tests/test_execution_limits.py
@@ -1,0 +1,162 @@
+"""The address-space limit the worker puts on itself before it runs any code.
+
+These run real interpreters. A limit is only worth having if the kernel
+actually holds the process to it, and an assertion about the arguments passed
+to ``setrlimit`` would not show that.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import resource
+import subprocess
+import sys
+
+import pytest
+
+from commons._execution import _runtime
+
+RUNTIME_DIR = str(pathlib.Path(_runtime.__file__).parent)
+
+GIB = 1024**3
+
+# Reporting the limit from inside the child is the only way to see it: the
+# parent's own limit is untouched, by design.
+REPORT = """
+import json, resource, sys
+{pre}
+import _limits
+applied = _limits.apply_address_space_limit({request})
+soft, hard = resource.getrlimit(resource.RLIMIT_AS)
+json.dump({{"applied": applied, "soft": soft, "hard": hard}}, sys.stdout)
+"""
+
+
+def apply_in_child(request: str = "", pre: str = "") -> dict[str, int | None]:
+    """Apply the limit in a fresh interpreter and report what stuck.
+
+    ``pre`` runs before the limit is applied, which is how a host that has
+    already capped the worker is simulated.
+    """
+    completed = subprocess.run(
+        [sys.executable, "-c", REPORT.format(pre=pre, request=request)],
+        env={**os.environ, "PYTHONPATH": RUNTIME_DIR},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(completed.stdout)
+
+
+REPORT_INHERITED = (
+    "import json, resource, sys;"
+    " json.dump(resource.getrlimit(resource.RLIMIT_AS), sys.stdout)"
+)
+
+
+def inherited_ceiling() -> int | None:
+    """The tightest limit a fresh child already has, or ``None`` for no limit.
+
+    Everything below is expressed relative to this: a host that already caps
+    address space caps these tests too, and a case that assumed otherwise
+    would be asserting the host's configuration rather than the code's.
+    """
+    reported = json.loads(
+        subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                REPORT_INHERITED,
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    )
+    finite = [value for value in reported if value != resource.RLIM_INFINITY]
+    return min(finite) if finite else None
+
+
+CEILING = inherited_ceiling()
+
+# The limit the clamp cases pre-set on the child, chosen to be one the child
+# can actually reach.
+LOWER = 2 * GIB if CEILING is None else min(2 * GIB, CEILING // 2)
+LOWER_THE_LIMIT = f"resource.setrlimit(resource.RLIMIT_AS, ({LOWER}, {LOWER}))"
+
+
+def address_space_is_settable() -> bool:
+    """Whether this host lets a process cap its own address space at all.
+
+    macOS accepts the call on some releases and rejects it with ``EINVAL`` on
+    others, so this is a question about the running kernel rather than about
+    the platform name.
+    """
+    completed = subprocess.run(
+        [sys.executable, "-c", f"import resource; {LOWER_THE_LIMIT}"],
+        capture_output=True,
+        check=False,
+    )
+    return completed.returncode == 0
+
+
+SETTABLE = address_space_is_settable()
+
+settable = pytest.mark.skipif(
+    not SETTABLE, reason="this kernel does not enforce RLIMIT_AS"
+)
+
+
+@settable
+@pytest.mark.skipif(
+    CEILING is not None and CEILING < 8 * GIB,
+    reason="this host already caps address space below the default",
+)
+def test_the_default_limit_is_eight_gibibytes_and_is_the_one_in_force() -> None:
+    reported = apply_in_child()
+    assert reported["applied"] == 8 * GIB
+    assert reported["soft"] == 8 * GIB
+    assert reported["hard"] == 8 * GIB
+
+
+@settable
+def test_a_lower_inherited_limit_is_not_raised() -> None:
+    reported = apply_in_child(pre=LOWER_THE_LIMIT)
+    assert reported["applied"] == LOWER
+    assert reported["soft"] == LOWER
+
+
+@settable
+def test_a_request_below_the_inherited_limit_still_applies() -> None:
+    reported = apply_in_child(request=str(LOWER // 2), pre=LOWER_THE_LIMIT)
+    assert reported["applied"] == LOWER // 2
+
+
+@pytest.mark.skipif(SETTABLE, reason="this kernel enforces RLIMIT_AS")
+def test_a_kernel_that_refuses_the_limit_does_not_stop_the_worker() -> None:
+    """The worker runs on without the cap rather than failing to start.
+
+    The cap guards against a runaway allocation; it is not the security
+    boundary, which is the sandbox. A host without it is worth reporting, not
+    worth refusing to run on. ``apply_in_child`` requires a clean exit, so
+    reaching an answer at all is half of what this asserts.
+    """
+    assert apply_in_child()["applied"] is None
+
+
+def test_the_limit_module_does_not_import_commons() -> None:
+    """It runs inside the worker, which has no ``commons`` on its path."""
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import _limits, sys; sys.exit('commons' in sys.modules)",
+        ],
+        env={"PYTHONPATH": RUNTIME_DIR, "PATH": os.environ.get("PATH", "")},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr

--- a/pkg-py/tests/test_execution_sandbox.py
+++ b/pkg-py/tests/test_execution_sandbox.py
@@ -1,0 +1,107 @@
+"""The gate that decides whether the worker can be sandboxed on this host.
+
+The decision table is driven with constructed capability values rather than
+whatever the test machine happens to support, so every branch is reachable
+from any host. The cases match pkg-r/tests/testthat/test-sandbox.R.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from commons._execution._sandbox import (
+    SandboxCapabilities,
+    protection_mode,
+    sandbox_capabilities,
+)
+
+NOTHING = SandboxCapabilities(
+    landlock_abi=0, seccomp=False, seatbelt=False, userns=False
+)
+
+
+def test_the_host_probe_reports_every_mechanism() -> None:
+    capabilities = sandbox_capabilities()
+    assert isinstance(capabilities.landlock_abi, int)
+    assert isinstance(capabilities.seccomp, bool)
+    assert isinstance(capabilities.seatbelt, bool)
+    assert isinstance(capabilities.userns, bool)
+
+
+@pytest.mark.parametrize("landlock_abi, userns", [(1, False), (0, True)])
+def test_linux_accepts_either_filesystem_sandbox(landlock_abi, userns) -> None:
+    capabilities = SandboxCapabilities(
+        landlock_abi=landlock_abi, seccomp=True, seatbelt=False, userns=userns
+    )
+    assert protection_mode(capabilities, sysname="Linux") == "sandbox"
+
+
+def test_linux_without_seccomp_is_refused() -> None:
+    capabilities = SandboxCapabilities(
+        landlock_abi=1, seccomp=False, seatbelt=False, userns=True
+    )
+    with pytest.raises(RuntimeError, match="does not support seccomp"):
+        protection_mode(capabilities, sysname="Linux")
+
+
+def test_linux_without_a_filesystem_sandbox_is_refused() -> None:
+    capabilities = SandboxCapabilities(
+        landlock_abi=0, seccomp=True, seatbelt=False, userns=False
+    )
+    with pytest.raises(
+        RuntimeError, match="neither Landlock nor unprivileged user namespaces"
+    ):
+        protection_mode(capabilities, sysname="Linux")
+
+
+def test_a_refusal_names_the_opt_in_and_what_to_check() -> None:
+    capabilities = SandboxCapabilities(
+        landlock_abi=0, seccomp=True, seatbelt=False, userns=False
+    )
+    with pytest.raises(RuntimeError) as caught:
+        protection_mode(capabilities, sysname="Linux")
+    message = str(caught.value)
+    assert "COMMONS_ALLOW_UNSAFE_FALLBACK" in message
+    assert "user.max_user_namespaces" in message
+
+
+def test_macos_needs_seatbelt() -> None:
+    seatbelt = SandboxCapabilities(
+        landlock_abi=-1, seccomp=False, seatbelt=True, userns=False
+    )
+    assert protection_mode(seatbelt, sysname="Darwin") == "sandbox"
+    with pytest.raises(RuntimeError, match="on Darwin"):
+        protection_mode(NOTHING, sysname="Darwin")
+
+
+def test_an_unknown_operating_system_is_refused_whatever_it_supports() -> None:
+    everything = SandboxCapabilities(
+        landlock_abi=5, seccomp=True, seatbelt=True, userns=True
+    )
+    with pytest.raises(RuntimeError, match="on Windows"):
+        protection_mode(everything, sysname="Windows")
+
+
+def test_the_environment_opt_in_downgrades_a_refusal_to_guardrails(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("COMMONS_ALLOW_UNSAFE_FALLBACK", "true")
+    assert protection_mode(NOTHING, sysname="Windows") == "guardrails"
+
+
+def test_the_opt_in_does_not_downgrade_a_host_that_can_be_sandboxed(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("COMMONS_ALLOW_UNSAFE_FALLBACK", "1")
+    seatbelt = SandboxCapabilities(
+        landlock_abi=-1, seccomp=False, seatbelt=True, userns=False
+    )
+    assert protection_mode(seatbelt, sysname="Darwin") == "sandbox"
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "maybe"])
+def test_only_an_affirmative_opt_in_counts(monkeypatch, value) -> None:
+    monkeypatch.setenv("COMMONS_ALLOW_UNSAFE_FALLBACK", value)
+    with pytest.raises(RuntimeError):
+        protection_mode(NOTHING, sysname="Windows")
+


### PR DESCRIPTION
This PR adds `protection_mode()`, which decides before an agent is built whether this host can sandbox the code execution worker, and the 8 GiB address-space cap the worker puts on itself at startup. Nothing calls the gate yet; `run_python` registration wires it in.

<details>
<summary>Agent-written detail</summary>

`sandbox_capabilities()` is the shape the four ctypes probes fill in. Until they exist it reports every mechanism unavailable, so the gate refuses every host. That is why it is not wired into `Commons.__init__` here: doing so now would abort construction everywhere, for a tool that is not registered yet.

Two departures from `run_r_protection_mode()`. The opt-in is `COMMONS_ALLOW_UNSAFE_FALLBACK` rather than an option, and there is deliberately no keyword for it, so accepting weaker protection takes an act outside the code. Only the address-space limit is set, not a CPU limit: `RLIMIT_CPU` is cumulative over the worker's whole life, so a long session would be killed mid-call rather than hit the parent's per-call timeout. Noted on kata `t7d4`.

A kernel that will not set `RLIMIT_AS` is reported rather than treated as fatal. Recent macOS is such a kernel, so the three clamp tests skip locally and run on the Ubuntu leg of CI.

roborev flagged the protection-mode decision table as a cross-language contract held twice, once per suite. Fixing it here would pull `pkg-r/` into a Python-only task, so kata `dkev`, which already owns the shared sandbox fixture, has been widened to cover the table.
</details>
