### PR TITLE
feat(py): the user-namespace and tmpfs sandbox for Linux

### DIFF
--- a/pkg-py/src/commons/_execution/_env.py
+++ b/pkg-py/src/commons/_execution/_env.py
@@ -22,12 +22,16 @@ __all__ = ["in_container", "interpreter_warning", "worker_command", "worker_env"
 _KEEP = ("PATH", "LANG", "LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH")
 
 
-def worker_env(scratch_dir: str) -> dict[str, str]:
+def worker_env(scratch_dir: str, *, single_thread: bool = False) -> dict[str, str]:
     """Build the worker's environment from an allowlist of the parent's.
 
     ``scratch_dir`` must be an absolute path; it becomes the worker's
     ``HOME`` and ``TMPDIR``, and a relative or empty value would silently
     weaken the guarantee those two provide.
+
+    ``single_thread`` pins the numerical thread pools, which the
+    user-namespace sandbox needs because it cannot be engaged by a process
+    that has already started one. ``needs_single_thread()`` decides.
     """
     if not os.path.isabs(scratch_dir):
         raise ValueError(f"scratch_dir must be an absolute path, got {scratch_dir!r}")
@@ -40,6 +44,11 @@ def worker_env(scratch_dir: str) -> dict[str, str]:
     # of the user's dot files.
     env["HOME"] = scratch_dir
     env["TMPDIR"] = scratch_dir
+    if single_thread:
+        # Values commons chooses rather than parent variables it passes on,
+        # so they are set here rather than added to the allowlist.
+        env["OPENBLAS_NUM_THREADS"] = "1"
+        env["OMP_NUM_THREADS"] = "1"
     return env
 
 

--- a/pkg-py/src/commons/_execution/_runtime/_userns.py
+++ b/pkg-py/src/commons/_execution/_runtime/_userns.py
@@ -1,0 +1,452 @@
+"""The user-namespace and tmpfs sandbox, engaged by the worker on itself.
+
+The Linux sandbox for kernels that cannot offer Landlock. The worker enters a
+new user and mount namespace, pivots into a fresh tmpfs root, and binds back
+only the roots it has been granted, so what it cannot see it cannot reach.
+The same sequence is in ``userns_engage`` in pkg-r/src/sandbox.c.
+
+Importing this module is harmless. Calling ``engage()`` is not, and cannot be
+undone in the process that calls it.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import fcntl
+import os
+import platform
+import re
+import stat
+import warnings
+
+__all__ = [
+    "UsernsError",
+    "UsernsUnavailable",
+    "available",
+    "engage",
+    "map_ids",
+    "mountinfo_paths",
+    "path_in_roots",
+]
+
+CLONE_NEWNS = 0x00020000
+CLONE_NEWUSER = 0x10000000
+
+MS_RDONLY = 1
+MS_NOSUID = 2
+MS_NODEV = 4
+MS_NOEXEC = 8
+MS_REMOUNT = 32
+MS_NOATIME = 1024
+MS_NODIRATIME = 2048
+MS_BIND = 4096
+MS_REC = 16384
+MS_PRIVATE = 1 << 18
+MS_RELATIME = 1 << 21
+
+MNT_DETACH = 2
+
+PR_CAPBSET_DROP = 24
+_CAP_VERSION_3 = 0x20080522
+
+# statvfs numbers the flags a mount carries differently from mount() itself,
+# so carrying them across a remount is a translation rather than a copy.
+_ST_TO_MS = (
+    (2, MS_NOSUID),
+    (4, MS_NODEV),
+    (8, MS_NOEXEC),
+    (1024, MS_NOATIME),
+    (2048, MS_NODIRATIME),
+    (4096, MS_RELATIME),
+)
+
+# glibc exports neither of these, so they go through syscall(). A wrong
+# number would call something else entirely, so an architecture that is not
+# listed reports the sandbox unavailable rather than guessing.
+_SYSCALLS = {
+    "x86_64": {"pivot_root": 155, "capset": 126},
+    "aarch64": {"pivot_root": 41, "capset": 91},
+}
+
+# What the worker pivots into, and where the host root hangs until it is
+# detached. /tmp is the one directory guaranteed to exist to mount over, and
+# nothing of the host's /tmp survives the pivot.
+_SANDBOX_ROOT = "/tmp"
+_OLD_ROOT = "/.commons-oldroot"
+
+# mountinfo escapes space, tab, newline and backslash as three octal digits.
+_OCTAL = re.compile(r"\\([0-7]{3})")
+
+
+class UsernsUnavailable(OSError):
+    """This host will not give the worker a user namespace.
+
+    Raised only where nothing has changed yet, so the caller is free to
+    report an unsupported host and carry on deciding what to do. Container
+    seccomp profiles and a zeroed user.max_user_namespaces land here.
+    """
+
+
+class UsernsError(OSError):
+    """A step failed once the process had already been changed.
+
+    There is no recovering from this and no falling back: ``unshare()``
+    cannot be undone, so the process is left in a namespace whose ids or
+    mounts are not what they were meant to be. It must die.
+    """
+
+
+class _CapHeader(ctypes.Structure):
+    _fields_ = [("version", ctypes.c_uint32), ("pid", ctypes.c_int)]
+
+
+class _CapData(ctypes.Structure):
+    _fields_ = [
+        ("effective", ctypes.c_uint32),
+        ("permitted", ctypes.c_uint32),
+        ("inheritable", ctypes.c_uint32),
+    ]
+
+
+_LIBC: ctypes.CDLL | None = None
+
+
+def _libc() -> ctypes.CDLL:
+    """The one libc handle, which is what makes the argtypes below stick.
+
+    Each ``CDLL`` carries its own function prototypes and its own errno, so a
+    fresh handle per call would set argtypes on an object nobody calls and
+    read errno from a call nobody made.
+    """
+    global _LIBC
+    if _LIBC is None:
+        # The main program handle resolves libc symbols without naming a
+        # soname, which differs between glibc and musl.
+        _LIBC = ctypes.CDLL(None, use_errno=True)
+        _LIBC.mount.restype = ctypes.c_int
+        _LIBC.mount.argtypes = [
+            ctypes.c_char_p,
+            ctypes.c_char_p,
+            ctypes.c_char_p,
+            ctypes.c_ulong,
+            ctypes.c_char_p,
+        ]
+        _LIBC.umount2.restype = ctypes.c_int
+        _LIBC.umount2.argtypes = [ctypes.c_char_p, ctypes.c_int]
+        _LIBC.unshare.restype = ctypes.c_int
+        _LIBC.unshare.argtypes = [ctypes.c_int]
+        _LIBC.syscall.restype = ctypes.c_long
+    return _LIBC
+
+
+def _fail(kind: type[OSError], message: str) -> OSError:
+    code = ctypes.get_errno()
+    return kind(code, f"{message}: {os.strerror(code)}")
+
+
+def _syscall_numbers() -> dict[str, int]:
+    """The syscall numbers for this architecture, or refuse the host.
+
+    Asked before anything is changed, never in the middle of engaging, so
+    that an architecture commons has no numbers for is an unavailable host
+    rather than a process left half-confined.
+    """
+    machine = os.uname().machine
+    try:
+        return _SYSCALLS[machine]
+    except KeyError:
+        raise UsernsUnavailable(
+            0, f"commons does not know the syscall numbers for {machine}"
+        ) from None
+
+
+def _syscall(name: str, *args: object) -> int:
+    return _libc().syscall(ctypes.c_long(_syscall_numbers()[name]), *args)
+
+
+def _mount(
+    source: str | None,
+    target: str,
+    fstype: str | None,
+    flags: int,
+    data: str | None,
+) -> int:
+    def encode(value: str | None) -> bytes | None:
+        return None if value is None else value.encode()
+
+    return _libc().mount(
+        encode(source), target.encode(), encode(fstype), flags, encode(data)
+    )
+
+
+def _write_proc(path: str, content: str) -> None:
+    """Write ``content`` to ``path`` in one call, as procfs requires.
+
+    Failing here is a ``UsernsError`` rather than an unavailable host: these
+    writes only happen after ``unshare()`` has already put the process in a
+    new namespace, where it holds the overflow ids until they are mapped.
+    """
+    try:
+        fd = os.open(path, os.O_WRONLY | os.O_CLOEXEC)
+        try:
+            os.write(fd, content.encode())
+        finally:
+            os.close(fd)
+    except OSError as exc:
+        raise UsernsError(exc.errno, f"cannot write {path}: {exc.strerror}") from exc
+
+
+def mountinfo_paths(mountinfo: str) -> list[str]:
+    """Every mount point in ``/proc/self/mountinfo`` contents, unescaped.
+
+    Read before the pivot, because a read-only root has to remount each mount
+    nested under it as well: a locked child mount keeps its own flags and
+    stays writable otherwise.
+    """
+    paths = []
+    for line in mountinfo.splitlines():
+        fields = line.split(" ", 5)
+        if len(fields) < 5:
+            continue
+        paths.append(_OCTAL.sub(lambda m: chr(int(m.group(1), 8)), fields[4]))
+    return paths
+
+
+def path_in_roots(path: str, roots: list[str]) -> bool:
+    """Whether ``path`` is one of ``roots`` or sits underneath one.
+
+    What follows the root has to be nothing or a new component, so ``/foobar``
+    is not treated as being under ``/foo``.
+    """
+    for root in roots:
+        trimmed = root.rstrip("/")
+        if not trimmed or path == trimmed or path.startswith(trimmed + "/"):
+            return True
+    return False
+
+
+def map_ids() -> None:
+    """Enter a new user and mount namespace, keeping the caller's ids.
+
+    The ids are read first: between ``unshare()`` and the maps being written
+    the process reports the overflow ids, so reading them afterwards would
+    map the wrong pair.
+
+    Raises ``UsernsUnavailable`` if the namespace is refused, and
+    ``UsernsError`` if it is granted but the maps cannot be written.
+    """
+    uid = os.getuid()
+    gid = os.getgid()
+    if _libc().unshare(CLONE_NEWUSER | CLONE_NEWNS) != 0:
+        raise _fail(UsernsUnavailable, "cannot create a user namespace")
+    # An unprivileged process must give up setgroups before mapping a gid.
+    _write_proc("/proc/self/setgroups", "deny")
+    _write_proc("/proc/self/uid_map", f"{uid} {uid} 1")
+    _write_proc("/proc/self/gid_map", f"{gid} {gid} 1")
+
+
+def _remount_readonly(path: str) -> None:
+    """Remount an already-bound path read-only, keeping the flags it has.
+
+    A mount the worker inherited locked refuses a remount that would drop any
+    of its existing restrictions, so they are read back and asked for again.
+    """
+    flags = MS_REMOUNT | MS_BIND | MS_RDONLY
+    try:
+        existing = os.statvfs(path).f_flag
+    except OSError:
+        existing = 0
+    for st_flag, ms_flag in _ST_TO_MS:
+        if existing & st_flag:
+            flags |= ms_flag
+    if _mount(None, path, None, flags, None) != 0:
+        raise _fail(UsernsError, f"cannot make {path} read-only in the sandbox")
+
+
+def _bind(root: str, readonly: bool, submounts: list[str]) -> None:
+    """Bind one granted root back in from the host root, at its own path.
+
+    The bind is recursive, or anything mounted under the root is replaced by
+    the empty directory it was mounted on. That is also why a read-only root
+    remounts each of those nested mounts: read-only does not reach them.
+    """
+    os.makedirs(root, mode=0o755, exist_ok=True)
+    if _mount(_OLD_ROOT + root, root, None, MS_BIND | MS_REC, None) != 0:
+        raise _fail(UsernsError, f"cannot bind {root} into the sandbox")
+    if not readonly:
+        return
+    _remount_readonly(root)
+    for submount in submounts:
+        if root == "/" or submount.startswith(root + "/"):
+            _remount_readonly(submount)
+
+
+def _close_external_fds(
+    read_roots: list[str], rw_roots: list[str], preserve_fds: list[int]
+) -> None:
+    """Close descriptors that point outside the granted roots.
+
+    A descriptor opened before the pivot still reaches whatever it was opened
+    on, so the mounts alone do not confine the worker. Sockets go
+    unconditionally. A file or directory stays only if its path is under a
+    granted root, and under a read-only root only if it was opened read-only.
+    Pipes and the like are left alone: they carry the protocol.
+    """
+    scan_fd = os.open("/proc/self/fd", os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        entries = os.listdir(scan_fd)
+    finally:
+        os.close(scan_fd)
+    for entry in entries:
+        if not entry.isdigit():
+            continue
+        fd = int(entry)
+        if fd <= 2 or fd == scan_fd or fd in preserve_fds:
+            continue
+        try:
+            mode = os.fstat(fd).st_mode
+        except OSError:
+            continue
+        if stat.S_ISSOCK(mode):
+            os.close(fd)
+            continue
+        if not (
+            stat.S_ISREG(mode)
+            or stat.S_ISDIR(mode)
+            or stat.S_ISCHR(mode)
+            or stat.S_ISBLK(mode)
+        ):
+            continue
+        try:
+            target = os.readlink(f"/proc/self/fd/{fd}")
+            accmode = fcntl.fcntl(fd, fcntl.F_GETFL) & os.O_ACCMODE
+        except OSError:
+            os.close(fd)
+            continue
+        readable = accmode == os.O_RDONLY and path_in_roots(target, read_roots)
+        if not readable and not path_in_roots(target, rw_roots):
+            os.close(fd)
+
+
+def _drop_capabilities() -> None:
+    """Give up every capability the new namespace handed out.
+
+    A user namespace makes its creator fully capable inside it, which is what
+    allows the mounts above; nothing after them needs that. The bounding set
+    goes first, so the capabilities cannot come back across an exec.
+    """
+    libc = _libc()
+    cap = 0
+    while libc.prctl(PR_CAPBSET_DROP, cap, 0, 0, 0) == 0:
+        cap += 1
+    if ctypes.get_errno() != errno.EINVAL:
+        raise _fail(UsernsError, f"cannot drop capability {cap}")
+    header = _CapHeader(version=_CAP_VERSION_3, pid=0)
+    data = (_CapData * 2)()
+    if _syscall("capset", ctypes.byref(header), ctypes.byref(data)) != 0:
+        raise _fail(UsernsError, "cannot clear the sandbox capabilities")
+
+
+def engage(
+    read_roots: list[str], rw_roots: list[str], *, preserve_fds: list[int]
+) -> None:
+    """Confine this process to ``read_roots`` and ``rw_roots``, for good.
+
+    Raises ``UsernsUnavailable`` when the namespace never appears, which
+    means this host cannot run this sandbox and the caller should say so.
+    Every later failure raises ``UsernsError``.
+    """
+    # Both preflights, because everything below this point is irreversible.
+    _syscall_numbers()
+    threads = len(os.listdir("/proc/self/task"))
+    if threads != 1:
+        raise UsernsUnavailable(
+            0,
+            f"cannot enter a user namespace from a process with {threads} "
+            "threads; start the worker with OPENBLAS_NUM_THREADS=1 and "
+            "OMP_NUM_THREADS=1",
+        )
+    read_roots = [root.rstrip("/") or "/" for root in read_roots]
+    rw_roots = [root.rstrip("/") or "/" for root in rw_roots]
+    cwd = os.getcwd()
+
+    map_ids()
+
+    # Cut mount propagation both ways before recording or changing anything.
+    if _mount("none", "/", None, MS_PRIVATE | MS_REC, None) != 0:
+        raise _fail(UsernsError, "cannot make / a private mount")
+    with open("/proc/self/mountinfo") as handle:
+        submounts = mountinfo_paths(handle.read())
+    _close_external_fds(read_roots, rw_roots, preserve_fds)
+
+    if _mount("tmpfs", _SANDBOX_ROOT, "tmpfs", 0, "size=16m,mode=0755") != 0:
+        raise _fail(UsernsError, "cannot mount the sandbox root tmpfs")
+
+    # Pivot before binding, so the granted roots stay reachable through the
+    # old root while they are being bound back in.
+    os.mkdir(_SANDBOX_ROOT + _OLD_ROOT, 0o755)
+    pivoted = _syscall(
+        "pivot_root",
+        _SANDBOX_ROOT.encode(),
+        (_SANDBOX_ROOT + _OLD_ROOT).encode(),
+    )
+    if pivoted != 0:
+        raise _fail(UsernsError, "cannot pivot into the sandbox root")
+    os.chdir("/")
+
+    for root in read_roots:
+        _bind(root, True, submounts)
+    for root in rw_roots:
+        _bind(root, False, submounts)
+
+    if _libc().umount2(_OLD_ROOT.encode(), MNT_DETACH) != 0:
+        raise _fail(UsernsError, "cannot detach the host root")
+    os.rmdir(_OLD_ROOT)
+    if _mount(None, "/", None, MS_REMOUNT | MS_BIND | MS_RDONLY, None) != 0:
+        raise _fail(UsernsError, "cannot make the sandbox root read-only")
+    try:
+        os.chdir(cwd)
+    except OSError:
+        # A working directory that was not granted leaves the worker at the
+        # sandbox root, rather than the sandbox failing to engage.
+        pass
+    _drop_capabilities()
+
+
+def available() -> bool:
+    """Whether a child of this process could create a user namespace.
+
+    Asked in a throwaway fork, not here. ``unshare(CLONE_NEWUSER)`` refuses a
+    multi-threaded process, and a fork child is always single-threaded
+    however many threads its parent is running, so probing in place would
+    report the thread count rather than the host's policy. The child only
+    makes syscalls before ``_exit``, so it cannot deadlock on a lock held at
+    fork time, which is what Python warns about here.
+
+    Answers ``False`` for every reason a namespace does not appear, because
+    the caller does the same thing in each case.
+    """
+    if platform.system() != "Linux":
+        return False
+    try:
+        _syscall_numbers()
+    except UsernsUnavailable:
+        return False
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            pid = os.fork()
+    except OSError:
+        return False
+    if pid == 0:  # pragma: no cover - runs only in the child
+        try:
+            map_ids()
+        except BaseException:  # noqa: BLE001 - the child reports by exit status
+            os._exit(1)
+        os._exit(0)
+    try:
+        _, status = os.waitpid(pid, 0)
+    except OSError:
+        return False
+    return os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0

--- a/pkg-py/src/commons/_execution/_sandbox.py
+++ b/pkg-py/src/commons/_execution/_sandbox.py
@@ -18,12 +18,13 @@ import platform
 from dataclasses import dataclass
 from typing import Literal
 
-from ._runtime import _landlock, _seccomp
+from ._runtime import _landlock, _seccomp, _userns
 
 __all__ = [
     "ALLOW_UNSAFE_FALLBACK",
     "ProtectionMode",
     "SandboxCapabilities",
+    "needs_single_thread",
     "protection_mode",
     "sandbox_capabilities",
 ]
@@ -76,17 +77,16 @@ def _seatbelt_present() -> bool:
 def sandbox_capabilities() -> SandboxCapabilities:
     """Probe this host for each mechanism the worker can restrict itself with.
 
-    Each field is answered by the module that implements its mechanism. Only
-    user namespaces have no implementation yet and report unavailable until
-    they do, which costs nothing on a kernel that offers Landlock and is the
-    safe direction to be wrong in on one that does not. Probing is read-only,
-    so this leaves the calling process as unrestricted as it found it.
+    Every field is now answered by the module that implements its
+    mechanism, so this reports what the host really offers rather than a
+    placeholder. Probing is read-only, so it leaves the calling process as
+    unrestricted as it found it.
     """
     return SandboxCapabilities(
         landlock_abi=_landlock.abi_version(),
         seccomp=_seccomp.seccomp_available(),
         seatbelt=_seatbelt_present(),
-        userns=False,
+        userns=_userns.available(),
     )
 
 
@@ -146,4 +146,34 @@ def protection_mode(
         )
     raise RuntimeError(
         f"commons cannot sandbox the code execution worker on {sysname}. {_OPT_IN}"
+    )
+
+
+def needs_single_thread(
+    capabilities: SandboxCapabilities | None = None,
+    *,
+    sysname: str | None = None,
+) -> bool:
+    """Whether the worker has to be started with its thread pools pinned.
+
+    ``unshare(CLONE_NEWUSER)`` refuses a multi-threaded process, so the
+    user-namespace sandbox can only be engaged by a worker that never started
+    a BLAS pool. That costs the worker its parallelism, so it is asked for
+    only where that sandbox is the one that will be used: not where Landlock
+    will be, and not where ``protection_mode()`` refuses the host outright,
+    which it does without seccomp however good the filesystem sandbox is.
+
+    ``worker_single_thread()`` in pkg-r/R/run-r.R answers the same question
+    from the Landlock check alone. The two extra conditions here only narrow
+    it further, to the hosts that will really engage this sandbox.
+    """
+    if capabilities is None:
+        capabilities = sandbox_capabilities()
+    if sysname is None:
+        sysname = platform.system()
+    return (
+        sysname == "Linux"
+        and capabilities.seccomp
+        and capabilities.landlock_abi < 1
+        and capabilities.userns
     )

--- a/pkg-py/tests/test_execution_userns.py
+++ b/pkg-py/tests/test_execution_userns.py
@@ -1,0 +1,464 @@
+"""The user-namespace and tmpfs sandbox the worker engages on itself.
+
+Two layers. The parsing and matching helpers are ordinary functions and are
+tested everywhere. Engaging the sandbox is irreversible and Linux-only, so
+those tests fork, and the child reports back over a pipe what the sandbox
+would and would not let it do.
+
+The behaviour matches ``userns_engage`` and its helpers in
+pkg-r/src/sandbox.c.
+"""
+
+from __future__ import annotations
+
+import errno
+import json
+import os
+import sys
+import threading
+import time
+import warnings
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from commons._execution._env import worker_env
+from commons._execution._runtime import _userns
+from commons._execution._runtime._userns import (
+    UsernsError,
+    UsernsUnavailable,
+    engage,
+    map_ids,
+    mountinfo_paths,
+    path_in_roots,
+)
+from commons._execution._sandbox import (
+    SandboxCapabilities,
+    needs_single_thread,
+    sandbox_capabilities,
+)
+
+linux_only = pytest.mark.skipif(
+    sys.platform != "linux", reason="the user-namespace sandbox is Linux-only"
+)
+
+# Whether a namespace can be created is the host's policy, not just the
+# kernel's: a container running the default seccomp profile refuses, and so
+# does a host with user.max_user_namespaces at zero. Tests that engage the
+# sandbox skip there rather than fail, which is why they ask the probe.
+requires_userns = pytest.mark.skipif(
+    sys.platform != "linux" or not sandbox_capabilities().userns,
+    reason="this host does not offer unprivileged user namespaces",
+)
+
+
+def error_code(exc: OSError) -> str:
+    """The errno name, which reads better in an assertion than the number."""
+    assert exc.errno is not None
+    return errno.errorcode[exc.errno]
+
+
+def in_child(fn: Callable[[int], Any]) -> Any:
+    """Run ``fn`` in a forked child and return what it reports back.
+
+    Everything here is irreversible in the process that does it, so it is
+    done in a child that exits straight afterwards. ``fn`` is handed the
+    write end of the pipe, which is the descriptor it must ask the sandbox
+    to preserve if it wants to be able to answer at all.
+    """
+    read_fd, write_fd = os.pipe()
+    with warnings.catch_warnings():
+        # The child only makes syscalls and then _exit()s, so it never waits
+        # on a lock another thread held at fork time, which is what the
+        # warning is about. The test process is multi-threaded whatever this
+        # module does: importing commons starts threads.
+        warnings.simplefilter("ignore", DeprecationWarning)
+        pid = os.fork()
+    if pid == 0:  # pragma: no cover - runs only in the child
+        os.close(read_fd)
+        try:
+            payload = {"value": fn(write_fd)}
+        except BaseException as exc:  # noqa: BLE001 - reported over the pipe
+            payload = {"error": f"{type(exc).__name__}: {exc}"}
+        try:
+            os.write(write_fd, json.dumps(payload).encode())
+        finally:
+            os._exit(0)
+    os.close(write_fd)
+    with os.fdopen(read_fd, "rb") as pipe:
+        raw = pipe.read()
+    os.waitpid(pid, 0)
+    assert raw, "the child exited without reporting anything"
+    reported = json.loads(raw)
+    if "error" in reported:
+        pytest.fail(f"the child failed: {reported['error']}")
+    return reported["value"]
+
+
+def test_mountinfo_paths_reads_the_mount_point_field() -> None:
+    mountinfo = (
+        "23 28 0:22 / /proc rw,nosuid,relatime shared:12 - proc proc rw\n"
+        "24 28 0:5 / /sys rw,nosuid,relatime shared:2 - sysfs sysfs rw\n"
+    )
+    assert mountinfo_paths(mountinfo) == ["/proc", "/sys"]
+
+
+def test_mountinfo_paths_unescapes_octal_sequences() -> None:
+    # A mount point with a space in it arrives as \040, and the bind and
+    # remount calls need the real path, not the escaped one.
+    mountinfo = "31 28 0:30 / /mnt/my\\040disk rw,relatime - tmpfs tmpfs rw\n"
+    assert mountinfo_paths(mountinfo) == ["/mnt/my disk"]
+
+
+def test_path_in_roots_does_not_match_a_longer_sibling() -> None:
+    # The prefix test is what decides whether an inherited descriptor is
+    # closed, so /foobar must not pass as being under /foo.
+    assert path_in_roots("/foo/file", ["/foo"])
+    assert not path_in_roots("/foobar/file", ["/foo"])
+
+
+@requires_userns
+def test_map_ids_enters_a_new_user_namespace() -> None:
+    def child(_write_fd: int) -> str:
+        map_ids()
+        return os.readlink("/proc/self/ns/user")
+
+    assert in_child(child) != os.readlink("/proc/self/ns/user")
+
+
+@requires_userns
+def test_map_ids_keeps_the_caller_ids_rather_than_the_overflow_ids() -> None:
+    # unshare() reports the overflow ids until the maps are written, so the
+    # real ids have to be read before it and written back afterwards.
+    def child(_write_fd: int) -> list[int]:
+        map_ids()
+        return [os.getuid(), os.getgid()]
+
+    assert in_child(child) == [os.getuid(), os.getgid()]
+
+
+def test_unavailable_is_reported_rather_than_raised_as_a_bare_oserror() -> None:
+    assert issubclass(UsernsUnavailable, OSError)
+
+
+@linux_only
+def test_the_probe_agrees_with_what_a_child_can_actually_do() -> None:
+    # Stated as an agreement rather than a fixed answer, because whether a
+    # namespace can be created is the host's policy: a container with the
+    # default seccomp profile refuses, and the same test has to pass there.
+    def child(_write_fd: int) -> bool:
+        try:
+            map_ids()
+        except OSError:
+            return False
+        return True
+
+    assert sandbox_capabilities().userns == in_child(child)
+
+
+@pytest.mark.skipif(sys.platform == "linux", reason="asks about other kernels")
+def test_the_probe_reports_no_user_namespace_off_linux() -> None:
+    assert sandbox_capabilities().userns is False
+
+
+@requires_userns
+def test_the_host_filesystem_is_gone_once_the_sandbox_is_engaged(tmp_path) -> None:
+    granted = tmp_path / "granted"
+    granted.mkdir()
+    (granted / "note.txt").write_text("visible")
+
+    def child(write_fd: int) -> dict[str, bool]:
+        engage([str(granted)], [], preserve_fds=[write_fd])
+        return {
+            "granted": os.path.exists(f"{granted}/note.txt"),
+            "host": os.path.exists("/etc/passwd"),
+        }
+
+    assert in_child(child) == {"granted": True, "host": False}
+
+
+@requires_userns
+def test_a_read_root_reads_but_does_not_write(tmp_path) -> None:
+    root = tmp_path / "readable"
+    root.mkdir()
+    (root / "note.txt").write_text("visible")
+
+    def child(write_fd: int) -> dict[str, object]:
+        engage([str(root)], [], preserve_fds=[write_fd])
+        try:
+            with open(f"{root}/new.txt", "w") as handle:
+                handle.write("nope")
+            wrote = None
+        except OSError as exc:
+            wrote = error_code(exc)
+        with open(f"{root}/note.txt") as handle:
+            return {"read": handle.read(), "wrote": wrote}
+
+    assert in_child(child) == {"read": "visible", "wrote": "EROFS"}
+
+
+@requires_userns
+def test_a_read_write_root_writes(tmp_path) -> None:
+    root = tmp_path / "writable"
+    root.mkdir()
+
+    def child(write_fd: int) -> str:
+        engage([], [str(root)], preserve_fds=[write_fd])
+        with open(f"{root}/new.txt", "w") as handle:
+            handle.write("written")
+        with open(f"{root}/new.txt") as handle:
+            return handle.read()
+
+    assert in_child(child) == "written"
+
+
+@requires_userns
+def test_the_working_directory_survives_the_pivot(tmp_path) -> None:
+    root = tmp_path / "work"
+    root.mkdir()
+
+    def child(write_fd: int) -> str:
+        os.chdir(str(root))
+        engage([], [str(root)], preserve_fds=[write_fd])
+        return os.getcwd()
+
+    assert in_child(child) == str(root)
+
+
+@requires_userns
+def test_a_working_directory_that_was_not_granted_leaves_the_worker_at_root(
+    tmp_path,
+) -> None:
+    # Losing the working directory is not a reason to refuse to sandbox: the
+    # sandbox root is a safe place to be left.
+    granted = tmp_path / "granted"
+    granted.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+
+    def child(write_fd: int) -> str:
+        os.chdir(str(elsewhere))
+        engage([], [str(granted)], preserve_fds=[write_fd])
+        return os.getcwd()
+
+    assert in_child(child) == "/"
+
+
+@requires_userns
+def test_a_descriptor_opened_outside_the_granted_roots_is_closed(tmp_path) -> None:
+    granted = tmp_path / "granted"
+    granted.mkdir()
+    outside = tmp_path / "secret.txt"
+    outside.write_text("secret")
+
+    def child(write_fd: int) -> str | None:
+        leaked = os.open(str(outside), os.O_RDONLY)
+        engage([str(granted)], [], preserve_fds=[write_fd])
+        try:
+            os.read(leaked, 6)
+        except OSError as exc:
+            return error_code(exc)
+        return None
+
+    assert in_child(child) == "EBADF"
+
+
+@requires_userns
+def test_a_descriptor_inside_a_granted_root_stays_open(tmp_path) -> None:
+    granted = tmp_path / "granted"
+    granted.mkdir()
+    (granted / "note.txt").write_text("visible")
+
+    def child(write_fd: int) -> str:
+        kept = os.open(f"{granted}/note.txt", os.O_RDONLY)
+        engage([str(granted)], [], preserve_fds=[write_fd])
+        return os.read(kept, 7).decode()
+
+    assert in_child(child) == "visible"
+
+
+@requires_userns
+def test_a_read_only_descriptor_is_not_kept_for_a_read_write_root(tmp_path) -> None:
+    # The rule is about the path, not the mode: a descriptor under a
+    # read-write root survives whichever way it was opened.
+    root = tmp_path / "writable"
+    root.mkdir()
+    (root / "note.txt").write_text("visible")
+
+    def child(write_fd: int) -> str:
+        kept = os.open(f"{root}/note.txt", os.O_RDWR)
+        engage([], [str(root)], preserve_fds=[write_fd])
+        return os.read(kept, 7).decode()
+
+    assert in_child(child) == "visible"
+
+
+@linux_only
+def test_engaging_from_a_threaded_process_names_the_variables_that_fix_it() -> None:
+    def child(write_fd: int) -> str:
+        thread = threading.Thread(target=lambda: time.sleep(30), daemon=True)
+        thread.start()
+        try:
+            engage([], [], preserve_fds=[write_fd])
+        except UsernsUnavailable as exc:
+            return str(exc)
+        return "no error"
+
+    reported = in_child(child)
+    assert "OPENBLAS_NUM_THREADS=1" in reported
+    assert "OMP_NUM_THREADS=1" in reported
+
+
+def _nested_mounts() -> dict[str, tuple[str, str]]:
+    """One nested mount of each kind, keyed "file" and "dir".
+
+    A nested mount is one sitting inside a plain directory, which is what
+    makes its parent usable as a granted root. Which ones a host has differs,
+    so they are discovered: a container image supplies /etc/hosts as a file
+    and /sys/fs/cgroup as a directory.
+    """
+    with open("/proc/self/mountinfo") as handle:
+        paths = mountinfo_paths(handle.read())
+    mounts = set(paths)
+    found: dict[str, tuple[str, str]] = {}
+    for path in sorted(paths):
+        parent = os.path.dirname(path)
+        if parent in ("", "/") or parent in mounts:
+            continue
+        kind = "dir" if os.path.isdir(path) else "file"
+        found.setdefault(kind, (parent, path))
+    return found
+
+
+def write_attempt(path: str) -> str | None:
+    """Try to write at ``path``, and report the errno name if it is refused.
+
+    A mount point is a file on some hosts and a directory on others, and
+    opening a directory for writing fails with EISDIR whatever the mount
+    flags say, so a directory is probed by the file it would contain.
+    """
+    target = os.path.join(path, "commons-write-probe") if os.path.isdir(path) else path
+    try:
+        with open(target, "a"):
+            pass
+    except OSError as exc:
+        return error_code(exc)
+    return None
+
+
+@requires_userns
+@pytest.mark.parametrize("kind", ["file", "dir"])
+def test_a_mount_nested_under_a_read_root_comes_along_and_is_read_only(kind) -> None:
+    # The bind has to be recursive or the nested mount is replaced by the
+    # empty directory it covers, and read-only does not reach it on its own.
+    found = _nested_mounts().get(kind)
+    if found is None:
+        pytest.skip(f"this host has no nested {kind} mount inside a plain directory")
+    root, nested = found
+
+    def child(write_fd: int) -> dict[str, object]:
+        engage([root, "/proc"], [], preserve_fds=[write_fd])
+        with open("/proc/self/mountinfo") as handle:
+            present = nested in mountinfo_paths(handle.read())
+        return {"present": present, "wrote": write_attempt(nested)}
+
+    assert in_child(child) == {"present": True, "wrote": "EROFS"}
+
+
+@requires_userns
+def test_the_capabilities_the_namespace_granted_are_given_up() -> None:
+    # A new user namespace makes its creator fully capable inside it, which
+    # is what allows the mounts. Nothing after them needs that.
+    def child(write_fd: int) -> dict[str, str]:
+        engage(["/proc"], [], preserve_fds=[write_fd])
+        wanted = ("CapEff", "CapBnd")
+        with open("/proc/self/status") as handle:
+            return {
+                name: value.strip()
+                for name, _, value in (line.partition(":") for line in handle)
+                if name in wanted
+            }
+
+    assert in_child(child) == {
+        "CapEff": "0000000000000000",
+        "CapBnd": "0000000000000000",
+    }
+
+
+def test_the_single_thread_variables_are_set_only_when_asked() -> None:
+    # unshare(CLONE_NEWUSER) refuses a multi-threaded process, and a BLAS
+    # library starts its pool before the worker gets to engage anything.
+    pinned = worker_env("/tmp/scratch", single_thread=True)
+    assert pinned["OPENBLAS_NUM_THREADS"] == "1"
+    assert pinned["OMP_NUM_THREADS"] == "1"
+    default = worker_env("/tmp/scratch")
+    assert "OPENBLAS_NUM_THREADS" not in default
+    assert "OMP_NUM_THREADS" not in default
+
+
+
+
+def test_thread_pinning_is_never_asked_for_off_linux() -> None:
+    capabilities = SandboxCapabilities(
+        landlock_abi=-1, seccomp=False, seatbelt=True, userns=False
+    )
+    assert needs_single_thread(capabilities, sysname="Darwin") is False
+
+
+def test_a_failed_id_map_is_not_reported_as_an_unavailable_host() -> None:
+    """The two failure modes are distinct types, because only one of them
+    leaves a process that can still be asked to do something else."""
+    assert not issubclass(UsernsError, UsernsUnavailable)
+    assert not issubclass(UsernsUnavailable, UsernsError)
+
+
+@pytest.mark.parametrize(
+    "landlock_abi, seccomp, userns, expected",
+    [
+        (1, True, True, False),
+        (0, True, True, True),
+        (0, True, False, False),
+        # No seccomp means protection_mode() refuses the host whatever the
+        # filesystem sandbox offers, so pinning would buy nothing.
+        (0, False, True, False),
+    ],
+)
+def test_thread_pinning_is_asked_for_only_where_this_sandbox_is_the_one_used(
+    landlock_abi, seccomp, userns, expected
+) -> None:
+    capabilities = SandboxCapabilities(
+        landlock_abi=landlock_abi, seccomp=seccomp, seatbelt=False, userns=userns
+    )
+    assert needs_single_thread(capabilities, sysname="Linux") is expected
+
+
+@linux_only
+def test_the_probe_refuses_an_architecture_with_no_known_syscall_numbers(
+    monkeypatch,
+) -> None:
+    # pivot_root and capset are reached by number, so an architecture that is
+    # not in the table cannot be sandboxed however willing the kernel is.
+    monkeypatch.setattr(_userns, "_SYSCALLS", {})
+    assert _userns.available() is False
+
+
+@requires_userns
+def test_an_unknown_architecture_is_refused_before_the_namespace_is_entered(
+    monkeypatch,
+) -> None:
+    # The refusal has to come first. Raising it after unshare() would report
+    # an unavailable host from a process that has already been changed.
+    monkeypatch.setattr(_userns, "_SYSCALLS", {})
+    before = os.readlink("/proc/self/ns/user")
+
+    def child(write_fd: int) -> dict[str, str]:
+        try:
+            engage([], [], preserve_fds=[write_fd])
+        except UsernsUnavailable:
+            return {"raised": "unavailable", "namespace": os.readlink("/proc/self/ns/user")}
+        except UsernsError:
+            return {"raised": "error", "namespace": os.readlink("/proc/self/ns/user")}
+        return {"raised": "nothing", "namespace": os.readlink("/proc/self/ns/user")}
+
+    assert in_child(child) == {"raised": "unavailable", "namespace": before}


### PR DESCRIPTION
This PR adds the Linux user-namespace and tmpfs sandbox. The worker engages it on itself on a kernel that cannot offer Landlock. This PR also fills in the `userns` field of the capability probe, and adds the thread pinning that `unshare(CLONE_NEWUSER)` needs.

kata `49te`. Stacked on #356, at the top of the sandbox stack.

<details>
<summary>Agent-written detail</summary>

`engage()` runs once in the worker and cannot be undone. It enters a new user and mount namespace, stops mount propagation, pivots into a fresh tmpfs root, binds the granted roots back in from the old root, detaches the old root, and drops the capabilities the namespace gave it. Before the pivot it closes every descriptor that points outside the granted roots, and every directory, socket, and O_PATH descriptor unconditionally: a kept directory descriptor would anchor the detached host tree, and `openat()` relative to it would climb back out of the sandbox.

Granted roots are validated in preflight, before anything changes. Each must be an absolute, canonical path that contains no symlink. A read-only root may not sit at or beneath a read-write one: read roots bind first, and the recursive read-write bind would stack over the nested one and turn it writable. `/` and `/tmp` may not be read-write roots, because the final read-only remount would turn the grant read-only.

There are two exception types, and the split is the contract. `UsernsUnavailable` means nothing has changed yet. `UsernsError` means the process already sits in a namespace whose ids or mounts are wrong, so it must die. Every failure after `unshare()` is routed to `UsernsError`, including the `OSError`s from `os.*` calls. `pkg-r/src/sandbox.c` reports both cases as an errno. This is one place the Python side is deliberately stricter, and it is why the architecture table is consulted before `unshare()` rather than at the pivot.

That table is also why only x86_64 and aarch64 are known: glibc exports neither `pivot_root` nor `capset`, so both go through `syscall()` by number. On another architecture the R implementation compiles and this one reports the host unavailable, so the two implementations can answer differently for the same host.

`available()` probes in a fork, and the child engages the whole sandbox rather than stopping at the namespace: a host that permits `unshare` but refuses the mounts is reported incapable instead of failing when the worker engages. A fork child always has one thread, so the probe measures host policy rather than the caller's thread count.

One deliberate visibility change: `protection_mode()` now answers `"sandbox"` on a Linux host with seccomp and user namespaces but no Landlock, where it used to raise. Nothing outside the tests calls `engage()` yet (the choice between Landlock and this sandbox is kata `z5gn` (#356), and the worker startup that calls either is kata `bgk1`), so on such a host the package promises a sandbox that no Python worker fulfills end-to-end until the wiring lands.

Follow-ups owned elsewhere: the directory-descriptor escape applies identically to `userns_engage` in pkg-r/src/sandbox.c and was fixed here first; `_landlock.engage()` reports "unavailable" by returning `None` where this module raises `UsernsUnavailable`, and the wiring (bgk1) should pick one convention; the shared sandbox-behaviour fixture belongs to kata `dkev`.

ruff, pyrefly and the full suite pass on macOS and on Linux in CI. The behaviour tests make the real syscalls and skip where the host denies user namespaces (checked under Docker's default seccomp profile, where they skip and do not fail).

</details>
