### PR TITLE
feat(py): enable the worker's Linux seccomp filter and network block

### DIFF
--- a/.github/workflows/py-check.yaml
+++ b/.github/workflows/py-check.yaml
@@ -18,6 +18,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.11", "3.12", "3.13", "3.14"]
+        include:
+          # One arm64 leg, for the seccomp filter's aarch64 syscall numbers.
+          # They are the same at every Python version, so one is enough.
+          - os: ubuntu-24.04-arm
+            python-version: "3.13"
     defaults:
       run:
         working-directory: pkg-py

--- a/pkg-py/src/commons/_execution/_runtime/_seccomp.py
+++ b/pkg-py/src/commons/_execution/_runtime/_seccomp.py
@@ -1,0 +1,480 @@
+"""The seccomp filter the worker installs on itself, and the network block.
+
+This runs in the child, after the filesystem sandbox and before any
+model-written code is loaded. Its job is the part of the boundary a
+filesystem sandbox cannot express: the syscalls that would let the worker
+step out of that sandbox rather than read around it, and, when the caller
+asked for no network, the syscalls that open a socket.
+
+A seccomp filter matches raw syscall numbers, and those are per
+architecture, so the number table below is per architecture too. The filter's
+first act is to confirm the calling architecture is the one its numbers came
+from, because a foreign ABI (the i386 compat ABI on an x86_64 kernel, say)
+numbers its syscalls differently and would let a screened call through under
+a number this filter reads as something else.
+
+The same filter is built by ``seccomp_engage()`` and ``network_engage()`` in
+``pkg-r/src/sandbox.c``, where the compiler supplies the numbers.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import pathlib
+import platform
+import struct
+import subprocess
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Literal
+
+__all__ = [
+    "ARCHES",
+    "NETWORK_SCREENED",
+    "SCREENED",
+    "Arch",
+    "allow_all",
+    "arch_for",
+    "build_network_filter",
+    "build_sandbox_filter",
+    "current_arch",
+    "engage",
+    "seccomp_available",
+    "set_no_new_privs",
+]
+
+# Syscalls that would let the worker escape the sandbox rather than read
+# around it: debugging another process, or rearranging the mount namespace
+# the sandbox is expressed in.
+SCREENED = (
+    "ptrace",
+    "process_vm_readv",
+    "process_vm_writev",
+    "pidfd_getfd",
+    "mount",
+    "umount2",
+    "pivot_root",
+    "chroot",
+    "unshare",
+    "setns",
+    "open_tree",
+    "move_mount",
+    "fsopen",
+    "fsconfig",
+    "fsmount",
+    "fspick",
+    "mount_setattr",
+)
+
+
+# Screened as well, on the architectures whose table still carries them.
+SCREENED_WHERE_PRESENT = ("umount",)
+
+# Syscalls that open a socket, screened only when the caller asked for no
+# network. Separate from SCREENED because network access is a choice and
+# escaping the sandbox is not.
+NETWORK_SCREENED = ("socket", "socketcall", "io_uring_setup")
+
+
+class SockFilter(ctypes.Structure):
+    """One BPF instruction, ``struct sock_filter``."""
+
+    _fields_ = (
+        ("code", ctypes.c_uint16),
+        ("jt", ctypes.c_uint8),
+        ("jf", ctypes.c_uint8),
+        ("k", ctypes.c_uint32),
+    )
+
+
+class SockFprog(ctypes.Structure):
+    """A filter program handed to the kernel, ``struct sock_fprog``."""
+
+    _fields_ = (
+        ("len", ctypes.c_uint16),
+        ("filter", ctypes.POINTER(SockFilter)),
+    )
+
+
+# The BPF subset the filters are built from: load a word at a fixed offset
+# into seccomp_data, compare the accumulator against a constant, return a
+# verdict.
+BPF_LD_W_ABS = 0x00 | 0x00 | 0x20
+BPF_JEQ_K = 0x05 | 0x10 | 0x00
+BPF_JGE_K = 0x05 | 0x30 | 0x00
+BPF_JSET_K = 0x05 | 0x40 | 0x00
+BPF_RET_K = 0x06 | 0x00
+
+# Offsets into struct seccomp_data, whose layout is fixed across
+# architectures.
+DATA_NR = 0
+DATA_ARCH = 4
+DATA_ARG0 = 16
+
+SECCOMP_RET_ALLOW = 0x7FFF0000
+_SECCOMP_RET_ERRNO = 0x00050000
+
+EPERM = 1
+ENOSYS = 38
+
+DENY_EPERM = _SECCOMP_RET_ERRNO | EPERM
+DENY_ENOSYS = _SECCOMP_RET_ERRNO | ENOSYS
+
+CLONE_NEWNS = 0x00020000
+CLONE_NEWCGROUP = 0x02000000
+CLONE_NEWUTS = 0x04000000
+CLONE_NEWIPC = 0x08000000
+CLONE_NEWUSER = 0x10000000
+CLONE_NEWPID = 0x20000000
+CLONE_NEWNET = 0x40000000
+
+NAMESPACE_FLAGS = (
+    CLONE_NEWNS
+    | CLONE_NEWCGROUP
+    | CLONE_NEWUTS
+    | CLONE_NEWIPC
+    | CLONE_NEWUSER
+    | CLONE_NEWPID
+    | CLONE_NEWNET
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class Arch:
+    """One architecture's syscall numbering and its audit tag."""
+
+    name: str
+    audit_arch: int
+    x32_bit: int | None = None
+    syscalls: Mapping[str, int]
+
+
+def _screen(program: list[SockFilter], nr: int, verdict: int) -> None:
+    """Deny one syscall number, leaving the rest to later instructions."""
+    program.append(SockFilter(code=BPF_JEQ_K, jt=0, jf=1, k=nr))
+    program.append(SockFilter(code=BPF_RET_K, jt=0, jf=0, k=verdict))
+
+
+def _preamble(arch: Arch) -> list[SockFilter]:
+    """Confirm the caller's ABI, then load the syscall number.
+
+    Everything after this compares against ``arch``'s numbers, so a call
+    arriving under any other ABI has to be refused before the comparisons
+    rather than misread by them.
+    """
+    program = [
+        SockFilter(code=BPF_LD_W_ABS, jt=0, jf=0, k=DATA_ARCH),
+        SockFilter(code=BPF_JEQ_K, jt=1, jf=0, k=arch.audit_arch),
+        SockFilter(code=BPF_RET_K, jt=0, jf=0, k=DENY_EPERM),
+        SockFilter(code=BPF_LD_W_ABS, jt=0, jf=0, k=DATA_NR),
+    ]
+    if arch.x32_bit is not None:
+        # x32 shares the x86_64 audit tag but sets a high bit and indexes its
+        # own table, so it clears the check above while numbering differently.
+        program.append(SockFilter(code=BPF_JGE_K, jt=0, jf=1, k=arch.x32_bit))
+        program.append(SockFilter(code=BPF_RET_K, jt=0, jf=0, k=DENY_EPERM))
+    return program
+
+
+def build_network_filter(arch: Arch) -> list[SockFilter]:
+    """A filter that refuses every way of opening a socket."""
+    program = _preamble(arch)
+    for name in NETWORK_SCREENED:
+        if name in arch.syscalls:
+            _screen(program, arch.syscalls[name], DENY_EPERM)
+    program.append(SockFilter(code=BPF_RET_K, jt=0, jf=0, k=SECCOMP_RET_ALLOW))
+    return program
+
+
+# Numbers read from each architecture's kernel headers rather than written
+# from memory: they agree from 425 up and diverge below, and two neighbours
+# disagree where it would be easy to assume otherwise (pivot_root is 217 on
+# i386 and 218 on arm).
+ARCHES: Mapping[str, Arch] = {
+    "x86_64": Arch(
+        name="x86_64",
+        audit_arch=0xC000003E,
+        x32_bit=0x40000000,
+        syscalls={
+            "ptrace": 101,
+            "process_vm_readv": 310,
+            "process_vm_writev": 311,
+            "pidfd_getfd": 438,
+            "mount": 165,
+            "umount2": 166,
+            "pivot_root": 155,
+            "chroot": 161,
+            "unshare": 272,
+            "setns": 308,
+            "open_tree": 428,
+            "move_mount": 429,
+            "fsopen": 430,
+            "fsconfig": 431,
+            "fsmount": 432,
+            "fspick": 433,
+            "mount_setattr": 442,
+            "clone": 56,
+            "clone3": 435,
+            "socket": 41,
+            "io_uring_setup": 425,
+        },
+    ),
+    "aarch64": Arch(
+        name="aarch64",
+        audit_arch=0xC00000B7,
+        syscalls={
+            "ptrace": 117,
+            "process_vm_readv": 270,
+            "process_vm_writev": 271,
+            "pidfd_getfd": 438,
+            "mount": 40,
+            "umount2": 39,
+            "pivot_root": 41,
+            "chroot": 51,
+            "unshare": 97,
+            "setns": 268,
+            "open_tree": 428,
+            "move_mount": 429,
+            "fsopen": 430,
+            "fsconfig": 431,
+            "fsmount": 432,
+            "fspick": 433,
+            "mount_setattr": 442,
+            "clone": 220,
+            "clone3": 435,
+            "socket": 198,
+            "io_uring_setup": 425,
+        },
+    ),
+    "i386": Arch(
+        name="i386",
+        audit_arch=0x40000003,
+        syscalls={
+            "ptrace": 26,
+            "process_vm_readv": 347,
+            "process_vm_writev": 348,
+            "pidfd_getfd": 438,
+            "mount": 21,
+            "umount2": 52,
+            # The one-argument umount predating umount2, which only the i386
+            # table still carries.
+            "umount": 22,
+            "pivot_root": 217,
+            "chroot": 61,
+            "unshare": 310,
+            "setns": 346,
+            "open_tree": 428,
+            "move_mount": 429,
+            "fsopen": 430,
+            "fsconfig": 431,
+            "fsmount": 432,
+            "fspick": 433,
+            "mount_setattr": 442,
+            "clone": 120,
+            "clone3": 435,
+            "socket": 359,
+            # i386 alone still multiplexes the socket calls through one entry
+            # point, so screening socket() by itself would leave a way to
+            # open one.
+            "socketcall": 102,
+            "io_uring_setup": 425,
+        },
+    ),
+    "arm": Arch(
+        name="arm",
+        audit_arch=0x40000028,
+        syscalls={
+            "ptrace": 26,
+            "process_vm_readv": 376,
+            "process_vm_writev": 377,
+            "pidfd_getfd": 438,
+            "mount": 21,
+            "umount2": 52,
+            "pivot_root": 218,
+            "chroot": 61,
+            "unshare": 337,
+            "setns": 375,
+            "open_tree": 428,
+            "move_mount": 429,
+            "fsopen": 430,
+            "fsconfig": 431,
+            "fsmount": 432,
+            "fspick": 433,
+            "mount_setattr": 442,
+            "clone": 120,
+            "clone3": 435,
+            "socket": 281,
+            "io_uring_setup": 425,
+        },
+    ),
+}
+
+
+def build_sandbox_filter(arch: Arch) -> list[SockFilter]:
+    """A filter that refuses the syscalls which would undo the sandbox.
+
+    Opening a socket is left alone here; that is the network block's call.
+    """
+    program = _preamble(arch)
+    for name in (*SCREENED, *SCREENED_WHERE_PRESENT):
+        if name in arch.syscalls:
+            _screen(program, arch.syscalls[name], DENY_EPERM)
+
+    # Report clone3 missing rather than forbidden, so glibc falls back to
+    # clone(). clone3 carries its flags in a struct behind a pointer, and a
+    # filter cannot dereference one, so its flags cannot be screened at all.
+    _screen(program, arch.syscalls["clone3"], DENY_ENOSYS)
+
+    # Threads are fine; a new namespace is not.
+    program.append(SockFilter(code=BPF_JEQ_K, jt=0, jf=3, k=arch.syscalls["clone"]))
+    program.append(SockFilter(code=BPF_LD_W_ABS, jt=0, jf=0, k=DATA_ARG0))
+    program.append(SockFilter(code=BPF_JSET_K, jt=0, jf=1, k=NAMESPACE_FLAGS))
+    program.append(SockFilter(code=BPF_RET_K, jt=0, jf=0, k=DENY_EPERM))
+
+    program.append(SockFilter(code=BPF_RET_K, jt=0, jf=0, k=SECCOMP_RET_ALLOW))
+    return program
+
+
+# What each ``platform.machine()`` means at each pointer size. A 32-bit
+# process finds its own name here without help, because the kernel reports
+# i686 or armv8l to one rather than the 64-bit name. The pointer size is in
+# the key for what it excludes: x32 is the one ABI that reports a 64-bit
+# machine with 32-bit pointers, and it belongs to neither table, since its
+# calls carry the x86_64 audit tag over its own syscall numbering. It gets
+# no entry, so such a host is reported unsandboxable rather than handed a
+# filter that would reject every call it makes.
+_MACHINES: Mapping[tuple[str, int], str] = {
+    ("x86_64", 8): "x86_64",
+    ("amd64", 8): "x86_64",
+    ("i386", 4): "i386",
+    ("i486", 4): "i386",
+    ("i586", 4): "i386",
+    ("i686", 4): "i386",
+    ("aarch64", 8): "aarch64",
+    ("arm64", 8): "aarch64",
+    ("armv6l", 4): "arm",
+    ("armv7l", 4): "arm",
+    ("armv8l", 4): "arm",
+}
+
+PR_SET_NO_NEW_PRIVS = 38
+PR_SET_SECCOMP = 22
+PR_GET_SECCOMP = 21
+SECCOMP_MODE_FILTER = 2
+
+
+def arch_for(machine: str, pointer_size: int) -> Arch | None:
+    """The table for a machine name and pointer size, or ``None`` for neither.
+
+    ``None`` is the fail-closed answer. A filter built from another
+    architecture's numbers is worse than no filter, because it reads as
+    protection while screening the wrong calls.
+    """
+    name = _MACHINES.get((machine.lower(), pointer_size))
+    return None if name is None else ARCHES[name]
+
+
+def current_arch() -> Arch | None:
+    """The table for the process this is running in."""
+    return arch_for(platform.machine(), struct.calcsize("P"))
+
+
+def _libc() -> ctypes.CDLL:
+    libc = ctypes.CDLL(None, use_errno=True)
+    libc.prctl.restype = ctypes.c_int
+    return libc
+
+
+def _a_filter_installs() -> bool:
+    """Whether this process may install a filter, found out by installing one.
+
+    Asking the kernel whether it has seccomp is a different question: a
+    container profile can answer that and still refuse PR_SET_SECCOMP. The
+    only reliable answer is to install an allow-all filter and see, and that
+    has to happen in a child because a filter cannot be lifted afterwards.
+    """
+    if not sys.executable:
+        return False
+    probe = (
+        f"import sys; sys.path.insert(0, {str(pathlib.Path(__file__).parent)!r}); "
+        "import _seccomp; _seccomp.set_no_new_privs(); "
+        "_seccomp._install(_seccomp.allow_all(), what='probe filter')"
+    )
+    try:
+        # -I to match how the worker is launched, so a sitecustomize on the
+        # host's PYTHONPATH cannot decide the answer. A timeout because this
+        # runs while the agent is being built, and a probe that never came
+        # back would hang that rather than report anything.
+        completed = subprocess.run(
+            [sys.executable, "-I", "-c", probe],
+            capture_output=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return completed.returncode == 0
+
+
+def allow_all() -> list[SockFilter]:
+    """A filter that permits everything, for finding out whether one installs."""
+    return [SockFilter(code=BPF_RET_K, jt=0, jf=0, k=SECCOMP_RET_ALLOW)]
+
+
+def seccomp_available() -> bool:
+    """Whether this host can hold the worker to a seccomp filter.
+
+    Part of what makes a Linux host sandboxable at all, so an architecture
+    with no table counts as unavailable rather than as a filter to skip.
+    """
+    if platform.system() != "Linux" or current_arch() is None:
+        return False
+    if _libc().prctl(PR_GET_SECCOMP, 0, 0, 0, 0) < 0:
+        return False
+    return _a_filter_installs()
+
+
+def set_no_new_privs() -> None:
+    """Give up ever gaining privilege, for this process and its children.
+
+    The kernel will not let an unprivileged process install a seccomp filter
+    without this, since a filter that made a setuid binary misbehave would
+    otherwise be a way to gain privilege rather than give it up. Landlock
+    wants it for the same reason, and it is safe to set twice.
+    """
+    libc = _libc()
+    if libc.prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0:
+        code = ctypes.get_errno()
+        raise OSError(code, f"prctl(PR_SET_NO_NEW_PRIVS) failed: {os.strerror(code)}")
+
+
+def _install(program: list[SockFilter], *, what: str) -> None:
+    """Install one filter program, permanently, on the calling process."""
+    instructions = (SockFilter * len(program))(*program)
+    fprog = SockFprog(len=len(program), filter=instructions)
+    if _libc().prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, ctypes.byref(fprog)) != 0:
+        code = ctypes.get_errno()
+        raise OSError(code, f"cannot install the {what}: {os.strerror(code)}")
+
+
+def engage(*, network: Literal["none", "full"]) -> None:
+    """Put the filters on this process, for the rest of its life.
+
+    Filters stack and none of them can be lifted, so this runs once, in the
+    worker, before any model-written code is loaded.
+    """
+    if network not in ("none", "full"):
+        raise ValueError(f"unknown network access level {network!r}")
+    arch = current_arch()
+    if arch is None:
+        raise RuntimeError(
+            "commons cannot install a seccomp filter on "
+            f"{platform.machine()}: the syscall numbers it would have to "
+            "match are not known for this architecture."
+        )
+    set_no_new_privs()
+    _install(build_sandbox_filter(arch), what="seccomp filter")
+    if network == "none":
+        _install(build_network_filter(arch), what="network block")

--- a/pkg-py/src/commons/_execution/_sandbox.py
+++ b/pkg-py/src/commons/_execution/_sandbox.py
@@ -18,6 +18,8 @@ import platform
 from dataclasses import dataclass
 from typing import Literal
 
+from ._runtime import _seccomp
+
 __all__ = [
     "ALLOW_UNSAFE_FALLBACK",
     "ProtectionMode",
@@ -74,14 +76,16 @@ def _seatbelt_present() -> bool:
 def sandbox_capabilities() -> SandboxCapabilities:
     """Probe this host for each mechanism the worker can restrict itself with.
 
-    Each field is filled in by the module that implements its mechanism. The
-    Linux fields have no implementation yet and report unavailable until they
-    do, so ``protection_mode()`` still refuses every Linux host: the safe
-    direction to be wrong in while those sandboxes are being built.
+    Each field is filled in by the module that implements its mechanism.
+    Landlock and user namespaces have no implementation yet and report
+    unavailable until they do, so ``protection_mode()`` still refuses every
+    Linux host: seccomp alone is not enough without a filesystem sandbox
+    beside it, which is the safe direction to be wrong in while those are
+    being built.
     """
     return SandboxCapabilities(
         landlock_abi=-1,
-        seccomp=False,
+        seccomp=_seccomp.seccomp_available(),
         seatbelt=_seatbelt_present(),
         userns=False,
     )
@@ -142,6 +146,5 @@ def protection_mode(
             f"a container, its seccomp profile. {_OPT_IN}"
         )
     raise RuntimeError(
-        "commons cannot sandbox the code execution worker on "
-        f"{sysname}. {_OPT_IN}"
+        f"commons cannot sandbox the code execution worker on {sysname}. {_OPT_IN}"
     )

--- a/pkg-py/tests/test_execution_sandbox.py
+++ b/pkg-py/tests/test_execution_sandbox.py
@@ -12,6 +12,7 @@ import platform
 import pytest
 
 from commons._execution import _sandbox
+from commons._execution._runtime import _seccomp
 from commons._execution._sandbox import (
     SandboxCapabilities,
     protection_mode,
@@ -109,7 +110,6 @@ def test_only_an_affirmative_opt_in_counts(monkeypatch, value) -> None:
         protection_mode(NOTHING, sysname="Windows")
 
 
-
 def test_a_host_that_is_not_a_mac_reports_no_seatbelt(monkeypatch) -> None:
     # The probe is called directly rather than through
     # sandbox_capabilities(). Claiming to be Linux patches the shared
@@ -142,3 +142,13 @@ def test_this_mac_reports_seatbelt() -> None:
 def test_a_mac_can_be_sandboxed_without_the_opt_in(monkeypatch) -> None:
     monkeypatch.delenv("COMMONS_ALLOW_UNSAFE_FALLBACK", raising=False)
     assert protection_mode() == "sandbox"
+
+
+def test_the_probe_takes_its_seccomp_answer_from_the_seccomp_module() -> None:
+    """Which is where that answer is worked out, and separately tested.
+
+    Not an assertion that every Linux host has seccomp: a host whose profile
+    permits the query but refuses the filter is one the probe is meant to
+    report False for, and the suite has to pass there too.
+    """
+    assert sandbox_capabilities().seccomp is _seccomp.seccomp_available()

--- a/pkg-py/tests/test_execution_seccomp.py
+++ b/pkg-py/tests/test_execution_seccomp.py
@@ -1,0 +1,510 @@
+"""The seccomp filter the worker installs on itself, and the network block.
+
+The filter matches raw syscall numbers, so it carries a hand-written number
+table per architecture. Most of what follows runs the filter programs through
+a small BPF interpreter, which is what lets one machine check all four tables
+rather than only the one it happens to be running on.
+"""
+
+from __future__ import annotations
+
+import errno
+import json
+import pathlib
+import platform
+import socket
+import subprocess
+import sys
+
+import pytest
+
+from commons._execution._runtime import _seccomp
+
+RUNTIME_DIR = str(pathlib.Path(_seccomp.__file__).parent)
+
+ARCH_NAMES = ["x86_64", "aarch64", "i386", "arm"]
+
+
+@pytest.mark.parametrize("name", ARCH_NAMES)
+def test_every_screened_syscall_has_a_number_on_every_arch(name: str) -> None:
+    arch = _seccomp.ARCHES[name]
+    missing = sorted(set(_seccomp.SCREENED) - set(arch.syscalls))
+    assert missing == []
+
+
+def run_filter(
+    program: list[_seccomp.SockFilter], *, arch: int, nr: int, arg0: int = 0
+) -> int:
+    """Return what the filter decides for one syscall.
+
+    A reading of the BPF subset the filter is built from, which is how the
+    tables for architectures this machine is not can still be checked.
+    """
+    data = {_seccomp.DATA_NR: nr, _seccomp.DATA_ARCH: arch, _seccomp.DATA_ARG0: arg0}
+    accumulator = 0
+    index = 0
+    while True:
+        assert 0 <= index < len(program), "a jump ran off the end of the filter"
+        instruction = program[index]
+        code, jt, jf, k = (
+            instruction.code,
+            instruction.jt,
+            instruction.jf,
+            instruction.k,
+        )
+        index += 1
+        if code == _seccomp.BPF_LD_W_ABS:
+            accumulator = data.get(k, 0)
+        elif code == _seccomp.BPF_RET_K:
+            return k
+        elif code == _seccomp.BPF_JEQ_K:
+            index += jt if accumulator == k else jf
+        elif code == _seccomp.BPF_JGE_K:
+            index += jt if accumulator >= k else jf
+        elif code == _seccomp.BPF_JSET_K:
+            index += jt if accumulator & k else jf
+        else:  # pragma: no cover - a code the builders never emit
+            raise AssertionError(f"unhandled BPF code {code}")
+
+
+@pytest.mark.parametrize("name", ARCH_NAMES)
+def test_the_network_filter_refuses_to_open_a_socket(name: str) -> None:
+    arch = _seccomp.ARCHES[name]
+    program = _seccomp.build_network_filter(arch)
+    decision = run_filter(program, arch=arch.audit_arch, nr=arch.syscalls["socket"])
+    assert decision == _seccomp.DENY_EPERM
+
+
+@pytest.mark.parametrize("name", ARCH_NAMES)
+def test_the_network_filter_denies_a_call_from_a_foreign_abi(name: str) -> None:
+    """The number a foreign ABI opens a socket with is not one this table screens.
+
+    Passing the native number here would prove nothing, because the filter
+    denies that number whatever ABI it arrives under.
+    """
+    arch = _seccomp.ARCHES[name]
+    # A number the native table does not screen for some other reason: 41 is
+    # socket on x86_64 and pivot_root on aarch64, which would deny either way.
+    other = next(
+        a
+        for a in _seccomp.ARCHES.values()
+        if a.name != name and a.syscalls["socket"] not in arch.syscalls.values()
+    )
+    foreign_socket = other.syscalls["socket"]
+    decision = run_filter(
+        _seccomp.build_network_filter(arch),
+        arch=other.audit_arch,
+        nr=foreign_socket,
+    )
+    assert decision == _seccomp.DENY_EPERM
+
+
+def test_the_network_filter_denies_the_x32_abi() -> None:
+    arch = _seccomp.ARCHES["x86_64"]
+    assert arch.x32_bit is not None
+    decision = run_filter(
+        _seccomp.build_network_filter(arch),
+        arch=arch.audit_arch,
+        nr=arch.x32_bit | arch.syscalls["socket"],
+    )
+    assert decision == _seccomp.DENY_EPERM
+
+
+def test_the_network_filter_denies_i386_socketcall() -> None:
+    arch = _seccomp.ARCHES["i386"]
+    decision = run_filter(
+        _seccomp.build_network_filter(arch),
+        arch=arch.audit_arch,
+        nr=arch.syscalls["socketcall"],
+    )
+    assert decision == _seccomp.DENY_EPERM
+
+
+@pytest.mark.parametrize("name", ARCH_NAMES)
+def test_the_network_filter_leaves_reading_a_file_alone(name: str) -> None:
+    arch = _seccomp.ARCHES[name]
+    decision = run_filter(
+        _seccomp.build_network_filter(arch),
+        arch=arch.audit_arch,
+        nr=arch.syscalls["ptrace"],
+    )
+    assert decision == _seccomp.SECCOMP_RET_ALLOW
+
+
+@pytest.mark.parametrize("name", ARCH_NAMES)
+@pytest.mark.parametrize("syscall", _seccomp.SCREENED)
+def test_the_sandbox_filter_denies_every_screened_syscall(
+    name: str, syscall: str
+) -> None:
+    arch = _seccomp.ARCHES[name]
+    decision = run_filter(
+        _seccomp.build_sandbox_filter(arch),
+        arch=arch.audit_arch,
+        nr=arch.syscalls[syscall],
+    )
+    assert decision == _seccomp.DENY_EPERM
+
+
+def test_the_sandbox_filter_denies_the_i386_only_umount() -> None:
+    arch = _seccomp.ARCHES["i386"]
+    decision = run_filter(
+        _seccomp.build_sandbox_filter(arch),
+        arch=arch.audit_arch,
+        nr=arch.syscalls["umount"],
+    )
+    assert decision == _seccomp.DENY_EPERM
+
+
+@pytest.mark.parametrize("name", ARCH_NAMES)
+def test_clone3_reports_itself_missing_rather_than_forbidden(name: str) -> None:
+    """ENOSYS sends glibc back to clone(), whose flags the filter can read.
+
+    clone3 passes its flags in a struct behind a pointer, and a seccomp
+    filter cannot follow a pointer, so a permitted clone3 would be a way to
+    ask for a namespace unseen.
+    """
+    arch = _seccomp.ARCHES[name]
+    decision = run_filter(
+        _seccomp.build_sandbox_filter(arch),
+        arch=arch.audit_arch,
+        nr=arch.syscalls["clone3"],
+    )
+    assert decision == _seccomp.DENY_ENOSYS
+
+
+@pytest.mark.parametrize("name", ARCH_NAMES)
+def test_clone_is_denied_when_it_asks_for_a_new_namespace(name: str) -> None:
+    arch = _seccomp.ARCHES[name]
+    decision = run_filter(
+        _seccomp.build_sandbox_filter(arch),
+        arch=arch.audit_arch,
+        nr=arch.syscalls["clone"],
+        arg0=_seccomp.CLONE_NEWUSER,
+    )
+    assert decision == _seccomp.DENY_EPERM
+
+
+@pytest.mark.parametrize("name", ARCH_NAMES)
+def test_an_ordinary_clone_is_allowed(name: str) -> None:
+    """Threads still have to work; it is namespaces the filter is refusing."""
+    arch = _seccomp.ARCHES[name]
+    decision = run_filter(
+        _seccomp.build_sandbox_filter(arch),
+        arch=arch.audit_arch,
+        nr=arch.syscalls["clone"],
+        arg0=0,
+    )
+    assert decision == _seccomp.SECCOMP_RET_ALLOW
+
+
+@pytest.mark.parametrize("name", ARCH_NAMES)
+def test_the_sandbox_filter_leaves_opening_a_socket_alone(name: str) -> None:
+    """Whether a socket may be opened is the network block's decision."""
+    arch = _seccomp.ARCHES[name]
+    decision = run_filter(
+        _seccomp.build_sandbox_filter(arch),
+        arch=arch.audit_arch,
+        nr=arch.syscalls["socket"],
+    )
+    assert decision == _seccomp.SECCOMP_RET_ALLOW
+
+
+@pytest.mark.parametrize(
+    ("machine", "pointer_size", "expected"),
+    [
+        ("x86_64", 8, "x86_64"),
+        ("amd64", 8, "x86_64"),
+        ("aarch64", 8, "aarch64"),
+        ("arm64", 8, "aarch64"),
+        ("i686", 4, "i386"),
+        ("i386", 4, "i386"),
+        ("armv7l", 4, "arm"),
+        ("armv6l", 4, "arm"),
+        ("armv8l", 4, "arm"),
+        # x32 is the only thing that reports a 64-bit machine with 32-bit
+        # pointers, and it is neither of the tables that pair might suggest.
+        ("x86_64", 4, None),
+        ("amd64", 4, None),
+        ("aarch64", 4, None),
+        # Fail closed: with no table there is no filter worth installing.
+        ("riscv64", 8, None),
+        ("s390x", 8, None),
+        ("ppc64le", 8, None),
+    ],
+)
+def test_the_arch_is_read_from_the_machine_and_the_pointer_size(
+    machine: str, pointer_size: int, expected: str | None
+) -> None:
+    arch = _seccomp.arch_for(machine, pointer_size)
+    assert (arch.name if arch is not None else None) == expected
+
+
+def test_x32_gets_no_table_rather_than_the_i386_one() -> None:
+    """x32 is 32-bit pointers over the x86_64 syscall table, not i386.
+
+    Its calls carry the x86_64 audit tag and set the x32 bit, so the i386
+    table would build a filter whose very first check rejects every syscall
+    the process makes. A 32-bit i386 process is not this case: the kernel
+    reports i686 to it, so it finds its own table.
+    """
+    assert _seccomp.arch_for("x86_64", 4) is None
+
+
+def test_seccomp_is_unavailable_where_the_kernel_has_no_seccomp() -> None:
+    if platform.system() == "Linux":
+        pytest.skip("this host has a kernel that may well offer seccomp")
+    assert _seccomp.seccomp_available() is False
+
+
+linux_only = pytest.mark.skipif(
+    platform.system() != "Linux", reason="seccomp is a Linux facility"
+)
+
+# Engaging for real needs a host that will let a filter be installed, which
+# a Linux host is entitled not to be: a container profile can permit the
+# query and refuse PR_SET_SECCOMP, and that is a host the probe is meant to
+# report False for, not one the suite should fail on.
+needs_seccomp = pytest.mark.skipif(
+    not _seccomp.seccomp_available(),
+    reason="this host does not let a seccomp filter be installed",
+)
+
+# A filter cannot be lifted once installed, so every one of these runs in an
+# interpreter of its own. Reporting from inside the child is also the only
+# honest way to see the effect: the parent is deliberately untouched.
+ENGAGE = """
+import json, sys
+sys.path.insert(0, {runtime!r})
+import _seccomp
+_seccomp.engage(network={network!r})
+result = {{}}
+{body}
+json.dump(result, sys.stdout)
+"""
+
+
+def engage_in_child(body: str, *, network: str = "none") -> dict[str, object]:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            ENGAGE.format(runtime=RUNTIME_DIR, network=network, body=body),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(completed.stdout)
+
+
+@needs_seccomp
+def test_no_new_privs_is_set_before_the_filter_goes_on() -> None:
+    """Seccomp refuses to install for an unprivileged process without it."""
+    result = engage_in_child("result['status'] = open('/proc/self/status').read()")
+    assert "NoNewPrivs:\t1" in str(result["status"])
+
+
+@needs_seccomp
+def test_a_socket_cannot_be_opened_under_no_network() -> None:
+    result = engage_in_child(
+        """
+import socket
+try:
+    socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    result['error'] = None
+except PermissionError as exc:
+    result['error'] = exc.errno
+""",
+        network="none",
+    )
+    assert result["error"] == errno.EPERM
+
+
+@needs_seccomp
+def test_a_socket_opens_normally_under_full_network() -> None:
+    result = engage_in_child(
+        """
+import socket
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    result['family'] = int(sock.family)
+""",
+        network="full",
+    )
+    assert result["family"] == int(socket.AF_INET)
+
+
+UNSHARE = """
+import ctypes
+libc = ctypes.CDLL(None, use_errno=True)
+CLONE_NEWUSER = 0x10000000
+result['rc'] = libc.unshare(CLONE_NEWUSER)
+result['errno'] = ctypes.get_errno()
+"""
+
+
+def unshare_refused_without_any_filter() -> bool:
+    """Whether this host refuses a new user namespace on its own.
+
+    A container's own seccomp profile commonly does, and on such a host an
+    assertion that unshare is refused would hold whatever this filter says.
+    """
+    completed = subprocess.run(
+        [sys.executable, "-c", f"result = {{}}\n{UNSHARE}\nprint(result['rc'])"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return completed.stdout.strip() == "-1"
+
+
+@needs_seccomp
+@pytest.mark.parametrize("network", ["none", "full"])
+def test_a_new_namespace_cannot_be_unshared(network: str) -> None:
+    """The escape the filesystem sandbox cannot refuse on its own."""
+    if unshare_refused_without_any_filter():
+        pytest.skip("this host refuses a new user namespace with no filter on")
+    result = engage_in_child(UNSHARE, network=network)
+    assert result["rc"] == -1
+    assert result["errno"] == errno.EPERM
+
+
+@needs_seccomp
+def test_threads_still_start_once_the_filter_is_on() -> None:
+    """The clone rule screens namespace flags, not clone itself."""
+    result = engage_in_child(
+        """
+import threading
+seen = []
+thread = threading.Thread(target=lambda: seen.append(True))
+thread.start()
+thread.join()
+result['ran'] = seen == [True]
+""",
+    )
+    assert result["ran"] is True
+
+
+# prctl's own number, needed to build a filter that lets the kernel be asked
+# about seccomp while refusing to install anything.
+PRCTL = {"x86_64": 157, "aarch64": 167, "i386": 172, "arm": 172}
+
+DENY_PR_SET_SECCOMP = """
+import ctypes, json, sys
+sys.path.insert(0, {runtime!r})
+import _seccomp
+
+arch = _seccomp.current_arch()
+program = [
+    _seccomp.SockFilter(code=_seccomp.BPF_LD_W_ABS, jt=0, jf=0, k=_seccomp.DATA_NR),
+    _seccomp.SockFilter(code=_seccomp.BPF_JEQ_K, jt=0, jf=3, k={prctl}),
+    _seccomp.SockFilter(code=_seccomp.BPF_LD_W_ABS, jt=0, jf=0, k=_seccomp.DATA_ARG0),
+    _seccomp.SockFilter(
+        code=_seccomp.BPF_JEQ_K, jt=0, jf=1, k=_seccomp.PR_SET_SECCOMP
+    ),
+    _seccomp.SockFilter(code=_seccomp.BPF_RET_K, jt=0, jf=0, k=_seccomp.DENY_EPERM),
+    _seccomp.SockFilter(
+        code=_seccomp.BPF_RET_K, jt=0, jf=0, k=_seccomp.SECCOMP_RET_ALLOW
+    ),
+]
+_seccomp.set_no_new_privs()
+_seccomp._install(program, what="test filter")
+json.dump(
+    {{
+        "kernel_answers": _seccomp._libc().prctl(_seccomp.PR_GET_SECCOMP, 0, 0, 0, 0),
+        "available": _seccomp.seccomp_available(),
+    }},
+    sys.stdout,
+)
+"""
+
+
+@needs_seccomp
+def test_seccomp_is_unavailable_where_a_filter_cannot_be_installed() -> None:
+    """Being able to ask the kernel about seccomp is not permission to use it.
+
+    A restrictive container profile can answer PR_GET_SECCOMP and still
+    refuse PR_SET_SECCOMP, and a host like that has to be reported
+    unsandboxable at construction rather than at the first call.
+    """
+    arch = _seccomp.current_arch()
+    assert arch is not None
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            DENY_PR_SET_SECCOMP.format(runtime=RUNTIME_DIR, prctl=PRCTL[arch.name]),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    result = json.loads(completed.stdout)
+    assert result["kernel_answers"] >= 0, "the kernel should still answer the query"
+    assert result["available"] is False
+
+
+PIDFD_GETFD = """
+import ctypes
+libc = ctypes.CDLL(None, use_errno=True)
+ctypes.set_errno(0)
+# Deliberately not a pidfd. Without the screen the kernel rejects the
+# argument; with it the call never reaches the kernel at all.
+result['rc'] = libc.syscall(438, -1, 0, 0)
+result['errno'] = ctypes.get_errno()
+"""
+
+
+def pidfd_getfd_unfiltered() -> int:
+    completed = subprocess.run(
+        [sys.executable, "-c", f"result = {{}}\n{PIDFD_GETFD}\nprint(result['errno'])"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return int(completed.stdout.strip())
+
+
+@needs_seccomp
+def test_a_descriptor_cannot_be_taken_from_another_process() -> None:
+    """pidfd_getfd() hands over an open descriptor, sandbox and all.
+
+    Screening ptrace is not enough on its own: this reaches into another
+    process of the same user by a different door, and what it brings back is
+    a descriptor the filesystem sandbox never granted.
+    """
+    unfiltered = pidfd_getfd_unfiltered()
+    if unfiltered != errno.EBADF:
+        # An old kernel answers ENOSYS and a restrictive container profile
+        # answers EPERM, and under either this would hold with no filter on.
+        pytest.skip(f"this host refuses pidfd_getfd on its own (errno {unfiltered})")
+    result = engage_in_child(PIDFD_GETFD)
+    assert result["rc"] == -1
+    assert result["errno"] == errno.EPERM
+
+
+def test_only_i386_still_carries_the_legacy_umount() -> None:
+    """ARM looks like it should have it too, and does not.
+
+    ARM numbers its syscalls close to i386's old order, so 22 reads like
+    umount there as well. It is reachable only through the obsolete OABI
+    entry path: the EABI headers do not define ``__NR_umount``, and the
+    kernel's ARM table marks 22 OABI-only, so an EABI process calling 22
+    gets ENOSYS. Screening it would screen nothing.
+    """
+    carriers = {a.name for a in _seccomp.ARCHES.values() if "umount" in a.syscalls}
+    assert carriers == {"i386"}
+
+
+@linux_only
+def test_the_probe_ignores_a_sitecustomize_on_the_host(tmp_path, monkeypatch) -> None:
+    """The worker is launched isolated, and the probe has to match it.
+
+    site.py imports sitecustomize from sys.path, PYTHONPATH included, before
+    anything the probe does. Without isolation an unrelated file on the
+    host's PYTHONPATH would decide whether this host looks sandboxable.
+    """
+    before = _seccomp.seccomp_available()
+    (tmp_path / "sitecustomize.py").write_text("raise SystemExit(3)\n")
+    monkeypatch.setenv("PYTHONPATH", str(tmp_path))
+
+    assert _seccomp.seccomp_available() is before


### PR DESCRIPTION
This PR adds the worker's seccomp filter and its `network="none"` socket block, built as ctypes BPF programs and installed with `prctl`. It also fills in the `seccomp` field of the construction-time gate, so that gate makes a real decision on Linux.

Stacked on #355. Nothing calls `engage()` yet; the worker that will is task 6.

<details>
<summary>Agent-written detail</summary>

The filter matches raw syscall numbers, so [`_seccomp.py`](https://github.com/posit-dev/commons/pull/362/files#diff-3624a903cd824133ab511c2f80ee03ccc5f5a4557a33c2e6eb2fe77319bdae91) carries a table for each of the four architectures the R implementation supports. The numbers came from each architecture's kernel headers rather than from memory: they diverge below 425, and `pivot_root` is 217 on i386 but 218 on arm.

Two entry points the R filter does not screen are screened here, and kata `mv69` tracks closing them there. `socketcall` reaches every socket operation on i386 behind one number. `pidfd_getfd` hands over a descriptor belonging to another process of the same user, which is a capability no filesystem sandbox granted; it postdates that C and looks like an omission rather than a decision.

x32 is the one ABI reporting a 64-bit machine with 32-bit pointers, and it belongs to neither table, so it gets no entry and such a host is refused rather than handed a filter that would reject its every call. A 32-bit i386 process is not that case: the kernel reports `i686` to it.

`seccomp_available()` finds out whether a filter installs by installing an allow-all one in an isolated child, because a kernel that answers `PR_GET_SECCOMP` can still refuse `PR_SET_SECCOMP`, and a gate that missed that would approve a host whose worker then fails to start.

[The tests](https://github.com/posit-dev/commons/pull/362/files#diff-8bd92ea7c845502b85df4f23430f7a526a83b16ac5b21844b01afeb9a33b38b6) run the filter programs through a small BPF interpreter, which is how one machine checks all four tables. The Linux ones engage for real in a child, since a filter cannot be lifted, and three of them first check the host does not already refuse the call, so they skip rather than passing hollowly inside a container. Verified under three container profiles: default, unconfined, and one that permits `PR_GET_SECCOMP` while denying `PR_SET_SECCOMP`, where the suite skips cleanly instead of failing.

[CI](https://github.com/posit-dev/commons/pull/362/files#diff-2642be6df2d7284e2840146597e4028c998ed357433af1e665eec2c28e508826) gains one arm64 leg, so the aarch64 numbers are exercised rather than merely built. kata `9jmj` covers the 32-bit tables, which need a container job rather than the current uv matrix. kata `hm25` records a separate gap this surfaced: abstract-namespace AF_UNIX sockets are reachable through `socketpair` and no filesystem sandbox governs them, which belongs with the Landlock and userns tasks.

</details>


