### PR TITLE
Situate Python measure tool results with the standard measure display

### DIFF
--- a/pkg-py/demo.py
+++ b/pkg-py/demo.py
@@ -30,11 +30,12 @@ import os
 from functools import cache
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import Any
+from typing import Annotated, Any
 
 import chatlas
 import pandas as pd
 import shinychat
+from pydantic import Field
 from shiny import App, Inputs, Outputs, Session
 
 import commons
@@ -128,8 +129,15 @@ def shared_notes_file() -> Path:
 
 
 @commons.measure(
+    # Past the card's clamp length on purpose: the chat UI collapses a long
+    # description like this behind a "See more" disclosure.
     description=(
-        "Acre-weighted canopy cover for each county, from the most recent survey."
+        "Acre-weighted canopy cover for each county, from the most recent "
+        "survey. Each stand counts in proportion to its acreage, so a "
+        "400-acre unit does not move the figure the way a 4,000-acre one "
+        "does. Established stands only: regeneration units are tracked "
+        "separately until they close canopy. When several survey years are "
+        "present, only the most recent one enters."
     )
 )
 def canopy_by_county(warehouse: commons.Injected[Any]) -> pd.DataFrame:
@@ -161,6 +169,50 @@ def low_canopy_stands(warehouse: commons.Injected[Any]) -> pd.DataFrame:
     ).fetchdf()
 
 
+@commons.measure(
+    description=(
+        "A county's current canopy cover as one headline figure, drawn as a "
+        "card. Use when someone asks for a headline, big number, or summary "
+        "readout for a single county."
+    ),
+    title="Canopy headline",
+)
+def canopy_headline(
+    county: Annotated[str, Field(description="The county to summarize.")],
+    warehouse: commons.Injected[Any],
+) -> chatlas.ContentToolResult:
+    # A measure returning a ContentToolResult authors its own HTML; commons
+    # frames it inside the standard card, after the metadata and arguments.
+    pct, acres = warehouse.execute(
+        """
+        SELECT SUM(canopy_pct * acres) / SUM(acres) AS canopy_pct,
+               SUM(acres) AS acres
+        FROM stands JOIN surveys USING (stand_id)
+        WHERE county = ? AND status = 'established'
+          AND survey_year = (SELECT MAX(survey_year) FROM surveys)
+        """,
+        [county],
+    ).fetchone()
+    return chatlas.ContentToolResult(
+        value=(
+            f"{county} County: {pct:.1f}% canopy cover across "
+            f"{acres:,.0f} established acres, 2026 survey."
+        ),
+        extra={
+            "display": {
+                "html": (
+                    "<div style='text-align: center; padding: 0.5rem 0'>"
+                    f"<div style='font-size: 2.5rem; font-weight: 300'>"
+                    f"{pct:.0f}%</div>"
+                    f"<div>canopy cover across {acres:,.0f} "
+                    "established acres</div>"
+                    "</div>"
+                )
+            }
+        },
+    )
+
+
 def client() -> chatlas.Chat:
     """A chat client, from `CHATLAS_CHAT_PROVIDER_MODEL` when it is set."""
     return chatlas.ChatAuto(os.getenv("CHATLAS_CHAT_PROVIDER_MODEL") or DEFAULT_MODEL)
@@ -172,7 +224,9 @@ def agent() -> commons.Commons:
         client(),
         # Named, because a measure's `warehouse` argument is injected by name.
         {"warehouse": commons.data_source(stands=stands, surveys=surveys)},
-        semantic_layer=commons.semantic_layer(canopy_by_county, low_canopy_stands),
+        semantic_layer=commons.semantic_layer(
+            canopy_by_county, low_canopy_stands, canopy_headline
+        ),
         context_layer=commons.context_layer(files=[shared_notes_file()]),
     )
 
@@ -181,6 +235,8 @@ QUESTIONS = [
     # Covered by a measure, so the answer should come back verified.
     "Which county has the most canopy cover?",
     "Which stands have the least canopy cover?",
+    # Covered by a measure that draws its own card.
+    "Draw a canopy headline for Lane County.",
     # No measure covers a single stand's change over time, so this one has to
     # reach run_sql, and the answer is untrusted or cited instead.
     "How much canopy has Winberry Ridge gained since 2021?",

--- a/pkg-py/src/commons/_display.py
+++ b/pkg-py/src/commons/_display.py
@@ -16,7 +16,7 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any, cast
 
-from htmltools import Tag, TagChild, TagList, div, tags
+from htmltools import HTML, Tag, TagChild, TagList, div, tags
 
 from ._frames import is_frame
 from ._rows import MAX_MARKDOWN_ROWS, frame_rows, render_value
@@ -32,6 +32,7 @@ __all__ = [
     "TRUSTED_SEARCH",
     "Title",
     "measure_display_html",
+    "measure_display_with_custom_html",
     "measure_source_footer",
     "tool_display",
     "visible_result_note",
@@ -126,6 +127,38 @@ def measure_display_html(
     )
 
 
+def measure_display_with_custom_html(
+    args: Mapping[str, Any],
+    html: Any,
+    *,
+    title: str | None = None,
+    description: str | None = None,
+) -> Tag:
+    """The standard measure card around HTML a measure authored for itself.
+
+    What commons knows heads the card -- the measure's metadata and the
+    arguments it ran with -- and the authored markup is the result. A string
+    is markup the measure wrote, not text to escape; a tag tree keeps the
+    dependencies attached to it.
+    """
+    if isinstance(html, str):
+        html = HTML(html)
+    return div(
+        _metadata_html(title, description),
+        _args_html(args),
+        div(
+            tags.strong("Result"),
+            div(
+                html,
+                class_="commons-measure-result-value "
+                "commons-measure-result-value-authored",
+            ),
+            class_="commons-measure-result",
+        ),
+        class_="commons-measure-display",
+    )
+
+
 def measure_source_footer(provenance: Iterable[str]) -> TagList | None:
     """Links back to wherever the measure's definition came from.
 
@@ -150,18 +183,43 @@ def measure_source_footer(provenance: Iterable[str]) -> TagList | None:
     )
 
 
+# Roughly three lines at chat-card width; the stylesheet supplies the exact
+# clamp, so a description longer than this is repeated behind a disclosure.
+_DETAILS_THRESHOLD = 200
+
+
 def _metadata_html(title: str | None, description: str | None) -> Tag | None:
     if not title:
         return None
+    details = (
+        description if description and len(description) > _DETAILS_THRESHOLD else None
+    )
     return div(
         div(
             tags.strong(title, class_="commons-measure-title"),
-            div(description, class_="commons-measure-description")
+            div(
+                description,
+                class_="commons-measure-description"
+                + (" commons-measure-description-summary" if details else ""),
+            )
             if description
             else None,
+            _details_html(details) if details else None,
             class_="commons-measure-metadata-item",
         ),
         class_="commons-measure-metadata",
+    )
+
+
+def _details_html(details: str) -> Tag:
+    """A long description behind a See more disclosure the stylesheet fades in."""
+    return tags.details(
+        tags.summary(
+            tags.span("See more", class_="commons-measure-details-more"),
+            tags.span("See less", class_="commons-measure-details-less"),
+        ),
+        div(details, class_="commons-measure-details-body"),
+        class_="commons-measure-details",
     )
 
 

--- a/pkg-py/src/commons/_tools.py
+++ b/pkg-py/src/commons/_tools.py
@@ -43,6 +43,7 @@ from ._display import (
     TRUSTED_CALL,
     TRUSTED_SEARCH,
     measure_display_html,
+    measure_display_with_custom_html,
     measure_source_footer,
     tool_display,
     visible_result_note,
@@ -309,7 +310,7 @@ def _call_measure(context: ToolContext) -> Tool:
         # table — has already said how it should look; commons only fills in
         # what it alone knows.
         if isinstance(value, ContentToolResult):
-            return _finish_measure_result(value, record, context)
+            return _finish_measure_result(value, record, context, args)
         advert = context.handles.register(value)
         body = "\n\n".join(
             part for part in (_format_measure_value(value), advert) if part
@@ -347,7 +348,10 @@ def _call_measure(context: ToolContext) -> Tool:
 
 
 def _finish_measure_result(
-    result: ContentToolResult, record: Measure, context: ToolContext
+    result: ContentToolResult,
+    record: Measure,
+    context: ToolContext,
+    args: Mapping[str, Any],
 ) -> ContentToolResult:
     """Fill in what commons knows about a result a measure built for itself.
 
@@ -363,7 +367,10 @@ def _finish_measure_result(
     extra = dict(result.extra or {})
     data = extra.pop("data", None)
     display = _defaulted(
-        extra.get(DISPLAY_EXTRA_KEY), measure_source_footer(record.provenance)
+        extra.get(DISPLAY_EXTRA_KEY),
+        measure_source_footer(record.provenance),
+        args,
+        record,
     )
     extra[DISPLAY_EXTRA_KEY] = display
     # The tag is commons' to set, so a measure never keeps one it supplied.
@@ -392,8 +399,15 @@ def _display_field(display: Any, name: str) -> Any:
     return getattr(display, name, None)
 
 
-def _defaulted(display: Any, footer: Any) -> Any:
-    """Fill a display's title and footer, unless the measure chose its own."""
+def _defaulted(
+    display: Any, footer: Any, args: Mapping[str, Any], record: Measure
+) -> Any:
+    """Fill a display's title and footer, unless the measure chose its own.
+
+    The request is never shown -- the arguments commons sends a tool are its
+    own plumbing -- and HTML the measure authored is framed inside the
+    standard measure card, after the measure's metadata and arguments.
+    """
     defaults = {"title": TRUSTED_CALL.settled, "footer": footer}
     if display is None:
         return tool_display(TRUSTED_CALL.settled, footer=footer)
@@ -402,13 +416,25 @@ def _defaulted(display: Any, footer: Any) -> Any:
         for name, default in defaults.items():
             if filled.get(name) is None:
                 filled[name] = default
+        filled["show_request"] = False
+        if filled.get("html") is not None:
+            filled["html"] = _framed_html(args, filled["html"], record)
         return filled
     # A shinychat ToolResultDisplay, which its own documentation recommends
     # over the mapping commons builds.
     for name, default in defaults.items():
         if getattr(display, name, None) is None:
             setattr(display, name, default)
+    display.show_request = False
+    if getattr(display, "html", None) is not None:
+        display.html = _framed_html(args, display.html, record)
     return display
+
+
+def _framed_html(args: Mapping[str, Any], html: Any, record: Measure) -> Any:
+    return measure_display_with_custom_html(
+        args, html, title=record.title, description=record.description
+    )
 
 
 def _parse_json_arguments(arguments: Any) -> dict[str, Any]:

--- a/pkg-py/tests/test_measure_html.py
+++ b/pkg-py/tests/test_measure_html.py
@@ -60,6 +60,28 @@ def test_a_measures_title_and_description_head_the_card() -> None:
     assert "After refunds." in html
 
 
+def test_a_long_description_collapses_behind_a_disclosure() -> None:
+    description = "A detailed description of the measure. " * 8
+
+    html = rendered(
+        measure_display_html({}, 41, title="Net revenue", description=description)
+    )
+
+    assert "commons-measure-description-summary" in html
+    assert "commons-measure-details-more" in html
+    assert "commons-measure-details-less" in html
+    assert "commons-measure-details-body" in html
+    assert "See more" in html
+
+
+def test_a_short_description_needs_no_disclosure() -> None:
+    html = rendered(
+        measure_display_html({}, 41, title="Net revenue", description="After refunds.")
+    )
+
+    assert "commons-measure-details" not in html
+
+
 def test_markup_in_a_value_is_shown_rather_than_rendered() -> None:
     html = rendered(measure_display_html({}, "<script>alert(1)</script>"))
 

--- a/pkg-py/tests/test_tool_display.py
+++ b/pkg-py/tests/test_tool_display.py
@@ -249,6 +249,99 @@ def test_a_measure_may_use_shinychats_own_display_class() -> None:
     assert "already visible to the user" in str(result.value)
 
 
+def test_a_measure_cannot_turn_the_request_back_on() -> None:
+    """The arguments commons sends a tool are its own plumbing."""
+    result = measure_result(display={"markdown": "**41**", "show_request": True})
+
+    assert shown(result).show_request is False
+
+
+def test_authored_html_is_framed_inside_the_measure_card() -> None:
+    """Custom HTML sits in the standard card, after metadata and arguments."""
+
+    @measure(description="Summarize adverse events.", title="Adverse events")
+    def events(
+        population: Annotated[str, Field(description="Analysis population.")],
+    ) -> ContentToolResult:
+        return ContentToolResult(
+            value="Headache: 7",
+            extra={
+                "display": {
+                    "html": "<table><tr><td>Headache</td></tr></table>",
+                    "open": True,
+                    "full_screen": True,
+                }
+            },
+        )
+
+    found = as_measure(events)
+    assert found is not None
+    built = tools(measures={found.name: found})
+
+    result = find(built, "call_measure").func(
+        name="events", arguments='{"population": "ITT"}'
+    )
+    assert isinstance(result, ContentToolResult)
+    display = shown(result)
+    html = markup(display.html)
+
+    assert "commons-measure-display" in html
+    assert "Adverse events" in html
+    assert "Summarize adverse events." in html
+    assert "Population:" in html
+    assert "ITT" in html
+    assert "<strong>Result</strong>" in html
+    assert "commons-measure-result-value-authored" in html
+    # Authored markup is rendered, not escaped.
+    assert "<table>" in html
+    assert display.open is True
+    assert display.full_screen is True
+    assert display.show_request is False
+
+
+def test_authored_html_keeps_the_dependencies_attached_to_it() -> None:
+    from htmltools import HTMLDependency, TagList, tags
+    from htmltools import Tag as HtmlTag
+
+    dependency = HTMLDependency(
+        "measure-table",
+        "1.0.0",
+        source={"href": "measure-table"},
+        stylesheet={"href": "table.css"},
+    )
+    table = TagList(tags.table(tags.tr(tags.td("Headache"))), dependency)
+
+    display = shown(measure_result(display={"html": table}))
+
+    assert isinstance(display.html, HtmlTag)
+    assert [d.name for d in display.html.get_dependencies()] == ["measure-table"]
+
+
+def test_authored_html_on_shinychats_display_class_is_framed() -> None:
+    result = measure_result(display=ToolResultDisplay(html="<p>custom</p>"))
+
+    display = shown(result)
+
+    assert "commons-measure-result-value-authored" in markup(display.html)
+    assert display.show_request is False
+
+
+def test_a_long_measure_description_can_be_expanded() -> None:
+    @measure(description="A detailed description of the measure. " * 8)
+    def orders() -> int:
+        return 1
+
+    found = as_measure(orders)
+    assert found is not None
+    built = tools(measures={found.name: found})
+
+    html = markup(ran(built, "call_measure", name="orders", arguments="{}").html)
+
+    assert "commons-measure-description-summary" in html
+    assert "commons-measure-details-more" in html
+    assert "commons-measure-details-less" in html
+
+
 # ---- the card behind a trusted calculation --------------------------------
 
 


### PR DESCRIPTION
Stacks on #350. Emits the classes its stylesheet added: long measure descriptions collapse behind a See more disclosure, and measure-authored HTML is framed in the standard card (metadata, arguments, Result) with `show_request` off.

Here's how it renders in the demo with `"open": True` in the display options:

<img width="1738" height="1118" alt="image" src="https://github.com/user-attachments/assets/942586b1-9b2e-4e02-84af-6534fb09f09b" />
