### PR TITLE
feat(py): the Landlock filesystem sandbox for the worker

### DIFF
--- a/pkg-py/src/commons/_execution/_runtime/__init__.py
+++ b/pkg-py/src/commons/_execution/_runtime/__init__.py
@@ -1,8 +1,9 @@
 """What runs inside the worker process, and nothing else.
 
-Every module here mutates the process it is imported into: it lowers resource
-limits, engages a sandbox on itself, and takes over stdout. Importing one from
-the parent would restrict the parent. Nothing here imports ``commons``, which
-is what lets the worker be launched by absolute path on an interpreter that
-has never heard of the package.
+The modules here restrict the process they are used from: they lower
+resource limits, engage a sandbox on it, and take over stdout. Importing one
+is inert and the parent does read a capability probe from here, but calling
+anything that restricts belongs in the child. Nothing here imports
+``commons``, which is what lets the worker be launched by absolute path on
+an interpreter that has never heard of the package.
 """

--- a/pkg-py/src/commons/_execution/_runtime/_landlock.py
+++ b/pkg-py/src/commons/_execution/_runtime/_landlock.py
@@ -1,0 +1,300 @@
+"""The Landlock filesystem sandbox, reached through ``ctypes``.
+
+Landlock has no libc wrapper, so the three syscalls are made by number
+through ``syscall()``.
+
+``engage()`` restricts the calling process and cannot be undone, so importing
+this module does nothing on its own. Enforcement afterwards is the kernel's,
+not this code's.
+
+``landlock_engage()`` in ``pkg-r/src/sandbox.c`` makes the same calls in the
+same order.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import errno
+import os
+import platform
+import sys
+from collections.abc import Iterable
+
+__all__ = [
+    "FS_EXECUTE",
+    "FS_IOCTL_DEV",
+    "FS_MAKE_REG",
+    "FS_READ_DIR",
+    "FS_READ_FILE",
+    "FS_READ_ONLY",
+    "FS_REFER",
+    "FS_REMOVE_FILE",
+    "FS_TRUNCATE",
+    "FS_WRITE_FILE",
+    "PathBeneathAttr",
+    "abi_version",
+    "engage",
+    "handled_access",
+]
+
+NR_CREATE_RULESET = 444
+NR_ADD_RULE = 445
+NR_RESTRICT_SELF = 446
+
+# Those numbers come from the table most architectures share for syscalls
+# added since 2019, but not all: mips offsets its whole table by thousands,
+# so 444 there is a different call entirely. Calling a syscall by the wrong
+# number is worse than not calling it, so this is an allowlist of the
+# architectures the numbers are known to hold for, and anything else reports
+# no Landlock and falls back.
+KNOWN_ARCHITECTURES = frozenset({"x86_64", "amd64", "aarch64", "arm64"})
+
+CREATE_RULESET_VERSION = 1 << 0
+RULE_PATH_BENEATH = 1
+
+PR_SET_NO_NEW_PRIVS = 38
+
+# Defined here rather than read from ``os``, which only carries it on Linux,
+# alongside the other kernel constants this module spells out.
+O_PATH = 0o10000000
+
+FS_EXECUTE = 1 << 0
+FS_WRITE_FILE = 1 << 1
+FS_READ_FILE = 1 << 2
+FS_READ_DIR = 1 << 3
+FS_REMOVE_FILE = 1 << 5
+FS_MAKE_REG = 1 << 8
+# Every right ABI 1 defines, which is bits 0 through 12.
+FS_V1_ALL = (1 << 13) - 1
+FS_REFER = 1 << 13
+FS_TRUNCATE = 1 << 14
+FS_IOCTL_DEV = 1 << 15
+
+# What a read root is granted. Running a file counts as reading it, and a
+# directory has to be listable for an import to find anything in it.
+FS_READ_ONLY = FS_EXECUTE | FS_READ_FILE | FS_READ_DIR
+
+# A kernel that has no Landlock, or that is behind a policy forbidding it,
+# is a kernel to fall back from rather than fail on.
+_UNAVAILABLE = frozenset({errno.ENOSYS, errno.EOPNOTSUPP, errno.EPERM})
+
+
+class RulesetAttr(ctypes.Structure):
+    """The ABI 1 ruleset attribute.
+
+    Later versions append fields for network rights and scoping. The struct
+    is extensible and read at the size it is given, so passing this one asks
+    for a filesystem-only ruleset on any kernel.
+    """
+
+    _fields_ = (("handled_access_fs", ctypes.c_uint64),)
+
+
+class PathBeneathAttr(ctypes.Structure):
+    """One rule: an access mask and the directory it applies beneath.
+
+    Packed, and 12 bytes rather than the 16 natural alignment would give.
+    The kernel checks the size it was handed against its own definition.
+    """
+
+    _pack_ = 1
+    _fields_ = (
+        ("allowed_access", ctypes.c_uint64),
+        ("parent_fd", ctypes.c_int32),
+    )
+
+
+# Syscall numbers are per-kernel and per-architecture, so making these calls
+# anywhere else would not fail to find Landlock, it would invoke whatever
+# that number means on the host instead. Everything below therefore refuses
+# to run outside the pairs the numbers are known for, rather than trusting
+# the call to come back with ENOSYS.
+ON_LINUX = sys.platform == "linux" and platform.machine().lower() in (
+    KNOWN_ARCHITECTURES
+)
+
+_libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True) if ON_LINUX else None
+if _libc is not None:
+    # syscall() returns long; ctypes would otherwise truncate to int.
+    _libc.syscall.restype = ctypes.c_long
+
+
+def _syscall(number: int, *args: object) -> int:
+    """Make a raw syscall, returning its result and leaving errno set.
+
+    ``argtypes`` is left unset and every argument passed explicitly typed,
+    because ``syscall()`` is variadic, and ctypes would otherwise promote
+    values by its own rules rather than the kernel's.
+    """
+    assert _libc is not None
+    ctypes.set_errno(0)
+    return _libc.syscall(ctypes.c_long(number), *args)
+
+
+def _set_no_new_privs() -> None:
+    """Give up the ability to gain privileges, as Landlock requires.
+
+    Landlock refuses to restrict an unprivileged process that could still
+    become privileged through a setuid binary. Seccomp needs the same flag
+    and setting it twice is harmless, so it belongs with whichever
+    restriction runs first rather than in a caller both have to remember.
+    """
+    assert _libc is not None
+    ctypes.set_errno(0)
+    if _libc.prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0):
+        code = ctypes.get_errno()
+        raise OSError(code, f"prctl(PR_SET_NO_NEW_PRIVS) failed: {os.strerror(code)}")
+
+
+def handled_access(abi: int) -> int:
+    """Every filesystem right a ruleset should handle on this ABI.
+
+    Landlock leaves a right the ruleset does not handle entirely
+    unrestricted, so the mask grows with the ABI the kernel reports rather
+    than being fixed at one version's rights. ABI 4 adds network rights,
+    which a filesystem ruleset does not handle, so it adds nothing here.
+
+    ABI 5 is the newest that adds a filesystem right. A kernel reporting
+    more than that is handled as 5, which means a filesystem right added by
+    some later ABI would go unhandled, and therefore unrestricted, until
+    this table learns about it. ABI 6, 7 and 8 exist and add none, so the
+    table is complete today; kata `ctv9` tracks re-checking it. Declining
+    Landlock on an unrecognised ABI was considered and rejected: it would
+    give up a working sandbox on every future kernel to guard against a
+    right that does not exist yet.
+    """
+    handled = FS_V1_ALL
+    if abi >= 2:
+        handled |= FS_REFER
+    if abi >= 3:
+        handled |= FS_TRUNCATE
+    if abi >= 5:
+        handled |= FS_IOCTL_DEV
+    return handled
+
+
+def abi_version() -> int:
+    """The Landlock ABI this kernel reports, or ``-1`` where there is none."""
+    if not ON_LINUX:
+        return -1
+    version = _syscall(
+        NR_CREATE_RULESET, ctypes.c_void_p(None), ctypes.c_size_t(0),
+        ctypes.c_uint32(CREATE_RULESET_VERSION)
+    )
+    return version if version >= 0 else -1
+
+
+def _grant(ruleset_fd: int, path: str, access: int) -> None:
+    """Add one path-beneath rule, or do nothing if the path is not there.
+
+    A missing root is skipped rather than fatal. The read roots are the
+    places an interpreter might keep its libraries and which of them exist
+    varies by host, so refusing to start over one would be a sandbox that
+    fails into not running at all. Not granting a path can only narrow what
+    the worker reaches.
+    """
+    try:
+        parent = os.open(path, O_PATH | os.O_CLOEXEC)
+    except FileNotFoundError:
+        return
+    try:
+        rule = PathBeneathAttr(allowed_access=access, parent_fd=parent)
+        if _syscall(
+            NR_ADD_RULE,
+            ctypes.c_int(ruleset_fd),
+            ctypes.c_int(RULE_PATH_BENEATH),
+            ctypes.byref(rule),
+            ctypes.c_uint32(0),
+        ):
+            raise OSError(
+                ctypes.get_errno(),
+                f"landlock_add_rule failed for {path!r}: "
+                f"{os.strerror(ctypes.get_errno())}",
+            )
+    finally:
+        os.close(parent)
+
+
+def _roots(paths: Iterable[str]) -> list[str]:
+    """Each path, what it resolves to, and where its entries lead.
+
+    Landlock matches the hierarchy a path resolves to, not the path as
+    written, so a rule naming a symlink grants nothing about the content
+    behind it. Connect gives a deployed application a package library whose
+    entries are symlinks into a shared store, and granting the library
+    directory alone leaves every package in it unreadable. Resolving one
+    level down is what covers that, and it is the same level
+    ``worker_init()`` resolves in pkg-r.
+
+    Deeper than one level is not walked: a store is granted whole once its
+    first entry points into it, and walking a large tree at startup would
+    cost more than the rules it produced.
+    """
+    resolved: dict[str, None] = {}
+    for path in paths:
+        resolved[path] = None
+        resolved[os.path.realpath(path)] = None
+        try:
+            entries = os.scandir(path)
+        except OSError:
+            # Unreadable or absent roots simply grant nothing.
+            continue
+        with entries:
+            for entry in entries:
+                if entry.is_symlink():
+                    resolved[os.path.realpath(entry.path)] = None
+    return list(resolved)
+
+
+def engage(read_roots: Iterable[str], write_roots: Iterable[str]) -> int | None:
+    """Restrict this process to ``read_roots`` and ``write_roots``.
+
+    Returns the ABI version the restriction was built for. Returns ``None``
+    when this kernel has no Landlock to engage, which is the caller's signal
+    to try another backend rather than an error: the user-namespace sandbox
+    covers kernels too old for this one.
+
+    Raises ``OSError`` when a kernel that does have Landlock refuses a step,
+    since that is a broken host rather than an old one.
+
+    Read roots are granted execute, read-file and read-dir. Write roots are
+    granted everything the ruleset handles. Once this returns, nothing can
+    widen the process's access again, including anything it goes on to
+    execute.
+    """
+    abi = abi_version()
+    if abi < 1:
+        return None
+
+    _set_no_new_privs()
+
+    handled = handled_access(abi)
+    attr = RulesetAttr(handled_access_fs=handled)
+    ruleset_fd = _syscall(
+        NR_CREATE_RULESET,
+        ctypes.byref(attr),
+        ctypes.c_size_t(ctypes.sizeof(attr)),
+        ctypes.c_uint32(0),
+    )
+    if ruleset_fd < 0:
+        code = ctypes.get_errno()
+        if code in _UNAVAILABLE:
+            return None
+        raise OSError(
+            code, f"landlock_create_ruleset failed: {os.strerror(code)}"
+        )
+
+    try:
+        for path in _roots(read_roots):
+            _grant(ruleset_fd, path, FS_READ_ONLY)
+        for path in _roots(write_roots):
+            _grant(ruleset_fd, path, handled)
+        if _syscall(NR_RESTRICT_SELF, ctypes.c_int(ruleset_fd), ctypes.c_uint32(0)):
+            code = ctypes.get_errno()
+            raise OSError(
+                code, f"landlock_restrict_self failed: {os.strerror(code)}"
+            )
+    finally:
+        os.close(ruleset_fd)
+    return abi

--- a/pkg-py/src/commons/_execution/_sandbox.py
+++ b/pkg-py/src/commons/_execution/_sandbox.py
@@ -18,7 +18,7 @@ import platform
 from dataclasses import dataclass
 from typing import Literal
 
-from ._runtime import _seccomp
+from ._runtime import _landlock, _seccomp
 
 __all__ = [
     "ALLOW_UNSAFE_FALLBACK",
@@ -76,15 +76,14 @@ def _seatbelt_present() -> bool:
 def sandbox_capabilities() -> SandboxCapabilities:
     """Probe this host for each mechanism the worker can restrict itself with.
 
-    Each field is filled in by the module that implements its mechanism.
-    Landlock and user namespaces have no implementation yet and report
-    unavailable until they do, so ``protection_mode()`` still refuses every
-    Linux host: seccomp alone is not enough without a filesystem sandbox
-    beside it, which is the safe direction to be wrong in while those are
-    being built.
+    Each field is answered by the module that implements its mechanism. Only
+    user namespaces have no implementation yet and report unavailable until
+    they do, which costs nothing on a kernel that offers Landlock and is the
+    safe direction to be wrong in on one that does not. Probing is read-only,
+    so this leaves the calling process as unrestricted as it found it.
     """
     return SandboxCapabilities(
-        landlock_abi=-1,
+        landlock_abi=_landlock.abi_version(),
         seccomp=_seccomp.seccomp_available(),
         seatbelt=_seatbelt_present(),
         userns=False,

--- a/pkg-py/tests/test_execution_landlock.py
+++ b/pkg-py/tests/test_execution_landlock.py
@@ -1,0 +1,306 @@
+"""The Landlock filesystem sandbox the worker engages on itself.
+
+What matters about a sandbox is what the kernel refuses afterwards, so the
+cases that count run a real interpreter on a real kernel and ask it to try
+things. On a host that is not Linux that kernel comes from a container; where
+neither can supply one they skip rather than assert something weaker.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import functools
+import json
+import pathlib
+import platform
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+from commons._execution._runtime import _landlock
+
+RUNTIME_DIR = str(pathlib.Path(_landlock.__file__).parent)
+
+# Any Landlock-capable kernel would do. This image is small and matches the
+# interpreter the package targets.
+IMAGE = "python:3.13-slim"
+
+ABI_PROBE = "import _landlock, sys; sys.exit(0 if _landlock.abi_version() >= 1 else 1)"
+
+
+def _host_has_landlock() -> bool:
+    return platform.system() == "Linux" and _landlock.abi_version() >= 1
+
+
+@functools.cache
+def _docker_has_landlock() -> bool:
+    """Whether a container on this machine can reach Landlock.
+
+    Asks the kernel through the same code under test rather than inferring it
+    from a version string: a daemon can be running, and its kernel can still
+    have Landlock compiled out or fenced off by a seccomp profile.
+    """
+    if shutil.which("docker") is None:
+        return False
+    return (
+        subprocess.run(
+            _docker_command(ABI_PROBE), capture_output=True, check=False
+        ).returncode
+        == 0
+    )
+
+
+def _docker_command(script: str) -> list[str]:
+    return [
+        "docker",
+        "run",
+        "--rm",
+        "-v",
+        f"{RUNTIME_DIR}:/runtime:ro",
+        "-e",
+        "PYTHONPATH=/runtime",
+        IMAGE,
+        "python",
+        "-c",
+        script,
+    ]
+
+
+def run_on_a_landlock_kernel(script: str) -> dict:
+    """Run ``script`` where Landlock exists, and read the JSON it prints.
+
+    Prefers this host and falls back to a container, so the same case gives
+    real coverage on a Linux CI runner and on a macOS laptop running Docker.
+    """
+    if _host_has_landlock():
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            env={"PYTHONPATH": RUNTIME_DIR},
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    else:
+        completed = subprocess.run(
+            _docker_command(script), capture_output=True, text=True, check=True
+        )
+    return json.loads(completed.stdout)
+
+
+landlock_kernel = pytest.mark.skipif(
+    not (_host_has_landlock() or _docker_has_landlock()),
+    reason="no Landlock-capable kernel available, on this host or through Docker",
+)
+
+# Reporting the exception's type rather than a bare "denied" keeps a case
+# honest: a setup mistake surfaces as FileNotFoundError instead of passing as
+# the refusal the test was hoping for.
+ATTEMPT = """
+def attempt(action):
+    try:
+        action()
+    except OSError as error:
+        return type(error).__name__
+    return "allowed"
+
+
+def read(directory):
+    return attempt(lambda: open(os.path.join(directory, "existing.txt")).close())
+
+
+def write(directory):
+    return attempt(lambda: open(os.path.join(directory, "new.txt"), "w").close())
+"""
+
+PROBE = (
+    """
+import json, os, sys, tempfile
+import _landlock
+
+# A fresh base each run: these probes engage a sandbox they cannot undo, so
+# they cannot clean up after themselves, and a fixed path would collide with
+# the run before it.
+base = tempfile.mkdtemp()
+readable = os.path.join(base, "readable")
+scratch = os.path.join(base, "scratch")
+outside = os.path.join(base, "outside")
+for directory in (readable, scratch, outside):
+    os.makedirs(directory)
+    with open(os.path.join(directory, "existing.txt"), "w") as handle:
+        handle.write("contents")
+
+# /usr is granted so the interpreter can still reach its own standard library
+# once the ruleset is in force.
+abi = _landlock.engage(["/usr", readable], [scratch])
+"""
+    + ATTEMPT
+    + """
+json.dump(
+    {
+        "abi": abi,
+        "read_readable": read(readable),
+        "write_readable": write(readable),
+        "read_scratch": read(scratch),
+        "write_scratch": write(scratch),
+        "read_outside": read(outside),
+        "write_outside": write(outside),
+        "still_running": sum(range(11)),
+    },
+    sys.stdout,
+)
+"""
+)
+
+
+@pytest.fixture(scope="module")
+def probe() -> dict:
+    return run_on_a_landlock_kernel(PROBE)
+
+
+@landlock_kernel
+def test_a_read_root_can_be_read_but_not_written(probe) -> None:
+    assert probe["read_readable"] == "allowed"
+    assert probe["write_readable"] == "PermissionError"
+
+
+@landlock_kernel
+def test_the_write_root_can_be_both_read_and_written(probe) -> None:
+    assert probe["read_scratch"] == "allowed"
+    assert probe["write_scratch"] == "allowed"
+
+
+@landlock_kernel
+def test_a_directory_in_no_rule_is_reachable_neither_way(probe) -> None:
+    assert probe["read_outside"] == "PermissionError"
+    assert probe["write_outside"] == "PermissionError"
+
+
+@landlock_kernel
+def test_the_worker_keeps_running_once_restricted(probe) -> None:
+    assert probe["still_running"] == 55
+
+
+@landlock_kernel
+def test_engage_reports_the_abi_it_restricted_the_process_with(probe) -> None:
+    assert probe["abi"] >= 1
+
+
+SYMLINK_PROBE = (
+    """
+import json, os, sys, tempfile
+import _landlock
+
+# The shape Connect gives a deployed application: the library directory is
+# real, and every package in it is a symlink into a store somewhere else.
+base = tempfile.mkdtemp()
+store = os.path.join(base, "store", "pkg")
+library = os.path.join(base, "library")
+scratch = os.path.join(base, "scratch")
+os.makedirs(store)
+os.makedirs(library)
+os.makedirs(scratch)
+with open(os.path.join(store, "existing.txt"), "w") as handle:
+    handle.write("contents")
+os.symlink(store, os.path.join(library, "pkg"))
+
+# Only the library is granted, which is what a caller listing sys.path would
+# pass. Reaching the package means resolving the entry beneath it.
+_landlock.engage(["/usr", library], [scratch])
+"""
+    + ATTEMPT
+    + """
+json.dump(
+    {
+        "through_the_link": read(os.path.join(library, "pkg")),
+        "at_the_store": read(store),
+    },
+    sys.stdout,
+)
+"""
+)
+
+
+@landlock_kernel
+def test_a_package_symlinked_into_a_store_is_readable_through_its_library(
+) -> None:
+    """Granting the library alone leaves every package in it unreadable.
+
+    Landlock matches the hierarchy a path resolves to, so a rule naming the
+    library grants nothing about a store its entries point into. This is
+    the shape a Connect deployment has, and getting it wrong fails as an
+    import error rather than as anything about sandboxing.
+    """
+    reported = run_on_a_landlock_kernel(SYMLINK_PROBE)
+    assert reported["through_the_link"] == "allowed"
+    assert reported["at_the_store"] == "allowed"
+
+
+MISSING_ROOT_PROBE = (
+    """
+import json, os, sys, tempfile
+import _landlock
+
+base = tempfile.mkdtemp()
+scratch = os.path.join(base, "scratch")
+os.makedirs(scratch)
+abi = _landlock.engage(["/usr", os.path.join(base, "not-here")], [scratch])
+"""
+    + ATTEMPT
+    + """
+json.dump({"abi": abi, "write_scratch": write(scratch)}, sys.stdout)
+"""
+)
+
+
+@landlock_kernel
+def test_a_root_that_does_not_exist_is_skipped_rather_than_fatal() -> None:
+    """Granting nothing can only narrow what the worker reaches.
+
+    The read roots are a list of places an interpreter might keep its
+    libraries, and which of them exist varies by host. A missing one that
+    refused to start the worker would be a sandbox that fails open into not
+    running at all.
+    """
+    reported = run_on_a_landlock_kernel(MISSING_ROOT_PROBE)
+    assert reported["abi"] >= 1
+    assert reported["write_scratch"] == "allowed"
+
+
+def test_the_handled_mask_covers_every_right_the_abi_defines() -> None:
+    """Landlock leaves any right the ruleset does not handle unrestricted.
+
+    The mask therefore has to grow with the kernel rather than be fixed at
+    whatever commons was written against.
+    """
+    v1 = _landlock.handled_access(1)
+    assert v1 == (1 << 13) - 1
+    assert _landlock.handled_access(2) == v1 | _landlock.FS_REFER
+    assert _landlock.handled_access(3) == (
+        v1 | _landlock.FS_REFER | _landlock.FS_TRUNCATE
+    )
+    # ABI 4 adds network rights, which a filesystem ruleset does not handle.
+    assert _landlock.handled_access(4) == _landlock.handled_access(3)
+    assert _landlock.handled_access(5) == (
+        _landlock.handled_access(4) | _landlock.FS_IOCTL_DEV
+    )
+
+
+def test_an_abi_newer_than_this_code_knows_is_handled_as_the_newest_known(
+) -> None:
+    assert _landlock.handled_access(99) == _landlock.handled_access(5)
+
+
+def test_the_rule_attribute_is_packed_as_the_kernel_reads_it() -> None:
+    """Natural alignment would pad this to 16 and the kernel would reject it."""
+    assert ctypes.sizeof(_landlock.PathBeneathAttr) == 12
+
+
+def test_a_read_root_is_granted_no_right_that_changes_anything() -> None:
+    assert _landlock.FS_READ_ONLY == (
+        _landlock.FS_EXECUTE | _landlock.FS_READ_FILE | _landlock.FS_READ_DIR
+    )
+    assert _landlock.FS_READ_ONLY & _landlock.FS_WRITE_FILE == 0
+    assert _landlock.FS_READ_ONLY & _landlock.FS_MAKE_REG == 0
+    assert _landlock.FS_READ_ONLY & _landlock.FS_REMOVE_FILE == 0

--- a/pkg-py/tests/test_execution_sandbox.py
+++ b/pkg-py/tests/test_execution_sandbox.py
@@ -12,7 +12,7 @@ import platform
 import pytest
 
 from commons._execution import _sandbox
-from commons._execution._runtime import _seccomp
+from commons._execution._runtime import _landlock, _seccomp
 from commons._execution._sandbox import (
     SandboxCapabilities,
     protection_mode,
@@ -152,3 +152,23 @@ def test_the_probe_takes_its_seccomp_answer_from_the_seccomp_module() -> None:
     report False for, and the suite has to pass there too.
     """
     assert sandbox_capabilities().seccomp is _seccomp.seccomp_available()
+
+
+def test_the_probe_reports_no_landlock_where_the_host_cannot_have_it() -> None:
+    """Landlock is a Linux facility, so everywhere else must report none."""
+    if platform.system() == "Linux":
+        pytest.skip("this host may legitimately have Landlock")
+    assert sandbox_capabilities().landlock_abi == -1
+
+
+@pytest.mark.skipif(
+    _landlock.abi_version() < 1, reason="this kernel has no Landlock to report"
+)
+def test_the_probe_reports_the_landlock_a_capable_kernel_has() -> None:
+    """The gate reads the running kernel rather than a fixed answer.
+
+    A Linux host without Landlock reports -1 legitimately, which is the
+    signal to fall back, so the assertion is guarded by the kernel actually
+    having some.
+    """
+    assert sandbox_capabilities().landlock_abi >= 1


### PR DESCRIPTION
This PR adds `_landlock.engage()`, which restricts the worker to a set of read roots and a writable scratch directory using Landlock, reached through `ctypes` because the three syscalls have no libc wrapper. `sandbox_capabilities()` now asks the kernel for its Landlock ABI instead of reporting the placeholder.

Stacked on #362; review the PRs below it first. Tracks kata `z5gn`.

<details>
<summary>Agent-written detail</summary>

The handled-access mask is built from the ABI the kernel reports, because Landlock leaves any right a ruleset does not handle unrestricted. ABI 5 is the newest that adds a filesystem right, so a newer kernel is handled as 5. That is a real gap if some later ABI adds one, and kata `ctv9` tracks re-checking the table. Declining Landlock above a known ABI was considered and rejected: it gives up a working sandbox on every future kernel to guard against a right that does not exist yet, and it would diverge from `landlock_handled()` in `pkg-r/src/sandbox.c`.

Roots are resolved one level down, not just at the root itself. Landlock matches the hierarchy a path resolves to, so granting a package library whose entries are symlinks into a shared store, which is what Connect gives a deployed application, leaves every package in it unreadable. One level is the same depth `worker_init()` resolves in `pkg-r`.

The syscall numbers are behind an architecture allowlist. 444, 445 and 446 come from the table most architectures share, but mips offsets its whole table, where 444 is a different call. An unlisted architecture reports no Landlock and falls back.

A kernel with no Landlock returns `None` rather than raising, which is what lets the user-namespace backend be chosen. A kernel that has it and then refuses a step raises, since that is a broken host rather than an old one.

Verification: the cases that matter run a real interpreter on a real kernel and ask it to try things, using the host on Linux and a container elsewhere. Locally that was Landlock ABI 8, where reads and writes outside the granted roots come back as `PermissionError`. The symlink case was confirmed to go red without the one-level resolution.
</details>

